### PR TITLE
fix(rust): validate workspace in kanban decompose endpoint

### DIFF
--- a/crates/routa-core/src/tools/mod.rs
+++ b/crates/routa-core/src/tools/mod.rs
@@ -668,8 +668,7 @@ impl AgentTools {
 
         let last_response = last_messages
             .iter()
-            .filter(|m| m.role == MessageRole::Assistant)
-            .next_back();
+            .rfind(|m| m.role == MessageRole::Assistant);
 
         let all_messages = self.conversation_store.get_conversation(agent_id).await?;
         let tool_call_count = all_messages

--- a/crates/routa-server/src/api/kanban.rs
+++ b/crates/routa-server/src/api/kanban.rs
@@ -212,6 +212,13 @@ async fn decompose_tasks(
         }
     };
 
+    if board.workspace_id != body.workspace_id {
+        return Err(ServerError::BadRequest(format!(
+            "workspace mismatch: board {} belongs to workspace {}",
+            body.board_id, board.workspace_id
+        )));
+    }
+
     // Validate tasks array is not empty
     if body.tasks.is_empty() {
         return Err(ServerError::BadRequest(
@@ -230,12 +237,16 @@ async fn decompose_tasks(
     }
 
     // Get existing tasks in the column to determine starting position
-    let existing_tasks = state.task_store.list_by_workspace(&body.workspace_id).await?;
+    let existing_tasks = state
+        .task_store
+        .list_by_workspace(&board.workspace_id)
+        .await?;
+    let backlog = String::from("backlog");
     let column_tasks: Vec<_> = existing_tasks
         .iter()
         .filter(|t| {
             t.board_id.as_ref() == Some(&body.board_id)
-                && t.column_id.as_ref().unwrap_or(&"backlog".to_string()) == &target_column_id
+                && t.column_id.as_ref().unwrap_or(&backlog) == &target_column_id
         })
         .collect();
     let mut position = column_tasks.len() as i64;


### PR DESCRIPTION
### Motivation

- Prevent cross-workspace writes when calling the Kanban decompose API by ensuring the `boardId` belongs to the provided `workspaceId` to avoid accidental/malicious task creation in the wrong workspace.
- Use the board's authoritative workspace when calculating column positions to ensure task ordering is computed from the correct task set.

### Description

- Add workspace ownership validation in `/api/kanban/decompose` to return `400` if `board.workspace_id != request.workspaceId` (file: `crates/routa-server/src/api/kanban.rs`).
- Use `board.workspace_id` when listing existing tasks for position calculation and avoid allocating a temporary string for the `column_id` fallback (file: `crates/routa-server/src/api/kanban.rs`).
- Fix a Clippy lint by replacing `.iter().filter(...).next_back()` with `.iter().rfind(...)` to satisfy strict lint checks (file: `crates/routa-core/src/tools/mod.rs`).

### Testing

- Ran `cargo check -p routa-server`, which completed successfully.
- Ran `cargo clippy -p routa-server -- -D warnings`, which passed after the small `rfind` change.
- Ran `cargo test -p routa-server`, which completed with tests passing (no failures).
- `npm run lint` was executed by the commit hook and completed; it reported warnings but no errors (no frontend changes in this PR, so no Playwright screenshot applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed7d4baf88326bad8549e25fda130)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added workspace validation to task decomposition operations to ensure the board and request target the same workspace, preventing potential data scope mismatches.

* **Refactor**
  * Optimized internal message retrieval logic for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->