### PR TITLE
feat(docker): implement full terminal lifecycle in opencode-bridge

### DIFF
--- a/docker/opencode-bridge/server.js
+++ b/docker/opencode-bridge/server.js
@@ -12,14 +12,21 @@
  *   POST /session/prompt { sessionId, prompt }  → text/event-stream (SSE)
  *   POST /session/cancel { sessionId }          → { ok: true }
  *   POST /session/delete { sessionId }          → { ok: true }
+ *
+ * Agent→Client terminal requests (handled over JSON-RPC):
+ *   terminal/create       → spawn persistent process, returns { terminalId }
+ *   terminal/output       → returns accumulated { output } for a terminal
+ *   terminal/wait_for_exit → awaits process exit, returns { exitCode }
+ *   terminal/kill          → SIGTERM then SIGKILL after 3s
+ *   terminal/release       → kill + remove from managed set
  */
 'use strict'
 
 const http = require('http')
-const { spawn, execSync } = require('child_process')
+const { spawn } = require('child_process')
 const fs = require('fs')
 const path = require('path')
-const { execFile } = require('child_process')
+// execFile removed — terminal/create now uses spawn for persistent terminals
 
 const PORT = parseInt(process.env.PORT || '4321', 10)
 const HOST = process.env.HOST || '0.0.0.0'
