### PR TITLE
feat: add Kanban interactive terminal POC

### DIFF
--- a/src/app/api/acp/route.ts
+++ b/src/app/api/acp/route.ts
@@ -49,6 +49,7 @@ import { persistSessionToDb, renameSessionInDb, saveHistoryToDb } from "@/core/a
 import { resolveSkillContent } from "@/core/skills/skill-resolver";
 import type { SessionUpdateNotification } from "@/core/acp/http-session-store";
 import { SessionWriteBuffer } from "@/core/acp/session-write-buffer";
+import { getTerminalManager } from "@/core/acp/terminal-manager";
 
 export const dynamic = "force-dynamic";
 
@@ -1256,6 +1257,89 @@ export async function POST(request: NextRequest) {
     }
 
     // ── session/cancel ─────────────────────────────────────────────────
+    if (method === "terminal/create") {
+      const p = (params ?? {}) as Record<string, unknown>;
+      const sessionId = p.sessionId as string | undefined;
+      const cwd = p.cwd as string | undefined;
+      const command = p.command as string | undefined;
+      const args = Array.isArray(p.args) ? p.args.filter((item): item is string => typeof item === "string") : undefined;
+      const shell = typeof p.shell === "boolean" ? p.shell : undefined;
+      const env = typeof p.env === "object" && p.env !== null
+        ? Object.fromEntries(
+            Object.entries(p.env as Record<string, unknown>).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+          )
+        : undefined;
+
+      if (!sessionId) {
+        return jsonrpcResponse(id ?? null, null, {
+          code: -32602,
+          message: "Missing sessionId",
+        });
+      }
+
+      const store = getHttpSessionStore();
+      await store.hydrateFromDb();
+      const session = store.getSession(sessionId);
+      if (!session) {
+        return jsonrpcResponse(id ?? null, null, {
+          code: -32000,
+          message: `Session ${sessionId} not found`,
+        });
+      }
+
+      const result = getTerminalManager().create(
+        {
+          cwd: cwd ?? session.cwd,
+          command,
+          args,
+          shell,
+          env,
+        },
+        sessionId,
+        createSessionUpdateForwarder(store, sessionId),
+      );
+
+      return jsonrpcResponse(id ?? null, result);
+    }
+
+    if (method === "terminal/write") {
+      const p = (params ?? {}) as Record<string, unknown>;
+      const terminalId = p.terminalId as string | undefined;
+      const data = p.data as string | undefined;
+
+      if (!terminalId || typeof data !== "string") {
+        return jsonrpcResponse(id ?? null, null, {
+          code: -32602,
+          message: "Missing terminalId or data",
+        });
+      }
+
+      const result = getTerminalManager().write(terminalId, data);
+      if (!result.ok) {
+        return jsonrpcResponse(id ?? null, null, {
+          code: -32000,
+          message: `Terminal ${terminalId} is not writable`,
+        });
+      }
+
+      return jsonrpcResponse(id ?? null, result);
+    }
+
+    if (method === "terminal/kill") {
+      const p = (params ?? {}) as Record<string, unknown>;
+      const terminalId = p.terminalId as string | undefined;
+
+      if (!terminalId) {
+        return jsonrpcResponse(id ?? null, null, {
+          code: -32602,
+          message: "Missing terminalId",
+        });
+      }
+
+      getTerminalManager().kill(terminalId);
+      return jsonrpcResponse(id ?? null, { ok: true });
+    }
+
     if (method === "session/respond_user_input") {
       const p = (params ?? {}) as Record<string, unknown>;
       const sessionId = p.sessionId as string | undefined;

--- a/src/app/workspace/[workspaceId]/kanban/kanban-tab.tsx
+++ b/src/app/workspace/[workspaceId]/kanban/kanban-tab.tsx
@@ -12,6 +12,7 @@ import { KanbanCardDetail } from "./kanban-card-detail";
 import { buildKanbanTaskAgentPrompt, scheduleKanbanRefreshBurst } from "./kanban-agent-input";
 import { ChatPanel } from "@/client/components/chat-panel";
 import { RepoPicker, type RepoSelection } from "@/client/components/repo-picker";
+import { InteractiveSessionTerminal } from "@/client/components/terminal/interactive-session-terminal";
 
 interface SpecialistOption {
   id: string;
@@ -76,6 +77,8 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
   const [agentLoading, setAgentLoading] = useState(false);
   const [agentSessionId, setAgentSessionId] = useState<string | null>(null);
   const [agentPanelOpen, setAgentPanelOpen] = useState(false);
+  const [agentTerminalEnabled, setAgentTerminalEnabled] = useState(false);
+  const [sessionTerminalEnabled, setSessionTerminalEnabled] = useState(false);
 
   // Codebase detail popup state
   const [selectedCodebase, setSelectedCodebase] = useState<CodebaseData | null>(null);
@@ -108,6 +111,7 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
   const openAgentPanel = useCallback((sessionId: string) => {
     setAgentSessionId(sessionId);
     setAgentPanelOpen(true);
+    setAgentTerminalEnabled(false);
     acp?.selectSession(sessionId);
   }, [acp]);
 
@@ -357,9 +361,26 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
     return result.sessionId;
   }, [acp, agentSessionId, defaultCodebase?.repoPath, openAgentPanel, workspaceId]);
 
