### PR TITLE
fix(security): harden capture_screenshot command execution

### DIFF
--- a/src/core/tools/agent-tools.ts
+++ b/src/core/tools/agent-tools.ts
@@ -1011,35 +1011,50 @@ export class AgentTools {
     const { agentId, taskId, workspaceId, url, fullPage, annotate, context, outputPath } = params;
 
     try {
-      // Build agent-browser command
-      const commands: string[] = [];
+      const path = await import("path");
+      const fs = await import("fs/promises");
+
+      // Force output into a safe local screenshots directory to prevent arbitrary file reads.
+      const screenshotsDir = path.resolve(process.cwd(), ".routa-screenshots");
+      await fs.mkdir(screenshotsDir, { recursive: true });
+
+      let screenshotPath = path.join(screenshotsDir, `${uuidv4()}.png`);
+      if (outputPath) {
+        const fileName = path.basename(outputPath);
+        if (!/^[\w.-]+\.png$/i.test(fileName)) {
+          return errorResult("Invalid outputPath: must be a .png filename");
+        }
+
+        screenshotPath = path.join(screenshotsDir, fileName);
+      }
+
+      // Execute via child_process without shell interpolation
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
+      const execFileAsync = promisify(execFile);
 
       if (url) {
-        commands.push(`agent-browser open "${url}"`);
-        commands.push("agent-browser wait --load networkidle");
+        await execFileAsync("agent-browser", ["open", url], {
+          timeout: 60000,
+          cwd: process.cwd(),
+        });
+
+        await execFileAsync("agent-browser", ["wait", "--load", "networkidle"], {
+          timeout: 60000,
+          cwd: process.cwd(),
+        });
       }
 
-      // Build screenshot command
-      let screenshotCmd = "agent-browser screenshot";
+      const screenshotArgs = ["screenshot"];
       if (fullPage) {
-        screenshotCmd += " --full";
+        screenshotArgs.push("--full");
       }
       if (annotate) {
-        screenshotCmd += " --annotate";
+        screenshotArgs.push("--annotate");
       }
-      if (outputPath) {
-        screenshotCmd += ` "${outputPath}"`;
-      }
-      commands.push(screenshotCmd);
+      screenshotArgs.push(screenshotPath);
 
-      const fullCommand = commands.join(" && ");
-
-      // Execute via child_process
-      const { exec } = await import("child_process");
-      const { promisify } = await import("util");
-      const execAsync = promisify(exec);
-
-      const result = await execAsync(fullCommand, {
+      const result = await execFileAsync("agent-browser", screenshotArgs, {
         timeout: 60000, // 60 second timeout
         cwd: process.cwd(),
       });
@@ -1048,28 +1063,14 @@ export class AgentTools {
       const output = result.stdout.trim();
       const stderrOutput = result.stderr?.trim();
 
-      // Read the screenshot file if path is available
+      // Read file and convert to base64
       let screenshotContent = "";
-      let screenshotPath = outputPath;
-
-      // Try to extract path from output if not specified
-      if (!screenshotPath) {
-        const pathMatch = output.match(/(?:Saved|Screenshot).*?([/\w.-]+\.png)/i);
-        if (pathMatch) {
-          screenshotPath = pathMatch[1];
-        }
-      }
-
-      // Read file and convert to base64 if we have a path
-      if (screenshotPath) {
-        try {
-          const fs = await import("fs/promises");
-          const buffer = await fs.readFile(screenshotPath);
-          screenshotContent = buffer.toString("base64");
-        } catch {
-          // File might not exist or be readable
-          screenshotContent = `Screenshot captured at: ${screenshotPath}`;
-        }
+      try {
+        const buffer = await fs.readFile(screenshotPath);
+        screenshotContent = buffer.toString("base64");
+      } catch {
+        // File might not exist or be readable
+        screenshotContent = `Screenshot captured at: ${screenshotPath}`;
       }
 
       // Store as artifact


### PR DESCRIPTION
### Motivation
- The `captureScreenshot` tool previously composed a shell command with unescaped `url`/`outputPath` and executed it via `exec`, allowing command injection and arbitrary file reads when artifact tools are enabled by default. 
- Artifact tools are wired into the system factories, making this code path reachable over the unauthenticated MCP endpoint and creating a high-severity remote RCE/info-leak vector.
- The intent is to eliminate shell interpolation and constrain screenshot output so artifacts cannot be used to read arbitrary files or execute injected commands.

### Description
- Replace shell-string execution via `exec` with argument-safe process execution using `execFile`/`execFileAsync` and call `agent-browser` with argument arrays to prevent shell interpolation of `url` and other inputs (`src/core/tools/agent-tools.ts`).
- Constrain all screenshot outputs to a dedicated `.routa-screenshots` directory under `process.cwd()` and compute a safe `screenshotPath` there, only allowing a filename-style `outputPath` with a `*.png` basename when provided.
- Always read back the computed safe `screenshotPath` (never an attacker-controlled path parsed from stdout) and store the artifact using that path, preserving the original artifact storage behavior while preventing arbitrary file disclosure.
- Change is localized to `captureScreenshot` implementation in `src/core/tools/agent-tools.ts` and preserves existing artifact storage and event emission logic.

### Testing
- Ran linting with `npm run lint` and the command completed successfully.
- Type-checked the codebase with `npx tsc --noEmit --pretty false` and it completed successfully.
- Playwright screenshots/recordings: Not applicable for this backend security-only fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27302695483268bbf928f05679b69)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced screenshot capture reliability with improved file handling and validation.
  * Implemented automatic fallback messaging for consistent feedback when screenshots are unavailable.
  * Strengthened output path validation with enhanced filename constraints.
  * Improved artifact creation and metadata handling for better screenshot tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->