### PR TITLE
fix(desktop): avoid cloning into /.routa when cwd is root

### DIFF
--- a/crates/routa-core/src/git.rs
+++ b/crates/routa-core/src/git.rs
@@ -48,6 +48,11 @@ pub fn parse_github_url(url: &str) -> Option<ParsedGitHubUrl> {
 /// Base directory for cloned repos.
 pub fn get_clone_base_dir() -> PathBuf {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    if cwd.parent().is_none() {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(".routa").join("repos");
+        }
+    }
     cwd.join(".routa").join("repos")
 }
 


### PR DESCRIPTION
When desktop process cwd resolves to '/', clone base dir became '/.routa/repos' and failed on read-only filesystems.

Fallback to '~/.routa/repos' when cwd is filesystem root, keeping existing behavior for normal cwd values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository clone directory handling for edge cases. When running from the root path, the app now gracefully falls back to storing cloned repositories in your home directory instead of the current working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->