### PR TITLE
feat(issue): add local GitHub issue sync + duplicate triage for issue-enricher (#128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:tauri": "playwright test --config=playwright.tauri.config.ts e2e/tauri-backend-check.spec.ts",
     "test:e2e:tauri:headed": "playwright test --config=playwright.tauri.config.ts e2e/tauri-backend-check.spec.ts --project=chromium-headed",
-    "prepare": "husky"
+    "prepare": "husky",
+    "issues:sync": "npx tsx scripts/sync-github-issues.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",

--- a/scripts/issue-enricher.ts
+++ b/scripts/issue-enricher.ts
@@ -21,12 +21,19 @@
 import { execSync } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import {
+  defaultIssueCachePath,
+  findDuplicateCandidates,
+  loadSyncedGitHubIssues,
+  syncGitHubIssues,
+} from "../src/core/github/github-issue-intel";
 
 // ─── Configuration ─────────────────────────────────────────────────────────
 
 const SKILL_PATH = ".claude/skills/issue-enricher/SKILL.md";
 
 interface IssueData {
+  repo: string;
   number: number;
   title: string;
   body: string;
@@ -37,6 +44,9 @@ interface IssueData {
 // ─── Label Taxonomy ────────────────────────────────────────────────────────
 
 const LABEL_TAXONOMY = {
+  triage: [
+    { name: "duplicated", color: "cfd3d7", description: "Likely duplicate of an existing issue" },
+  ],
   type: [
     { name: "bug", color: "d73a4a", description: "Something isn't working" },
     { name: "enhancement", color: "a2eeef", description: "New feature or request" },
@@ -65,6 +75,7 @@ function ensureLabelsExist(): void {
     ...LABEL_TAXONOMY.type,
     ...LABEL_TAXONOMY.area,
     ...LABEL_TAXONOMY.complexity,
+    ...LABEL_TAXONOMY.triage,
   ];
 
   for (const label of allLabels) {
@@ -85,11 +96,13 @@ function ensureLabelsExist(): void {
 function fetchIssue(issueNumber: number): IssueData | null {
   try {
     const output = execSync(
-      `gh issue view ${issueNumber} --json number,title,body,labels,author`,
+      `gh issue view ${issueNumber} --json number,title,body,labels,author --repo $(gh repo view --json nameWithOwner --jq .nameWithOwner)`,
       { encoding: "utf-8", cwd: process.cwd() }
     );
     const data = JSON.parse(output);
+    const repo = execSync("gh repo view --json nameWithOwner --jq .nameWithOwner", { encoding: "utf-8", cwd: process.cwd() }).trim();
     return {
+      repo,
       number: data.number,
       title: data.title,
       body: data.body || "",
@@ -119,10 +132,29 @@ async function analyzeIssue(issue: IssueData, dryRun: boolean): Promise<void> {
 
   const hasBody = issue.body.trim().length > 0;
 
+  let duplicateHints = "(none)";
+  try {
+    const cachePath = defaultIssueCachePath(issue.repo);
+    const allIssues = syncGitHubIssues(issue.repo, cachePath, 300);
+    const duplicates = findDuplicateCandidates(issue, allIssues, 6);
+    duplicateHints = duplicates.length > 0
+      ? duplicates
+        .map((candidate) => `- #${candidate.number} [${candidate.state}] ${candidate.title} (${candidate.score}) ${candidate.url}`)
+        .join("\n")
+      : "(no high-confidence duplicates from local sync)";
+
+    const locallySyncedCount = loadSyncedGitHubIssues(cachePath).length;
+    console.log(`   📦 Local GitHub issue cache ready: ${locallySyncedCount} issues (${cachePath})`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`   ⚠️  Failed to refresh local issue cache: ${message}`);
+  }
+
   // Build label taxonomy strings for prompt
   const typeLabels = LABEL_TAXONOMY.type.map((l) => `\`${l.name}\``).join(", ");
   const areaLabels = LABEL_TAXONOMY.area.map((l) => `\`${l.name}\``).join(", ");
   const complexityLabels = LABEL_TAXONOMY.complexity.map((l) => `\`${l.name}\``).join(", ");
+  const triageLabels = LABEL_TAXONOMY.triage.map((l) => `\`${l.name}\``).join(", ");
 
   const prompt = `Analyze GitHub issue #${issue.number} and provide a detailed analysis.
 
@@ -134,6 +166,9 @@ ${hasBody ? issue.body : "(empty - user did not write a body)"}
 
 ## Current Labels
 ${issue.labels.length > 0 ? issue.labels.join(", ") : "(none)"}
+
+## Local Duplicate Hints (from synced GitHub issues)
+${duplicateHints}
 
 ## CRITICAL: External Repository References
 If the issue title or body contains a GitHub repository URL (e.g. https://github.com/user/repo):
@@ -166,7 +201,10 @@ This is essential — if the user says "clone" or references an external repo, t
    - 2-3 proposed approaches with trade-offs
    - Recommended approach
    - Effort estimate (Small/Medium/Large)
-7. Automatically apply labels based on your analysis using these categories:
+7. First, determine whether this issue duplicates existing ones:
+   - If duplicate, identify canonical issue(s), explain the overlap, and apply triage label ${triageLabels}.
+   - If not duplicate, state why it is distinct.
+8. Automatically apply labels based on your analysis using these categories:
    - **Type** (pick ONE): ${typeLabels}
    - **Area** (pick ONE or MORE that apply): ${areaLabels}
    - **Complexity** (pick ONE): ${complexityLabels}
@@ -174,6 +212,8 @@ This is essential — if the user says "clone" or references an external repo, t
      ? "Output the labels you would apply and why, but do NOT run any gh commands."
      : `Apply the labels with: gh issue edit ${issue.number} --add-label "bug,area:frontend,complexity:small" (replace with the labels you chose)
    Use only labels from the taxonomy above. Do NOT invent new label names.`}
+
+9. If this issue needs follow-up from a code owner, include @mentions based on git history and relevant files. Only mention maintainers when you have concrete file-level evidence.
 
 Do NOT create a new issue - only analyze and update issue #${issue.number}.`;
 

--- a/scripts/sync-github-issues.ts
+++ b/scripts/sync-github-issues.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env npx tsx
+
+import { execSync } from "child_process";
+import {
+  defaultIssueCachePath,
+  syncGitHubIssues,
+} from "../src/core/github/github-issue-intel";
+
+function getArg(name: string): string | undefined {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function detectCurrentRepo(): string {
+  return execSync("gh repo view --json nameWithOwner --jq .nameWithOwner", {
+    encoding: "utf-8",
+    cwd: process.cwd(),
+  }).trim();
+}
+
+function main(): void {
+  const repo = getArg("--repo") ?? detectCurrentRepo();
+  const limit = Number(getArg("--limit") ?? "200");
+  const output = getArg("--output") ?? defaultIssueCachePath(repo);
+
+  console.log(`📥 Syncing issues for ${repo} ...`);
+  const issues = syncGitHubIssues(repo, output, limit);
+  console.log(`✅ Synced ${issues.length} issues -> ${output}`);
+}
+
+main();

--- a/src/core/github/__tests__/github-issue-intel.test.ts
+++ b/src/core/github/__tests__/github-issue-intel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { findDuplicateCandidates, type GitHubIssueRecord } from "../github-issue-intel";
+
+describe("findDuplicateCandidates", () => {
+  it("returns similar issues ranked by score", () => {
+    const issues: GitHubIssueRecord[] = [
+      {
+        number: 11,
+        title: "Kanban column automation does not trigger session",
+        body: "Moving cards to In Progress should create an ACP session but nothing happens.",
+        state: "OPEN",
+        url: "https://github.com/phodal/routa/issues/11",
+      },
+      {
+        number: 12,
+        title: "UI alignment issue in settings panel",
+        body: "Minor css spacing problem",
+        state: "OPEN",
+        url: "https://github.com/phodal/routa/issues/12",
+      },
+      {
+        number: 13,
+        title: "Kanban automation session creation missing after card move",
+        body: "When card moves into automation column, no workflow session starts.",
+        state: "CLOSED",
+        url: "https://github.com/phodal/routa/issues/13",
+      },
+    ];
+
+    const candidates = findDuplicateCandidates(
+      {
+        number: 200,
+        title: "Card move to automation column fails to create session",
+        body: "Expected ACP session trigger after moving kanban card.",
+      },
+      issues,
+    );
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].number === 11 || candidates[0].number === 13).toBe(true);
+    expect(candidates.some((c) => c.number === 11)).toBe(true);
+    expect(candidates.some((c) => c.number === 13)).toBe(true);
+    expect(candidates.some((c) => c.number === 12)).toBe(false);
+  });
+});

--- a/src/core/github/github-issue-intel.ts
+++ b/src/core/github/github-issue-intel.ts
@@ -1,0 +1,101 @@
+import { execSync } from "child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+export interface GitHubIssueRecord {
+  number: number;
+  title: string;
+  body?: string;
+  state: "OPEN" | "CLOSED" | string;
+  url: string;
+  createdAt?: string;
+  updatedAt?: string;
+  labels?: Array<{ name: string }>;
+  author?: { login: string };
+}
+
+export interface DuplicateCandidate {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  score: number;
+}
+
+const STOP_WORDS = new Set([
+  "the", "and", "for", "with", "that", "this", "from", "when", "into", "after", "issue", "error",
+  "task", "bug", "about", "while", "then", "does", "have", "been", "are", "was", "were", "not", "can",
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[`*_#()[\]{}:;,.!?/\\|<>="']/g, " ")
+      .split(/\s+/)
+      .filter((token) => token.length >= 3 && !STOP_WORDS.has(token))
+  );
+}
+
+function similarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersect = 0;
+  for (const token of a) {
+    if (b.has(token)) intersect += 1;
+  }
+  const union = a.size + b.size - intersect;
+  return union > 0 ? intersect / union : 0;
+}
+
+export function findDuplicateCandidates(
+  target: Pick<GitHubIssueRecord, "title" | "body" | "number">,
+  issues: GitHubIssueRecord[],
+  maxCandidates = 5,
+): DuplicateCandidate[] {
+  const targetTokens = tokenize(`${target.title}\n${target.body ?? ""}`);
+  return issues
+    .filter((issue) => issue.number !== target.number)
+    .map((issue) => ({
+      issue,
+      score: similarity(targetTokens, tokenize(`${issue.title}\n${issue.body ?? ""}`)),
+    }))
+    .filter((item) => item.score >= 0.2)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxCandidates)
+    .map((item) => ({
+      number: item.issue.number,
+      title: item.issue.title,
+      url: item.issue.url,
+      state: item.issue.state,
+      score: Number(item.score.toFixed(3)),
+    }));
+}
+
+export function syncGitHubIssues(repo: string, outputFile: string, limit = 200): GitHubIssueRecord[] {
+  const cmd = [
+    "gh issue list",
+    `--repo ${repo}`,
+    "--state all",
+    `--limit ${limit}`,
+    "--json number,title,body,state,url,labels,author,createdAt,updatedAt",
+  ].join(" ");
+
+  const raw = execSync(cmd, { encoding: "utf-8", cwd: process.cwd() });
+  const issues = JSON.parse(raw) as GitHubIssueRecord[];
+
+  mkdirSync(dirname(outputFile), { recursive: true });
+  writeFileSync(outputFile, JSON.stringify({ repo, syncedAt: new Date().toISOString(), issues }, null, 2), "utf-8");
+
+  return issues;
+}
+
+export function loadSyncedGitHubIssues(outputFile: string): GitHubIssueRecord[] {
+  const content = readFileSync(outputFile, "utf-8");
+  const parsed = JSON.parse(content) as { issues?: GitHubIssueRecord[] };
+  return parsed.issues ?? [];
+}
+
+export function defaultIssueCachePath(repo: string): string {
+  const safeRepo = repo.replace("/", "__");
+  return join(process.cwd(), ".cache", "github-issues", `${safeRepo}.json`);
+}

--- a/src/core/github/index.ts
+++ b/src/core/github/index.ts
@@ -25,3 +25,16 @@ export type {
   PostPRCommentOptions,
   PostPRReviewOptions,
 } from "./github-pr-comment";
+
+
+export {
+  findDuplicateCandidates,
+  syncGitHubIssues,
+  loadSyncedGitHubIssues,
+  defaultIssueCachePath,
+} from "./github-issue-intel";
+
+export type {
+  GitHubIssueRecord,
+  DuplicateCandidate,
+} from "./github-issue-intel";


### PR DESCRIPTION
### Motivation
- Provide the issue-enricher agent a local, synced copy of repository issues so it can reliably detect duplicates and produce maintainer-directed analysis (implements #128).
- Reduce maintainer triage burden by surfacing likely duplicates and giving file-level guidance for follow-up.

### Description
- Add a reusable Node module `src/core/github/github-issue-intel.ts` that syncs issues via `gh issue list` into `.cache/github-issues/*.json` and exposes `findDuplicateCandidates`, `syncGitHubIssues`, `loadSyncedGitHubIssues`, and `defaultIssueCachePath`.
- Add CLI `scripts/sync-github-issues.ts` and npm script `issues:sync` to manually or CI-trigger sync issues into local cache using `gh`.
- Integrate local-sync + duplicate hints into `scripts/issue-enricher.ts` so the enricher refreshes the cache, injects duplicate candidates into the prompt, and ensures a `duplicated` triage label is available.
- Export the new APIs from `src/core/github/index.ts` and add unit test `src/core/github/__tests__/github-issue-intel.test.ts` for duplicate candidate logic.

### Testing
- Ran lint with `npm run lint` and it completed without errors.
- Ran unit test `npx vitest run src/core/github/__tests__/github-issue-intel.test.ts` and it passed.
- Verified the new CLI via local invocation pattern `npx tsx scripts/sync-github-issues.ts` (requires `gh` and appropriate tokens/permissions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b801ad348326b5c8b69f09717645)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local duplicate issue detection that identifies and flags similar issues using intelligent matching.
  * Added new "duplicated" triage label for issues identified as duplicates.
  * Added repository tracking for all issues.
  * Added "issues:sync" npm script to sync and cache GitHub issues locally for duplicate detection analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->