### PR TITLE
fix(security): prevent automatic background task execution on enqueue and server startup

### DIFF
--- a/src/app/api/background-tasks/route.ts
+++ b/src/app/api/background-tasks/route.ts
@@ -8,7 +8,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRoutaSystem } from "@/core/routa-system";
 import { createBackgroundTask } from "@/core/models/background-task";
-import { getBackgroundWorker, startBackgroundWorker } from "@/core/background-worker";
 import { v4 as uuidv4 } from "uuid";
 
 export const dynamic = "force-dynamic";
@@ -99,10 +98,6 @@ export async function POST(request: NextRequest) {
   });
 
   await system.backgroundTaskStore.save(task);
-
-  // Ensure worker is running and kick an immediate dispatch cycle (fire-and-forget)
-  startBackgroundWorker();
-  void getBackgroundWorker().dispatchPending();
 
   return NextResponse.json({ task }, { status: 201 });
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -10,13 +10,9 @@ export async function register() {
     const { startSchedulerService } = await import(
       "./core/scheduling/scheduler-service"
     );
-    const { startBackgroundWorker } = await import(
-      "./core/background-worker"
-    );
     // Delay startup slightly to let the HTTP server become ready
     setTimeout(() => {
       startSchedulerService();
-      startBackgroundWorker();
     }, 5000);
   }
 }


### PR DESCRIPTION
### Motivation
- The `POST /api/background-tasks` endpoint accepted attacker-controlled `prompt`/`agentId` and previously kicked the background worker immediately, allowing unauthenticated creation to trigger ACP sessions.  
- The instrumentation code auto-started the background worker on server boot, lowering the bar for remote, unauthenticated task execution.  

### Description
- Removed the immediate dispatch call from the enqueue handler in `src/app/api/background-tasks/route.ts` so `POST /api/background-tasks` only persists tasks as `PENDING` and does not start or dispatch the worker.  
- Removed automatic background-worker start from server instrumentation in `src/instrumentation.ts` so tasks are not processed automatically at server boot.  
- Preserved existing task creation behavior and the explicit dispatch endpoint (`POST /api/background-tasks/process`) so scheduled/cron-driven workflows continue to work.  

### Testing
- Ran `npm run lint` and the repository linter (`eslint .`) with no lint errors reported.  
- Verified that `POST /api/background-tasks` still returns the created task (`201`) but no longer invokes background dispatch (static code inspection of modified files).  
- Playwright/screenshots: N/A for this backend-only security fix (no UI changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b292d4c4308326ac58e2069c2a0955)