### PR TITLE
fix(security): disable default Claude SDK permission bypass

### DIFF
--- a/src/core/acp/__tests__/claude-code-sdk-adapter.test.ts
+++ b/src/core/acp/__tests__/claude-code-sdk-adapter.test.ts
@@ -164,6 +164,7 @@ describe("ClaudeCodeSdkAdapter", () => {
   afterEach(async () => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.CLAUDE_CODE_BYPASS_PERMISSIONS;
   });
 
   // ── connect ────────────────────────────────────────────────────────────────
@@ -229,9 +230,26 @@ describe("ClaudeCodeSdkAdapter", () => {
       const callArgs = mockQuery.mock.calls[0][0];
       expect(callArgs.prompt).toBe("Say hello");
       expect(callArgs.options.cwd).toBe("/tmp/test-cwd");
+      expect(callArgs.options.permissionMode).toBeUndefined();
+      expect(callArgs.options.allowDangerouslySkipPermissions).toBeUndefined();
+      expect(callArgs.options.maxTurns).toBe(30);
+    });
+
+    it("enables permission bypass only when explicitly configured", async () => {
+      process.env.CLAUDE_CODE_BYPASS_PERMISSIONS = "true";
+      mockQuery.mockReturnValue(makeStream([]));
+
+      const { handler } = collectNotifications();
+      const adapter = new ClaudeCodeSdkAdapter("/tmp/test-cwd", handler);
+      await adapter.connect();
+      await adapter.prompt("Say hello");
+
+      expect(mockQuery).toHaveBeenCalledOnce();
+      const callArgs = mockQuery.mock.calls[0][0];
       expect(callArgs.options.permissionMode).toBe("bypassPermissions");
       expect(callArgs.options.allowDangerouslySkipPermissions).toBe(true);
-      expect(callArgs.options.maxTurns).toBe(30);
+
+      delete process.env.CLAUDE_CODE_BYPASS_PERMISSIONS;
     });
 
     it("emits agent_message_chunk notifications from text_delta stream events", async () => {

--- a/src/core/acp/claude-code-sdk-adapter.ts
+++ b/src/core/acp/claude-code-sdk-adapter.ts
@@ -88,6 +88,23 @@ export function getClaudeCodeSdkConfig(): {
   };
 }
 
+function getPermissionOptions(): {
+  permissionMode?: "bypassPermissions";
+  allowDangerouslySkipPermissions?: boolean;
+} {
+  if (process.env.CLAUDE_CODE_BYPASS_PERMISSIONS === "true") {
+    console.warn(
+      "[ClaudeCodeSdkAdapter] CLAUDE_CODE_BYPASS_PERMISSIONS=true enables dangerous tool permission bypass"
+    );
+    return {
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    };
+  }
+
+  return {};
+}
+
 /**
  * Claude Code SDK Adapter — wraps the official agent SDK to provide an
  * ACP-compatible streaming interface.
@@ -244,8 +261,7 @@ export class ClaudeCodeSdkAdapter {
         model: this._modelOverride ?? config.model,
         maxTurns: this._maxTurnsOverride ?? 30,
         abortController: this.abortController,
-        permissionMode: "bypassPermissions",
-        allowDangerouslySkipPermissions: true,
+        ...getPermissionOptions(),
         pathToClaudeCodeExecutable: cliPath,
         // Load Skills from user (~/.claude/skills/) and project (.claude/skills/) dirs
         settingSources: ["user", "project"],
@@ -424,10 +440,7 @@ export class ClaudeCodeSdkAdapter {
         model: this._modelOverride ?? config.model,
         maxTurns: this._maxTurnsOverride ?? 30,
         abortController: this.abortController,
-        // Allow the agent to execute tools without interactive permission prompts.
-        // Required for autonomous operation in serverless environments.
-        permissionMode: "bypassPermissions",
-        allowDangerouslySkipPermissions: true,
+        ...getPermissionOptions(),
         // Explicitly point to cli.js so the SDK doesn't try to resolve it
         // relative to its own import.meta.url (which fails after webpack
         // bundling on Vercel because cli.js is not a statically-imported module


### PR DESCRIPTION
### Motivation

- The Claude Code SDK adapter previously enabled `permissionMode: "bypassPermissions"` and `allowDangerouslySkipPermissions: true` unconditionally, allowing unauthenticated ACP requests to trigger tool execution without user consent and creating a remote RCE/file-access risk.
- The intent is to remove this dangerous default and require an explicit opt-in for deployments that genuinely need automatic tool execution.
- Provide a minimal, reversible change that preserves existing behavior when explicitly requested via an environment variable.

### Description

- Added a new helper `getPermissionOptions()` that returns permission-related SDK options only when `CLAUDE_CODE_BYPASS_PERMISSIONS=true` is set, and emits a warning when enabled; otherwise it returns an empty object (`src/core/acp/claude-code-sdk-adapter.ts`).
- Replaced the hardcoded `permissionMode: "bypassPermissions"` / `allowDangerouslySkipPermissions: true` occurrences with `...getPermissionOptions()` in both `promptStream()` and `prompt()` so bypass is opt-in.
- Updated unit tests in `src/core/acp/__tests__/claude-code-sdk-adapter.test.ts` to assert the secure default (bypass flags `undefined`) and added a test that verifies opt-in behavior when `CLAUDE_CODE_BYPASS_PERMISSIONS` is explicitly set; tests also clean up the new env var between cases.

### Testing

- Ran linting with `npm run lint` and targeted `npx eslint src/core/acp/claude-code-sdk-adapter.ts src/core/acp/__tests__/claude-code-sdk-adapter.test.ts`, both completed successfully.
- Ran unit tests for the adapter with `npx vitest run src/core/acp/__tests__/claude-code-sdk-adapter.test.ts` and all tests passed.
- Ran full test suite with `npm run test` and `vitest` returned all tests passing (429 tests in total passed in the environment used).
- Attempted `npm run typecheck` but the repository does not define a `typecheck` script (no-op for this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2abe6661483269ce35284ea62d4a1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for environment variable configuration of permission settings, allowing behavior to be conditionally controlled through external configuration.
  * Implemented warning notification when permission bypass mode is activated.

* **Tests**
  * Enhanced test coverage to validate default permission configuration and environment-based settings behavior.
  * Verified that configuration values are correctly applied while default values remain preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->