+  const handleOpenTerminalPoc = useCallback(async () => {
+    if (!acp) return;
+    if (!acp.connected) {
+      await acp.connect();
+    }
+
+    const sessionId = await ensureKanbanAgentSession(
+      defaultCodebase?.repoPath,
+      acp.selectedProvider,
+    );
+    if (!sessionId) return;
+
+    openAgentPanel(sessionId);
+    setAgentTerminalEnabled(true);
+  }, [acp, defaultCodebase?.repoPath, ensureKanbanAgentSession, openAgentPanel]);
+
   const openTaskDetail = useCallback(async (task: TaskInfo) => {
     setActiveTaskId(task.id);
     setActiveSessionId(task.triggerSessionId ?? null);
+    setSessionTerminalEnabled(false);
 
     if (task.codebaseIds?.length === 0 && defaultCodebase) {
       try {
@@ -378,6 +399,7 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
   const openSession = useCallback((sessionId: string | null) => {
     setActiveTaskId(null);
     setActiveSessionId(sessionId);
+    setSessionTerminalEnabled(false);
     // Select the session in ACP
     if (sessionId && acp) {
       acp.selectSession(sessionId);
@@ -387,6 +409,7 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
   const closeTaskDetail = useCallback(() => {
     setActiveTaskId(null);
     setActiveSessionId(null);
+    setSessionTerminalEnabled(false);
   }, []);
 
   useEffect(() => {
@@ -816,6 +839,14 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
                     View
                   </button>
                 )}
+                <button
+                  onClick={() => void handleOpenTerminalPoc()}
+                  disabled={agentLoading}
+                  className="shrink-0 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300 dark:hover:bg-emerald-950/30"
+                  data-testid="kanban-terminal-poc-button"
+                >
+                  Terminal POC
+                </button>
               </div>
             )}
           </div>
@@ -949,6 +980,17 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
                 </div>
               </div>
               <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setAgentTerminalEnabled((current) => !current)}
+                  className={`rounded-md border px-2 py-1 text-xs ${
+                    agentTerminalEnabled
+                      ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
+                      : "border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-[#191c28]"
+                  }`}
+                  data-testid="kanban-agent-terminal-toggle"
+                >
+                  {agentTerminalEnabled ? "Hide terminal" : "Enable interactive terminal"}
+                </button>
                 <a
                   href={`/workspace/${workspaceId}/sessions/${agentSessionId}`}
                   target="_blank"
@@ -966,19 +1008,34 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
               </div>
             </div>
             <div className="min-h-0 flex-1">
-              <ChatPanel
-                acp={acp}
-                activeSessionId={agentSessionId}
-                onEnsureSession={ensureKanbanAgentSession}
-                onSelectSession={async (sessionId) => {
-                  openAgentPanel(sessionId);
-                }}
-                repoSelection={kanbanRepoSelection}
-                onRepoChange={() => {}}
-                codebases={codebases}
-                activeWorkspaceId={workspaceId}
-                agentRole="DEVELOPER"
-              />
+              <div className="flex h-full min-h-0 flex-col">
+                <div className={`${agentTerminalEnabled ? "min-h-0 flex-[0_0_58%]" : "min-h-0 flex-1"}`}>
+                  <ChatPanel
+                    acp={acp}
+                    activeSessionId={agentSessionId}
+                    onEnsureSession={ensureKanbanAgentSession}
+                    onSelectSession={async (sessionId) => {
+                      openAgentPanel(sessionId);
+                    }}
+                    repoSelection={kanbanRepoSelection}
+                    onRepoChange={() => {}}
+                    codebases={codebases}
+                    activeWorkspaceId={workspaceId}
+                    agentRole="DEVELOPER"
+                    hideTerminalMessages={agentTerminalEnabled}
+                  />
+                </div>
+                {agentTerminalEnabled && (
+                  <div className="min-h-0 flex-[0_0_42%] border-t border-slate-800/80">
+                    <InteractiveSessionTerminal
+                      acp={acp}
+                      sessionId={agentSessionId}
+                      cwd={kanbanRepoSelection?.path ?? defaultCodebase?.repoPath}
+                      title="KanbanTask Agent terminal"
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </aside>
         )}
@@ -1012,6 +1069,19 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
                   </div>
                 </div>
               <div className="flex items-center gap-2">
+                {activeSessionId && (
+                  <button
+                    onClick={() => setSessionTerminalEnabled((current) => !current)}
+                    className={`rounded-md border px-2 py-1 text-xs ${
+                      sessionTerminalEnabled
+                        ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
+                        : "border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-[#191c28]"
+                    }`}
+                    data-testid="kanban-session-terminal-toggle"
+                  >
+                    {sessionTerminalEnabled ? "Hide terminal" : "Enable interactive terminal"}
+                  </button>
+                )}
                 {activeSessionId && (
                   <a
                     href={`/workspace/${workspaceId}/sessions/${activeSessionId}`}
@@ -1086,20 +1156,36 @@ export function KanbanTab({ workspaceId, boards, tasks, sessions, providers, spe
                 return (
                   <div className={`${activeTaskId ? "w-2/3" : "w-full"} h-full overflow-hidden`}>
                     {acp && (
-                    <ChatPanel
-                      acp={acp}
-                      activeSessionId={activeSessionId}
-                      onEnsureSession={async () => activeSessionId}
-                      onSelectSession={async (sessionId) => {
-                        setActiveSessionId(sessionId);
-                        acp.selectSession(sessionId);
-                      }}
-                      repoSelection={repoSelection}
-                      onRepoChange={() => {}}
-                      codebases={codebases}
-                      activeWorkspaceId={workspaceId}
-                      agentRole={taskAgentRole}
-                    />
+                    <div className="flex h-full min-h-0 flex-col">
+                      <div className={`${sessionTerminalEnabled ? "min-h-0 flex-[0_0_58%]" : "min-h-0 flex-1"}`}>
+                        <ChatPanel
+                          acp={acp}
+                          activeSessionId={activeSessionId}
+                          onEnsureSession={async () => activeSessionId}
+                          onSelectSession={async (sessionId) => {
+                            setActiveSessionId(sessionId);
+                            setSessionTerminalEnabled(false);
+                            acp.selectSession(sessionId);
+                          }}
+                          repoSelection={repoSelection}
+                          onRepoChange={() => {}}
+                          codebases={codebases}
+                          activeWorkspaceId={workspaceId}
+                          agentRole={taskAgentRole}
+                          hideTerminalMessages={sessionTerminalEnabled}
+                        />
+                      </div>
+                      {sessionTerminalEnabled && activeSessionId && (
+                        <div className="min-h-0 flex-[0_0_42%] border-t border-slate-800/80">
+                          <InteractiveSessionTerminal
+                            acp={acp}
+                            sessionId={activeSessionId}
+                            cwd={repoSelection?.path ?? defaultCodebase?.repoPath}
+                            title={activeTask ? "Task session terminal" : "Session terminal"}
+                          />
+                        </div>
+                      )}
+                    </div>
                     )}
                   </div>
                 );

--- a/src/client/acp-client.ts
+++ b/src/client/acp-client.ts
@@ -42,6 +42,10 @@ export interface AcpPromptResult {
   };
 }
 
+export interface AcpTerminalCreateResult {
+  terminalId: string;
+}
+
 export interface AcpProviderInfo {
   id: string;
   name: string;
@@ -414,6 +418,38 @@ export class BrowserAcpClient {
       sessionId,
       toolCallId,
       response,
+    });
+  }
+
+  async createTerminal(
+    sessionId: string,
+    params: {
+      cwd?: string;
+      command?: string;
+      args?: string[];
+      shell?: boolean;
+      env?: Record<string, string>;
+    },
+  ): Promise<AcpTerminalCreateResult> {
+    return this.rpc<AcpTerminalCreateResult>("terminal/create", {
+      sessionId,
+      ...params,
+    });
+  }
+
+  async writeTerminal(
+    terminalId: string,
+    data: string,
+  ): Promise<{ ok: boolean }> {
+    return this.rpc<{ ok: boolean }>("terminal/write", {
+      terminalId,
+      data,
+    });
+  }
+
+  async killTerminal(terminalId: string): Promise<{ ok: boolean }> {
+    return this.rpc<{ ok: boolean }>("terminal/kill", {
+      terminalId,
     });
   }
 

--- a/src/client/components/chat-panel.tsx
+++ b/src/client/components/chat-panel.tsx
@@ -85,6 +85,7 @@ interface ChatPanelProps {
   activeWorkspaceId?: string | null;
   onWorkspaceChange?: (id: string) => void;
   codebases?: CodebaseData[];
+  hideTerminalMessages?: boolean;
   /** When set, pre-fills the chat input (e.g. to restore text after a session error) */
   inputPrefill?: string | null;
   /** Called after inputPrefill has been consumed */
@@ -111,6 +112,7 @@ export function ChatPanel({
   activeWorkspaceId,
   onWorkspaceChange,
   codebases: _codebases = [],
+  hideTerminalMessages = false,
   inputPrefill,
   onInputPrefillConsumed,
 }: ChatPanelProps) {
@@ -498,6 +500,9 @@ export function ChatPanel({
                   }
                   // Hide pending AskUserQuestion from chat stream — shown sticky above input
                   if (msg.role === "tool" && isAskUserQuestionMessage(msg) && !hasAskUserQuestionAnswers(msg) && msg.toolStatus !== "failed") {
+                    return false;
+                  }
+                  if (hideTerminalMessages && msg.role === "terminal") {
                     return false;
                   }
                   return true;

--- a/src/client/components/terminal/interactive-session-terminal.tsx
+++ b/src/client/components/terminal/interactive-session-terminal.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { UseAcpActions, UseAcpState } from "@/client/hooks/use-acp";
+
+type XTerminal = import("@xterm/xterm").Terminal;
+type XFitAddon = import("@xterm/addon-fit").FitAddon;
+
+interface InteractiveSessionTerminalProps {
+  acp: UseAcpState & UseAcpActions;
+  sessionId: string;
+  cwd?: string;
+  title?: string;
+}
+
+const TERMINAL_THEME = {
+  background: "#0d1117",
+  foreground: "#c9d1d9",
+  cursor: "#58a6ff",
+  cursorAccent: "#0d1117",
+  selectionBackground: "#264f78",
+  selectionForeground: "#ffffff",
+  selectionInactiveBackground: "#264f7850",
+  black: "#484f58",
+  red: "#ff7b72",
+  green: "#3fb950",
+  yellow: "#d29922",
+  blue: "#58a6ff",
+  magenta: "#bc8cff",
+  cyan: "#39d353",
+  white: "#b1bac4",
+  brightBlack: "#6e7681",
+  brightRed: "#ffa198",
+  brightGreen: "#56d364",
+  brightYellow: "#e3b341",
+  brightBlue: "#79c0ff",
+  brightMagenta: "#d2a8ff",
+  brightCyan: "#56d364",
+  brightWhite: "#f0f6fc",
+};
+
+export function InteractiveSessionTerminal({
+  acp,
+  sessionId,
+  cwd,
+  title = "Interactive terminal",
+}: InteractiveSessionTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<XTerminal | null>(null);
+  const fitAddonRef = useRef<XFitAddon | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const terminalIdRef = useRef<string | null>(null);
+  const processedUpdatesRef = useRef(0);
+  const outputLengthRef = useRef(0);
+  const [initialized, setInitialized] = useState(false);
+  const [terminalId, setTerminalId] = useState<string | null>(null);
+  const [statusText, setStatusText] = useState("starting");
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [buffer, setBuffer] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createTerminal = useCallback(async () => {
+    if (creating || terminalIdRef.current) return;
+    setCreating(true);
+    setError(null);
+
+    const result = await acp.createTerminal(sessionId, {
+      cwd,
+      command: "/bin/bash",
+      args: [],
+      shell: false,
+      env: {
+        TERM: "xterm-256color",
+      },
+    });
+
+    setCreating(false);
+    if (!result?.terminalId) {
+      setError("Failed to start terminal");
+      setStatusText("failed");
+      return;
+    }
+
+    terminalIdRef.current = result.terminalId;
+    setTerminalId(result.terminalId);
+    setStatusText("connected");
+  }, [acp, creating, cwd, sessionId]);
+
+  const stopTerminal = useCallback(async () => {
+    if (!terminalIdRef.current) return;
+    await acp.killTerminal(terminalIdRef.current);
+  }, [acp]);
+
+  const initTerminal = useCallback(async () => {
+    if (!containerRef.current || terminalRef.current) return;
+
+    try {
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+      ]);
+
+      const fitAddon = new FitAddon();
+      const terminal = new Terminal({
+        fontFamily: '"SF Mono", Monaco, Menlo, "Courier New", monospace',
+        fontSize: 12,
+        lineHeight: 1.3,
+        cursorBlink: true,
+        cursorStyle: "block",
+        scrollback: 5000,
+        allowTransparency: true,
+        convertEol: true,
+        drawBoldTextInBrightColors: true,
+        theme: TERMINAL_THEME,
+      });
+
+      terminal.loadAddon(fitAddon);
+      terminal.open(containerRef.current);
+      fitAddon.fit();
+
+      terminal.onData((data) => {
+        const currentTerminalId = terminalIdRef.current;
+        if (!currentTerminalId) return;
+        terminal.write(data === "\r" ? "\r\n" : data);
+        void acp.writeTerminal(currentTerminalId, data);
+      });
+
+      observerRef.current = new ResizeObserver(() => {
+        requestAnimationFrame(() => {
+          try {
+            fitAddon.fit();
+          } catch {
+            // Ignore resize races during unmount.
+          }
+        });
+      });
+      observerRef.current.observe(containerRef.current);
+
+      terminalRef.current = terminal;
+      fitAddonRef.current = fitAddon;
+      terminal.writeln("Connected to Kanban session shell");
+      terminal.writeln("Type a command and press Enter.");
+      setInitialized(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStatusText("failed");
+    }
+  }, [acp]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void initTerminal();
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [initTerminal]);
+
+  useEffect(() => {
+    if (initialized) {
+      void createTerminal();
+    }
+  }, [createTerminal, initialized]);
+
+  useEffect(() => {
+    if (acp.updates.length < processedUpdatesRef.current) {
+      processedUpdatesRef.current = 0;
+    }
+    const nextUpdates = acp.updates.slice(processedUpdatesRef.current);
+    processedUpdatesRef.current = acp.updates.length;
+
+    for (const notification of nextUpdates) {
+      if (notification.sessionId !== sessionId) continue;
+
+      const update = notification.update as Record<string, unknown> | undefined;
+      const kind = update?.sessionUpdate;
+      const updateTerminalId = typeof update?.terminalId === "string" ? update.terminalId : undefined;
+
+      if (kind === "terminal_created" && updateTerminalId && updateTerminalId === terminalIdRef.current) {
+        setStatusText("connected");
+      }
+
+      if (kind === "terminal_output" && updateTerminalId && updateTerminalId === terminalIdRef.current) {
+        const data = typeof update?.data === "string" ? update.data : "";
+        if (data) {
+          setBuffer((current) => current + data);
+        }
+      }
+
+      if (kind === "terminal_exited" && updateTerminalId && updateTerminalId === terminalIdRef.current) {
+        const nextExitCode = typeof update?.exitCode === "number" ? update.exitCode : 0;
+        setExitCode(nextExitCode);
+        setStatusText(nextExitCode === 0 ? "completed" : `failed (${nextExitCode})`);
+      }
+    }
+  }, [acp.updates, sessionId]);
+
+  useEffect(() => {
+    if (!terminalRef.current || !buffer) return;
+
+    const newData = buffer.slice(outputLengthRef.current);
+    if (!newData) return;
+
+    terminalRef.current.write(newData);
+    outputLengthRef.current = buffer.length;
+  }, [buffer]);
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+      fitAddonRef.current = null;
+      terminalRef.current?.dispose();
+      terminalRef.current = null;
+    };
+  }, []);
+
+  const statusTone = useMemo(() => {
+    if (statusText === "connected") return "bg-green-500";
+    if (statusText.startsWith("failed")) return "bg-red-500";
+    if (statusText === "completed") return "bg-slate-400";
+    return "bg-yellow-500 animate-pulse";
+  }, [statusText]);
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-slate-800 bg-[#0d1117]"
+      data-testid="kanban-interactive-terminal"
+    >
+      <div className="flex items-center gap-3 border-b border-slate-800 px-3 py-2">
+        <span className={`h-2 w-2 rounded-full ${statusTone}`} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-semibold text-slate-100">{title}</div>
+          <div className="truncate text-[11px] text-slate-400">
+            {cwd ?? "session cwd"} {terminalId ? `- ${terminalId}` : ""}
+          </div>
+        </div>
+        <div className="text-[11px] text-slate-400">
+          {exitCode !== null ? `exit ${exitCode}` : statusText}
+        </div>
+        <button
+          type="button"
+          onClick={() => void stopTerminal()}
+          className="rounded border border-slate-700 px-2 py-1 text-[11px] text-slate-300 hover:bg-slate-800"
+          disabled={!terminalId}
+        >
+          Stop
+        </button>
+      </div>
+      {error ? (
+        <div className="px-3 py-3 text-sm text-red-300">{error}</div>
+      ) : (
+        <div
+          ref={containerRef}
+          className="min-h-0 flex-1 bg-[#0d1117]"
+          style={{ minHeight: "240px" }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/client/hooks/use-acp.ts
+++ b/src/client/hooks/use-acp.ts
@@ -18,6 +18,7 @@ import {
   AcpClientError,
   AcpAuthMethod,
   AcpSessionNotification,
+  AcpTerminalCreateResult,
 } from "../acp-client";
 import {
   getDesktopApiBaseUrl,
@@ -92,6 +93,18 @@ export interface UseAcpActions {
   setMode: (modeId: string) => Promise<void>;
   prompt: (text: string, skillContext?: { skillName: string; skillContent: string }) => Promise<void>;
   respondToUserInput: (toolCallId: string, response: Record<string, unknown>) => Promise<void>;
+  createTerminal: (
+    sessionId: string,
+    params?: {
+      cwd?: string;
+      command?: string;
+      args?: string[];
+      shell?: boolean;
+      env?: Record<string, string>;
+    },
+  ) => Promise<AcpTerminalCreateResult | null>;
+  writeTerminal: (terminalId: string, data: string) => Promise<boolean>;
+  killTerminal: (terminalId: string) => Promise<boolean>;
   cancel: () => Promise<void>;
   disconnect: () => void;
   /** Clear auth error (e.g., when user dismisses the popup) */
@@ -471,6 +484,65 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
     }
   }, []);
 
+  const createTerminal = useCallback(async (
+    sessionId: string,
+    params?: {
+      cwd?: string;
+      command?: string;
+      args?: string[];
+      shell?: boolean;
+      env?: Record<string, string>;
+    },
+  ): Promise<AcpTerminalCreateResult | null> => {
+    const client = clientRef.current;
+    if (!client) return null;
+
+    try {
+      return await client.createTerminal(sessionId, params ?? {});
+    } catch (err) {
+      logRuntime("error", "useAcp.createTerminal", "Failed to create terminal", err);
+      setState((s) => ({
+        ...s,
+        error: toErrorMessage(err) || "Failed to create terminal",
+      }));
+      return null;
+    }
+  }, []);
+
+  const writeTerminal = useCallback(async (terminalId: string, data: string): Promise<boolean> => {
+    const client = clientRef.current;
+    if (!client) return false;
+
+    try {
+      const result = await client.writeTerminal(terminalId, data);
+      return result.ok;
+    } catch (err) {
+      logRuntime("error", "useAcp.writeTerminal", "Failed to write terminal input", err);
+      setState((s) => ({
+        ...s,
+        error: toErrorMessage(err) || "Failed to write terminal input",
+      }));
+      return false;
+    }
+  }, []);
+
+  const killTerminal = useCallback(async (terminalId: string): Promise<boolean> => {
+    const client = clientRef.current;
+    if (!client) return false;
+
+    try {
+      const result = await client.killTerminal(terminalId);
+      return result.ok;
+    } catch (err) {
+      logRuntime("error", "useAcp.killTerminal", "Failed to kill terminal", err);
+      setState((s) => ({
+        ...s,
+        error: toErrorMessage(err) || "Failed to kill terminal",
+      }));
+      return false;
+    }
+  }, []);
+
   const disconnect = useCallback(() => {
     clientRef.current?.disconnect();
     clientRef.current = null;
@@ -507,6 +579,9 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
     setMode,
     prompt,
     respondToUserInput,
+    createTerminal,
+    writeTerminal,
+    killTerminal,
     cancel,
     disconnect,
     clearAuthError,

--- a/src/core/acp/__tests__/terminal-manager.test.ts
+++ b/src/core/acp/__tests__/terminal-manager.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.fn();
+
+vi.mock("@/core/platform", () => ({
+  getServerBridge: () => ({
+    process: {
+      isAvailable: () => true,
+      spawn: spawnMock,
+    },
+  }),
+}));
+
+import { TerminalManager } from "../terminal-manager";
+
+function createProcessHandle() {
+  const listeners: Record<string, (value?: unknown, signal?: string | null) => void> = {};
+  const writes: string[] = [];
+
+  return {
+    handle: {
+      pid: 1234,
+      stdin: {
+        writable: true,
+        write(data: string | Buffer) {
+          writes.push(data.toString());
+          return true;
+        },
+      },
+      stdout: {
+        on: vi.fn(),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      exitCode: null,
+      kill: vi.fn(),
+      on(event: "exit" | "error", handler: (value: unknown, signal?: string | null) => void) {
+        listeners[event] = handler;
+      },
+    },
+    writes,
+    listeners,
+  };
+}
+
+describe("TerminalManager", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("passes shell mode through to spawn and normalizes carriage return writes", () => {
+    const proc = createProcessHandle();
+    spawnMock.mockReturnValue(proc.handle);
+
+    const manager = new TerminalManager();
+    const notifications: Array<Record<string, unknown>> = [];
+
+    const result = manager.create(
+      {
+        command: "/bin/bash",
+        shell: false,
+      },
+      "session-1",
+      (notification) => notifications.push(notification),
+    );
+
+    expect(result.terminalId).toMatch(/^term-/);
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/bin/bash",
+      [],
+      expect.objectContaining({
+        shell: false,
+      }),
+    );
+    expect(notifications).toHaveLength(1);
+
+    const writeResult = manager.write(result.terminalId, "echo ok\r");
+    expect(writeResult.ok).toBe(true);
+    expect(proc.writes).toEqual(["echo ok\n"]);
+  });
+
+  it("returns ok=false when attempting to write to a missing terminal", () => {
+    const manager = new TerminalManager();
+
+    expect(manager.write("missing-terminal", "pwd\r")).toEqual({ ok: false });
+  });
+});

--- a/src/core/acp/terminal-manager.ts
+++ b/src/core/acp/terminal-manager.ts
@@ -22,6 +22,7 @@ export type TerminalNotificationEmitter = (notification: {
 
 interface ManagedTerminal {
   terminalId: string;
+  sessionId: string;
   process: IProcessHandle;
   output: string;
   exitCode: number | null;
@@ -54,6 +55,7 @@ export class TerminalManager {
     const args = (params.args as string[]) ?? [];
     const cwd = (params.cwd as string) ?? process.cwd();
     const env = (params.env as Record<string, string>) ?? {};
+    const useShell = typeof params.shell === "boolean" ? params.shell : true;
 
     console.log(
       `[TerminalManager] Creating terminal ${terminalId}: ${command} ${args.join(" ")} (cwd: ${cwd})`
@@ -87,7 +89,7 @@ export class TerminalManager {
         FORCE_COLOR: "1",
         TERM: "xterm-256color",
       },
-      shell: true,
+      shell: useShell,
     });
 
     const output = "";
@@ -98,6 +100,7 @@ export class TerminalManager {
 
     const managed: ManagedTerminal = {
       terminalId,
+      sessionId,
       process: proc,
       output,
       exitCode: null,
@@ -183,6 +186,19 @@ export class TerminalManager {
     this.terminals.set(terminalId, managed);
 
     return { terminalId };
+  }
+
+  /**
+   * Write input to a running terminal process.
+   */
+  write(terminalId: string, data: string): { ok: boolean } {
+    const terminal = this.terminals.get(terminalId);
+    if (!terminal || terminal.exited || !terminal.process.stdin?.writable) {
+      return { ok: false };
+    }
+
+    terminal.process.stdin.write(data.replace(/\r/g, "\n"));
+    return { ok: true };
   }
 
   /**


### PR DESCRIPTION
## Summary

- add a Kanban-side `Terminal POC` entry point that creates an ACP session and opens an embedded interactive terminal panel
- add browser terminal control RPCs for create/write/kill through `/api/acp`
- add a dedicated xterm-based `InteractiveSessionTerminal` component and hide inline terminal bubbles while it is active
- normalize carriage returns before writing to shell stdin and cover that behavior with a focused unit test

## Validation

- `npm run lint`
- `npm run test:run -- src/core/acp/__tests__/terminal-manager.test.ts`
- manual browser verification on `/workspace/2866e6c6-9502-444d-9fa3-1b43fdde64df/kanban`
  - clicked `Terminal POC`
  - typed commands into the embedded xterm input
  - confirmed shell output rendered back in the panel

## Screenshot Evidence

- Local screenshot: `/tmp/kanban-terminal-pwd-proof.png`
- Local screenshot: `/tmp/kanban-terminal-final-proof.png`

## Related

- Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive terminal support for managing session-based terminal workflows.
  * Introduced terminal creation, input, and termination capabilities.
  * Added terminal UI in Kanban view with toggles to display interactive terminals alongside chat.
  * Terminal sessions now integrated with existing session management.
  * Chat panel now supports hiding terminal-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->