### PR TITLE
Kimi2.5 + CR => fix: require similarity threshold > 0 to prevent validation bypass

### DIFF
--- a/.claude/skills/code-review/LICENSE
+++ b/.claude/skills/code-review/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/code-review/README.md
+++ b/.claude/skills/code-review/README.md
@@ -1,0 +1,246 @@
+# Code Review Plugin
+
+Automated code review for pull requests using multiple specialized agents with confidence-based scoring to filter false positives.
+
+## Overview
+
+The Code Review Plugin automates pull request review by launching multiple agents in parallel to independently audit changes from different perspectives. It uses confidence scoring to filter out false positives, ensuring only high-quality, actionable feedback is posted.
+
+## Commands
+
+### `/code-review`
+
+Performs automated code review on a pull request using multiple specialized agents.
+
+**What it does:**
+1. Checks if review is needed (skips closed, draft, trivial, or already-reviewed PRs)
+2. Gathers relevant CLAUDE.md guideline files from the repository
+3. Summarizes the pull request changes
+4. Launches 4 parallel agents to independently review:
+   - **Agents #1 & #2**: Audit for CLAUDE.md compliance
+   - **Agent #3**: Scan for obvious bugs in changes
+   - **Agent #4**: Analyze git blame/history for context-based issues
+5. Scores each issue 0-100 for confidence level
+6. Filters out issues below 80 confidence threshold
+7. Posts review comment with high-confidence issues only
+
+**Usage:**
+```bash
+/code-review
+```
+
+**Example workflow:**
+```bash
+# On a PR branch, run:
+/code-review
+
+# Claude will:
+# - Launch 4 review agents in parallel
+# - Score each issue for confidence
+# - Post comment with issues ≥80 confidence
+# - Skip posting if no high-confidence issues found
+```
+
+**Features:**
+- Multiple independent agents for comprehensive review
+- Confidence-based scoring reduces false positives (threshold: 80)
+- CLAUDE.md compliance checking with explicit guideline verification
+- Bug detection focused on changes (not pre-existing issues)
+- Historical context analysis via git blame
+- Automatic skipping of closed, draft, or already-reviewed PRs
+- Links directly to code with full SHA and line ranges
+
+**Review comment format:**
+```markdown
+## Code review
+
+Found 3 issues:
+
+1. Missing error handling for OAuth callback (CLAUDE.md says "Always handle OAuth errors")
+
+https://github.com/owner/repo/blob/abc123.../src/auth.ts#L67-L72
+
+2. Memory leak: OAuth state not cleaned up (bug due to missing cleanup in finally block)
+
+https://github.com/owner/repo/blob/abc123.../src/auth.ts#L88-L95
+
+3. Inconsistent naming pattern (src/conventions/CLAUDE.md says "Use camelCase for functions")
+
+https://github.com/owner/repo/blob/abc123.../src/utils.ts#L23-L28
+```
+
+**Confidence scoring:**
+- **0**: Not confident, false positive
+- **25**: Somewhat confident, might be real
+- **50**: Moderately confident, real but minor
+- **75**: Highly confident, real and important
+- **100**: Absolutely certain, definitely real
+
+**False positives filtered:**
+- Pre-existing issues not introduced in PR
+- Code that looks like a bug but isn't
+- Pedantic nitpicks
+- Issues linters will catch
+- General quality issues (unless in CLAUDE.md)
+- Issues with lint ignore comments
+
+## Installation
+
+This plugin is included in the Claude Code repository. The command is automatically available when using Claude Code.
+
+## Best Practices
+
+### Using `/code-review`
+- Maintain clear CLAUDE.md files for better compliance checking
+- Trust the 80+ confidence threshold - false positives are filtered
+- Run on all non-trivial pull requests
+- Review agent findings as a starting point for human review
+- Update CLAUDE.md based on recurring review patterns
+
+### When to use
+- All pull requests with meaningful changes
+- PRs touching critical code paths
+- PRs from multiple contributors
+- PRs where guideline compliance matters
+
+### When not to use
+- Closed or draft PRs (automatically skipped anyway)
+- Trivial automated PRs (automatically skipped)
+- Urgent hotfixes requiring immediate merge
+- PRs already reviewed (automatically skipped)
+
+## Workflow Integration
+
+### Standard PR review workflow:
+```bash
+# Create PR with changes
+/code-review
+
+# Review the automated feedback
+# Make any necessary fixes
+# Merge when ready
+```
+
+### As part of CI/CD:
+```bash
+# Trigger on PR creation or update
+# Automatically posts review comments
+# Skip if review already exists
+```
+
+## Requirements
+
+- Git repository with GitHub integration
+- GitHub CLI (`gh`) installed and authenticated
+- CLAUDE.md files (optional but recommended for guideline checking)
+
+## Troubleshooting
+
+### Review takes too long
+
+**Issue**: Agents are slow on large PRs
+
+**Solution**:
+- Normal for large changes - agents run in parallel
+- 4 independent agents ensure thoroughness
+- Consider splitting large PRs into smaller ones
+
+### Too many false positives
+
+**Issue**: Review flags issues that aren't real
+
+**Solution**:
+- Default threshold is 80 (already filters most false positives)
+- Make CLAUDE.md more specific about what matters
+- Consider if the flagged issue is actually valid
+
+### No review comment posted
+
+**Issue**: `/code-review` runs but no comment appears
+
+**Solution**:
+Check if:
+- PR is closed (reviews skipped)
+- PR is draft (reviews skipped)
+- PR is trivial/automated (reviews skipped)
+- PR already has review (reviews skipped)
+- No issues scored ≥80 (no comment needed)
+
+### Link formatting broken
+
+**Issue**: Code links don't render correctly in GitHub
+
+**Solution**:
+Links must follow this exact format:
+```
+https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
+```
+- Must use full SHA (not abbreviated)
+- Must use `#L` notation
+- Must include line range with at least 1 line of context
+
+### GitHub CLI not working
+
+**Issue**: `gh` commands fail
+
+**Solution**:
+- Install GitHub CLI: `brew install gh` (macOS) or see [GitHub CLI installation](https://cli.github.com/)
+- Authenticate: `gh auth login`
+- Verify repository has GitHub remote
+
+## Tips
+
+- **Write specific CLAUDE.md files**: Clear guidelines = better reviews
+- **Include context in PRs**: Helps agents understand intent
+- **Use confidence scores**: Issues ≥80 are usually correct
+- **Iterate on guidelines**: Update CLAUDE.md based on patterns
+- **Review automatically**: Set up as part of PR workflow
+- **Trust the filtering**: Threshold prevents noise
+
+## Configuration
+
+### Adjusting confidence threshold
+
+The default threshold is 80. To adjust, modify the command file at `commands/code-review.md`:
+```markdown
+Filter out any issues with a score less than 80.
+```
+
+Change `80` to your preferred threshold (0-100).
+
+### Customizing review focus
+
+Edit `commands/code-review.md` to add or modify agent tasks:
+- Add security-focused agents
+- Add performance analysis agents
+- Add accessibility checking agents
+- Add documentation quality checks
+
+## Technical Details
+
+### Agent architecture
+- **2x CLAUDE.md compliance agents**: Redundancy for guideline checks
+- **1x bug detector**: Focused on obvious bugs in changes only
+- **1x history analyzer**: Context from git blame and history
+- **Nx confidence scorers**: One per issue for independent scoring
+
+### Scoring system
+- Each issue independently scored 0-100
+- Scoring considers evidence strength and verification
+- Threshold (default 80) filters low-confidence issues
+- For CLAUDE.md issues: verifies guideline explicitly mentions it
+
+### GitHub integration
+Uses `gh` CLI for:
+- Viewing PR details and diffs
+- Fetching repository data
+- Reading git blame and history
+- Posting review comments
+
+## Author
+
+Boris Cherny (boris@anthropic.com)
+
+## Version
+
+1.0.0

--- a/.claude/skills/code-review/commands/code-review.md
+++ b/.claude/skills/code-review/commands/code-review.md
@@ -1,0 +1,92 @@
+---
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)
+description: Code review a pull request
+disable-model-invocation: false
+---
+
+Provide a code review for the given pull request.
+
+To do this, follow these steps precisely:
+
+1. Use a Haiku agent to check if the pull request (a) is closed, (b) is a draft, (c) does not need a code review (eg. because it is an automated pull request, or is very simple and obviously ok), or (d) already has a code review from you from earlier. If so, do not proceed.
+2. Use another Haiku agent to give you a list of file paths to (but not the contents of) any relevant CLAUDE.md files from the codebase: the root CLAUDE.md file (if one exists), as well as any CLAUDE.md files in the directories whose files the pull request modified
+3. Use a Haiku agent to view the pull request, and ask the agent to return a summary of the change
+4. Then, launch 5 parallel Sonnet agents to independently code review the change. The agents should do the following, then return a list of issues and the reason each issue was flagged (eg. CLAUDE.md adherence, bug, historical git context, etc.):
+   a. Agent #1: Audit the changes to make sure they compily with the CLAUDE.md. Note that CLAUDE.md is guidance for Claude as it writes code, so not all instructions will be applicable during code review.
+   b. Agent #2: Read the file changes in the pull request, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on large bugs, and avoid small issues and nitpicks. Ignore likely false positives.
+   c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
+   d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current pull request.
+   e. Agent #5: Read code comments in the modified files, and make sure the changes in the pull request comply with any guidance in the comments.
+5. For each issue found in #4, launch a parallel Haiku agent that takes the PR, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
+   a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
+   b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
+   c. 50: Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very important.
+   d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
+   e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
+6. Filter out any issues with a score less than 80. If there are no issues that meet this criteria, do not proceed.
+7. Use a Haiku agent to repeat the eligibility check from #1, to make sure that the pull request is still eligible for code review.
+8. Finally, use the gh bash command to comment back on the pull request with the result. When writing your comment, keep in mind to:
+   a. Keep your output brief
+   b. Avoid emojis
+   c. Link and cite relevant code, files, and URLs
+
+Examples of false positives, for steps 4 and 5:
+
+- Pre-existing issues
+- Something that looks like a bug but is not actually a bug
+- Pedantic nitpicks that a senior engineer wouldn't call out
+- Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
+- General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
+- Changes in functionality that are likely intentional or are directly related to the broader change
+- Real issues, but on lines that the user did not modify in their pull request
+
+Notes:
+
+- Do not check build signal or attempt to build or typecheck the app. These will run separately, and are not relevant to your code review.
+- Use `gh` to interact with Github (eg. to fetch a pull request, or to create inline comments), rather than web fetch
+- Make a todo list first
+- You must cite and link each bug (eg. if referring to a CLAUDE.md, you must link it)
+- For your final comment, follow the following format precisely (assuming for this example that you found 3 issues):
+
+---
+
+### Code review
+
+Found 3 issues:
+
+1. <brief description of bug> (CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context, note that you MUST provide the full sha and not use bash here, eg. https://github.com/anthropics/claude-code/blob/1d54823877c4de72b2316a64032a54afc404e619/README.md#L13-L17>
+
+2. <brief description of bug> (some/other/CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context>
+
+3. <brief description of bug> (bug due to <file and code snippet>)
+
+<link to file and line with full sha1 + line range for context>
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+<sub>- If this code review was useful, please react with 👍. Otherwise, react with 👎.</sub>
+
+---
+
+- Or, if you found no issues:
+
+---
+
+### Code review
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+- When linking to code, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-cli-internal/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+  - Requires full git sha
+  - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
+  - Repo name must match the repo you're code reviewing
+  - # sign after the file name
+  - Line range format is L[start]-L[end]
+  - Provide at least 1 line of context before and after, centered on the line you are commenting about (eg. if you are commenting about lines 5-6, you should link to `L4-7`)

--- a/scripts/page-snapshot-lib.mjs
+++ b/scripts/page-snapshot-lib.mjs
@@ -52,7 +52,7 @@ export function parseCliArgs(argv) {
       options.timeoutMs = Number.parseInt(arg.slice("--timeout=".length), 10) || DEFAULT_TIMEOUT_MS;
     } else if (arg.startsWith("--similarity=")) {
       const value = Number.parseFloat(arg.slice("--similarity=".length));
-      if (value >= 0 && value <= 1) {
+      if (value > 0 && value <= 1) {
         options.similarityThreshold = value;
       }
     }


### PR DESCRIPTION
The previous validation allowed --similarity=0 which would make any snapshot pass since calculateSimilarity() can return 0.0 and the check "similarity >= 0" is always true.

Changed from "value >= 0" to "value > 0" to require at least some minimal similarity threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Code Review Plugin enabling automated multi-agent pull request review workflow with confidence-based issue detection
  * Added comprehensive documentation and workflow guides for code review functionality

* **Bug Fixes**
  * Fixed similarity flag validation to require strictly positive values

* **Chores**
  * Added Apache License 2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->