@@ -133,6 +140,9 @@ class OpenCodeSession {
     this.sseClients = new Set()
     this.opencodeSessionId = null
     this.alive = false
+    // Terminal lifecycle management
+    this.terminals = new Map()   // terminalId → ManagedTerminal
+    this.terminalCounter = 0
   }
 
   /**
@@ -225,6 +235,19 @@ class OpenCodeSession {
 
   kill() {
     this.alive = false
+    // Kill all managed terminal processes
+    for (const [termId, terminal] of this.terminals) {
+      if (!terminal.exited) {
+        console.log(`[terminal] session cleanup — killing ${termId}`)
+        try { terminal.process.kill('SIGTERM') } catch {}
+        setTimeout(() => {
+          if (!terminal.exited) {
+            try { terminal.process.kill('SIGKILL') } catch {}
+          }
+        }, 3000)
+      }
+    }
+    this.terminals.clear()
     if (this.proc) {
       try { this.proc.kill('SIGTERM') } catch {}
       setTimeout(() => {
@@ -362,20 +385,165 @@ class OpenCodeSession {
       }
 
       case 'terminal/create': {
-        const p = params || {}
-        const shell = p.shell || '/bin/sh'
-        const cmd = typeof p.command === 'string' ? p.command
-          : Array.isArray(p.command) ? p.command.join(' ') : null
+        const MAX_TERMINALS = 10
+        const MAX_OUTPUT_BYTES = 1024 * 1024 // 1 MB
 
-        if (!cmd) {
-          this._write({ jsonrpc: '2.0', id, result: { terminalId: `t-${id}`, output: '' } })
+        if (this.terminals.size >= MAX_TERMINALS) {
+          this._write({ jsonrpc: '2.0', id, error: { code: -32000, message: `Terminal limit reached (max ${MAX_TERMINALS})` } })
           break
         }
 
-        execFile(shell, ['-c', cmd], { cwd: this.cwd, timeout: 30000 }, (err, stdout, stderr) => {
-          const output = stdout + (stderr ? `\n${stderr}` : '')
-          this._write({ jsonrpc: '2.0', id, result: { terminalId: `t-${id}`, output } })
+        const p = params || {}
+        const command = typeof p.command === 'string' ? p.command
+          : Array.isArray(p.command) ? p.command.join(' ') : ''
+        const terminalId = `term-${++this.terminalCounter}-${Date.now()}`
+
+        if (!command) {
+          this._write({ jsonrpc: '2.0', id, result: { terminalId } })
+          break
+        }
+
+        // Broadcast terminal_created event
+        this._broadcastSSE({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId: this.opencodeSessionId,
+            update: { sessionUpdate: 'terminal_created', terminalId, command },
+          },
         })
+
+        let exitResolve
+        const exitPromise = new Promise((resolve) => { exitResolve = resolve })
+
+        const termProc = spawn(command, [], {
+          shell: true,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          cwd: (p.cwd) || this.cwd,
+          env: { ...process.env, ...(p.env || {}), FORCE_COLOR: '1', TERM: 'xterm-256color' },
+        })
+
+        const managed = {
+          terminalId,
+          process: termProc,
+          output: '',
+          exitCode: null,
+          exited: false,
+          exitPromise,
+          exitResolve,
+        }
+
+        const appendOutput = (data) => {
+          if (managed.output.length < MAX_OUTPUT_BYTES) {
+            managed.output += data.substring(0, MAX_OUTPUT_BYTES - managed.output.length)
+          }
+          this._broadcastSSE({
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId: this.opencodeSessionId,
+              update: { sessionUpdate: 'terminal_output', terminalId, data },
+            },
+          })
+        }
+
+        termProc.stdout.on('data', (chunk) => appendOutput(chunk.toString('utf-8')))
+        termProc.stderr.on('data', (chunk) => appendOutput(chunk.toString('utf-8')))
+
+        termProc.on('exit', (code, signal) => {
+          console.log(`[terminal] ${terminalId} exited code=${code} signal=${signal}`)
+          managed.exitCode = code ?? (signal ? 128 : 0)
+          managed.exited = true
+          exitResolve(managed.exitCode)
+          this._broadcastSSE({
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId: this.opencodeSessionId,
+              update: { sessionUpdate: 'terminal_exited', terminalId, exitCode: managed.exitCode },
+            },
+          })
+        })
+
+        termProc.on('error', (err) => {
+          console.error(`[terminal] ${terminalId} error:`, err)
+          managed.exited = true
+          managed.exitCode = 1
+          exitResolve(1)
+        })
+
+        this.terminals.set(terminalId, managed)
+        this._write({ jsonrpc: '2.0', id, result: { terminalId } })
+        break
+      }
+
+      case 'terminal/output': {
+        const termId = (params || {}).terminalId
+        const terminal = termId ? this.terminals.get(termId) : null
+        this._write({ jsonrpc: '2.0', id, result: { output: terminal ? terminal.output : '' } })
+        break
+      }
+
+      case 'terminal/wait_for_exit': {
+        const termId = (params || {}).terminalId
+        const terminal = termId ? this.terminals.get(termId) : null
+
+        if (!terminal) {
+          this._write({ jsonrpc: '2.0', id, result: { exitCode: -1 } })
+          break
+        }
+
+        if (terminal.exited) {
+          this._write({ jsonrpc: '2.0', id, result: { exitCode: terminal.exitCode ?? 0 } })
+          break
+        }
+
+        terminal.exitPromise.then((exitCode) => {
+          this._write({ jsonrpc: '2.0', id, result: { exitCode } })
+        })
+        break
+      }
+
+      case 'terminal/kill': {
+        const termId = (params || {}).terminalId
+        const terminal = termId ? this.terminals.get(termId) : null
+
+        if (terminal && !terminal.exited) {
+          console.log(`[terminal] killing ${termId}`)
+          try {
+            terminal.process.kill('SIGTERM')
+            setTimeout(() => {
+              if (!terminal.exited) {
+                try { terminal.process.kill('SIGKILL') } catch {}
+              }
+            }, 3000)
+          } catch (err) {
+            console.error(`[terminal] error killing ${termId}:`, err)
+          }
+        }
+        this._write({ jsonrpc: '2.0', id, result: {} })
+        break
+      }
+
+      case 'terminal/release': {
+        const termId = (params || {}).terminalId
+        const terminal = termId ? this.terminals.get(termId) : null
+
+        if (terminal) {
+          console.log(`[terminal] releasing ${termId}`)
+          if (!terminal.exited) {
+            try {
+              terminal.process.kill('SIGTERM')
+              setTimeout(() => {
+                if (!terminal.exited) {
+                  try { terminal.process.kill('SIGKILL') } catch {}
+                }
+              }, 3000)
+            } catch {}
+          }
+          this.terminals.delete(termId)
+        }
+        this._write({ jsonrpc: '2.0', id, result: {} })
         break
       }
 

--- a/issues/spec-issue-73.md
+++ b/issues/spec-issue-73.md
@@ -1,0 +1,244 @@
+---
+title: "opencode-bridge 缺失 terminal 相关 agent 请求的需求分析"
+issue: 73
+date: "2026-03-07"
+status: open
+severity: high
+area: acp, docker
+tags: [terminal, opencode-bridge, acp-protocol]
+reported_by: "QoderAI"
+related_issues:
+  - https://github.com/phodal/routa/issues/73
+---
+
+# opencode-bridge 缺失 terminal 相关 agent 请求
+
+## 需求概述
+
+`docker/opencode-bridge/server.js` 作为 Docker 容器内 opencode agent 与 Routa 主系统之间的 HTTP+SSE 桥接层，当前仅实现了部分 ACP 协议中的 agent-to-client 请求。具体来说，`terminal/create` 虽然已实现，但使用的是 `execFile` 一次性执行模式，不支持长时间运行的终端会话，且缺少 `terminal/output`、`terminal/wait_for_exit`、`terminal/kill`、`terminal/release` 四个配套操作。
+
+这导致当 opencode agent 在 Docker 容器内执行需要长时间运行的 bash 命令时，无法正常获取终端输出、等待命令完成或终止命令，bridge 会对未知请求返回空结果 `{}`，可能引起 agent 行为异常。
+
+### 缺失的请求方法
+
+| 方法 | 用途 | 当前状态 |
+|------|------|----------|
+| `terminal/create` | 创建终端进程 | 已实现（但为一次性执行模式） |
+| `terminal/output` | 获取终端累积输出 | 缺失 |
+| `terminal/wait_for_exit` | 等待终端进程退出 | 缺失 |
+| `terminal/kill` | 终止终端进程 | 缺失 |
+| `terminal/release` | 释放终端资源 | 缺失 |
+
+## 涉及的模块/文件
+
+### 需要修改的文件
+
+- **`docker/opencode-bridge/server.js`** — 核心修改目标。`_handleAgentRequest` 方法（第 302-387 行）需要：
+  1. 重构 `terminal/create`：从 `execFile` 一次性执行改为 `spawn` 长期运行模式
+  2. 新增终端状态管理（Map 存储运行中的终端）
+  3. 新增 `terminal/output`、`terminal/wait_for_exit`、`terminal/kill`、`terminal/release` 四个 case
+
+### 参考实现（主系统中的对应逻辑）
+
+- **`src/core/acp/terminal-manager.ts`** — 主系统的终端管理器，实现了完整的终端生命周期管理（create/output/waitForExit/kill/release），是 bridge 实现的**主要参考模板**。它使用 `spawn` 创建子进程，维护输出缓冲区、退出码和 Promise，并通过 `session/update` 通知推送终端事件。
+
+- **`src/core/acp/acp-process.ts`**（第 538-618 行）— 主系统中 `handleAgentRequest` 的 terminal 分支实现，展示了如何将 agent 的 terminal 请求转发给 `TerminalManager`，并通过 JSON-RPC 返回结果。
+
+### 相关上下文文件
+
+- **`docker/Dockerfile.opencode-agent`** — Docker 镜像定义，了解容器内可用工具链（node:22-bookworm-slim）
+- **`src/core/acp/docker/docker-opencode-adapter.ts`** — Routa 主系统侧的 Docker 适配器，通过 HTTP 与 bridge 通信，当前不涉及 terminal 请求中转（terminal 请求由 bridge 在容器内部直接处理）
+- **`src/core/acp/docker/process-manager.ts`** — Docker 容器的生命周期管理，包括容器复用机制
+- **`src/core/acp/processer.ts`** — `JsonRpcMessage` 和 `NotificationHandler` 类型定义
+
+## 技术方案建议
+
+### 方案：在 bridge 内实现轻量级 TerminalManager
+
+由于 bridge 运行在 Docker 容器内（Node.js 环境），可以直接使用 `child_process.spawn` 实现终端管理，无需依赖主系统的 platform bridge 抽象层。
+
+#### 1. 新增终端状态管理
+
+在 `OpenCodeSession` 类中添加一个 `Map<string, ManagedTerminal>` 用于跟踪活跃终端：
+
+```javascript
+// 在 OpenCodeSession 类中新增
+this.terminals = new Map() // terminalId → ManagedTerminal
+this.terminalCounter = 0
+
+// ManagedTerminal 结构
+// {
+//   terminalId: string,
+//   process: ChildProcess,     // spawn 返回的子进程
+//   output: string,            // 累积输出缓冲区
+//   exitCode: number | null,
+//   exited: boolean,
+//   exitPromise: Promise<number>,
+//   exitResolve: (code) => void,
+// }
+```
+
+#### 2. 重构 `terminal/create`
+
+将当前的 `execFile` 一次性执行改为 `spawn` 长期运行模式：
+
+```javascript
+case 'terminal/create': {
+  const p = params || {}
+  const command = p.command || '/bin/sh'
+  const args = p.args || []
+  const cwd = p.cwd || this.cwd
+  const terminalId = `term-${++this.terminalCounter}-${Date.now()}`
+
+  const proc = spawn(command, args, {
+    cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    shell: true,
+    env: { ...process.env, FORCE_COLOR: '1', TERM: 'xterm-256color' },
+  })
+
+  // 设置 exitPromise、output 累积、退出处理...
+  // 存入 this.terminals Map
+  // 通过 SSE 广播 terminal_output 和 terminal_exited 事件
+
+  this._write({ jsonrpc: '2.0', id, result: { terminalId } })
+  break
+}
+```
+
+#### 3. 新增四个终端操作
+
+- **`terminal/output`**: 从 `terminals` Map 中获取对应终端的累积输出
+- **`terminal/wait_for_exit`**: 若已退出则直接返回 exitCode，否则 await exitPromise
+- **`terminal/kill`**: 向子进程发送 SIGTERM，3 秒后 SIGKILL
+- **`terminal/release`**: 先 kill（如果还在运行），然后从 Map 中移除
+
+#### 4. 终端输出实时推送
+
+通过现有的 `_broadcastSSE` 机制推送终端事件通知，格式参考 `terminal-manager.ts`：
+
+```javascript
+// terminal_output 事件
+{
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: this.opencodeSessionId,
+    update: {
+      sessionUpdate: 'terminal_output',
+      terminalId,
+      data: chunk.toString('utf-8'),
+    },
+  },
+}
+
+// terminal_exited 事件
+{
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: this.opencodeSessionId,
+    update: {
+      sessionUpdate: 'terminal_exited',
+      terminalId,
+      exitCode,
+    },
+  },
+}
+```
+
+#### 5. Session 清理
+
+在 `kill()` 方法中遍历并清理所有关联的终端进程，防止孤儿进程。
+
+## 风险点
+
+### R1: 终端超时与资源泄漏（高风险）
+
+当前 `execFile` 有 30 秒超时机制。改为 `spawn` 后，终端进程可以长期运行。如果 agent 创建了终端但没有调用 `release`（例如 agent 崩溃或会话异常终止），会导致容器内出现孤儿进程。
+
+**缓解措施**: 
+- 在 `OpenCodeSession.kill()` 中清理所有终端
+- 为每个终端设置最大生存时间（例如 5 分钟）
+- 在 `proc.on('exit')` 回调中清理 Map 条目
+
+### R2: 输出缓冲区内存压力（中风险）
+
+`terminal/output` 需要保存终端的全部输出。如果命令产生大量输出（如 `cat` 大文件或持续日志流），内存可能快速增长。
+
+**缓解措施**: 
+- 限制缓冲区大小（例如最大 1MB），超过后截断旧内容
+- 或仅保留最近 N 行输出
+
+### R3: 并发终端数量（低风险）
+
+Docker 容器有 `--pids-limit 100` 的限制。如果 agent 频繁创建终端而不释放，可能触发 PID 上限。
+
+**缓解措施**: 
+- 限制每个 Session 最大终端数量（例如 10 个）
+- 创建新终端时检查并清理已退出的终端
+
+### R4: 协议兼容性（中风险）
+
+需要确保 bridge 返回的响应格式与 `@agentclientprotocol/sdk@0.14.1` 定义的类型完全一致。特别是 `terminal/create` 返回的字段名和 `terminal/wait_for_exit` 返回的字段名需要与 SDK 类型定义对齐。
+
+**缓解措施**: 
+- 参考 SDK 类型定义 (`dist/schema/types.gen.d.ts`) 验证响应格式
+- 编写集成测试验证请求/响应流程
+
+### R5: ExtRequest 可扩展请求（低风险）
+
+ACP 协议中还定义了 `ExtRequest` 类型用于扩展请求。当前 bridge 的 default case 返回空结果 `{}`，对于未知的扩展请求这可能不是最佳处理方式。
+
+**缓解措施**: 
+- 可暂时保持当前行为，但记录 warn 日志
+- 未来考虑返回标准的 JSON-RPC `-32601 Method not found` 错误
+
+## 实施步骤
+
+### 步骤 1: 在 OpenCodeSession 中添加终端状态管理
+
+- 在 `constructor` 中初始化 `this.terminals = new Map()` 和 `this.terminalCounter = 0`
+- 定义 `ManagedTerminal` 结构（对象字面量即可，不需要 class）
+- 在 `kill()` 方法中添加终端清理逻辑
+
+### 步骤 2: 重构 `terminal/create` 实现
+
+- 将 `execFile` 替换为 `spawn`，使用 `{ shell: true }` 选项
+- 设置 stdout/stderr 数据监听器，累积输出到缓冲区
+- 通过 `_broadcastSSE` 推送 `terminal_output` 和 `terminal_exited` 通知
+- 创建 exitPromise 用于 `wait_for_exit` 操作
+- 将 ManagedTerminal 存入 `this.terminals` Map
+
+### 步骤 3: 实现 `terminal/output`
+
+- 从 `params.terminalId` 查找对应的终端
+- 返回 `{ output: terminal.output }` 或空输出（终端不存在时）
+
+### 步骤 4: 实现 `terminal/wait_for_exit`
+
+- 从 `params.terminalId` 查找对应的终端
+- 如果已退出，直接返回 `{ exitCode }`
+- 否则 await `terminal.exitPromise` 后返回
+
+### 步骤 5: 实现 `terminal/kill`
+
+- 从 `params.terminalId` 查找对应的终端
+- 如果终端还在运行，发送 SIGTERM
+- 设置 3 秒后 SIGKILL 的超时机制
+- 返回 `{}`
+
+### 步骤 6: 实现 `terminal/release`
+
+- 从 `params.terminalId` 查找对应的终端
+- 如果终端还在运行，先 kill
+- 从 `this.terminals` Map 中删除
+- 返回 `{}`
+
+### 步骤 7: 测试与验证
+
+- 手动测试：启动 Docker 容器，通过 bridge API 发送 terminal 相关请求
+- 验证终端创建、输出流式推送、等待退出、kill、release 全流程
+- 验证 Session 清理时终端进程是否正确清理
+- 验证内存不会因大量输出而无限增长
+- 考虑添加 e2e 测试覆盖 Docker bridge 的 terminal 流程


### PR DESCRIPTION
## Summary
- Refactor `terminal/create` from one-shot `execFile` to persistent `spawn` mode for long-running terminal sessions
- Add `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release` handlers in `OpenCodeSession`
- Include output buffer limit (1MB), per-session terminal cap (10), SSE broadcast for terminal events, and session cleanup on kill

Closes #73

## Changes
- `docker/opencode-bridge/server.js` — full terminal lifecycle management
- `issues/spec-issue-73.md` — spec analysis document

## Test plan
- [ ] Start Docker container with opencode-bridge, verify `terminal/create` returns a persistent terminalId
- [ ] Send `terminal/output` request and confirm accumulated stdout/stderr is returned
- [ ] Run a long-running command, call `terminal/wait_for_exit` and verify it blocks until completion
- [ ] Call `terminal/kill` on a running terminal and verify SIGTERM → SIGKILL escalation
- [ ] Call `terminal/release` and verify terminal is cleaned up from session state
- [ ] Kill session and verify all child terminal processes are cleaned up
- [ ] Verify SSE broadcasts `terminal_output` and `terminal_exited` events

	🤖 Generated with [Qoder][https://qoder.com]