### PR TITLE
feat(review): multi-phase PR review + confidence-based false-positive filtering (issue #136)

### DIFF
--- a/resources/flows/code-review.yaml
+++ b/resources/flows/code-review.yaml
@@ -1,11 +1,11 @@
-# Code Review Workflow — analyze and review code changes
+# Code Review Workflow — multi-phase review with confidence filtering
 #
 # Usage:
-#   routa workflow run resources/flows/code-review.yaml --trigger-payload "Review the changes in PR #42"
+#   routa workflow run resources/flows/code-review.yaml --trigger-payload "Review PR #42 in owner/repo"
 
 name: "Code Review Flow"
-description: "Two-step workflow: analyze changes, then verify quality"
-version: "1.0"
+description: "Four-phase code review: context, diff analysis, false-positive filtering, final verdict"
+version: "2.0"
 
 trigger:
   type: manual
@@ -14,36 +14,72 @@ variables:
   model: "${ANTHROPIC_MODEL:-GLM-4.7}"
 
 steps:
-  - name: "Analyze Changes"
-    specialist: "developer"
+  - name: "Phase 1 - Gather Context"
+    specialist: "pr-reviewer"
     adapter: "claude-code-sdk"
     config:
       model: "${model}"
     input: |
-      Analyze the following code changes or request:
+      You are running phase 1 only.
 
+      Task:
       ${trigger.payload}
 
-      Provide:
-      1. Summary of changes
-      2. Potential issues or bugs
-      3. Suggestions for improvement
-      4. Security concerns (if any)
-    output_key: "analysis"
+      Gather project context (tech stack, lint coverage, conventions, custom review rules).
+      Do not output review findings yet.
+    output_key: "project_context"
 
-  - name: "Quality Gate"
-    specialist: "gate"
+  - name: "Phase 2 - Raw Diff Analysis"
+    specialist: "pr-reviewer"
     adapter: "claude-code-sdk"
     config:
       model: "${model}"
     input: |
-      Based on the following analysis, provide a final quality verdict:
+      You are running phase 2 only.
 
-      ## Analysis
-      ${steps.Analyze Changes.output}
+      ## Phase 1 Context
+      ${steps.Phase 1 - Gather Context.output}
 
-      ## Original Request
+      ## Task
       ${trigger.payload}
 
-      Provide your verification verdict with evidence for each point.
+      Analyze only PR-introduced changes and return a raw findings list with confidence.
+    output_key: "raw_findings"
+
+  - name: "Phase 3 - Validate Findings"
+    specialist: "pr-reviewer"
+    adapter: "claude-code-sdk"
+    config:
+      model: "${model}"
+    input: |
+      You are running phase 3 only.
+
+      ## Phase 1 Context
+      ${steps.Phase 1 - Gather Context.output}
+
+      ## Phase 2 Raw Findings
+      ${steps.Phase 2 - Raw Diff Analysis.output}
+
+      Validate each finding with hard exclusions and confidence re-scoring.
+      Keep only findings with verdict=KEEP and confidence>=7.
+    output_key: "validated_findings"
+
+  - name: "Phase 4 - Final Review Report"
+    specialist: "pr-reviewer"
+    adapter: "claude-code-sdk"
+    config:
+      model: "${model}"
+    input: |
+      You are running phase 4 only.
+
+      ## Context
+      ${steps.Phase 1 - Gather Context.output}
+
+      ## Raw Findings
+      ${steps.Phase 2 - Raw Diff Analysis.output}
+
+      ## Validated Findings
+      ${steps.Phase 3 - Validate Findings.output}
+
+      Generate the final concise review report.
     output_key: "verdict"

--- a/resources/specialists/pr-reviewer.md
+++ b/resources/specialists/pr-reviewer.md
@@ -1,121 +1,107 @@
 ---
 name: "PR Reviewer"
-description: "Automated code review specialist for pull requests"
+description: "Multi-phase code review specialist with confidence scoring and false-positive filtering"
 modelTier: "smart"
 role: "DEVELOPER"
-roleReminder: "Review constructively. Be specific with file paths and line numbers. Focus on helping the developer improve their code."
+roleReminder: "Review with evidence. Filter false positives aggressively. Report only actionable findings with validated confidence >= 7."
 ---
 
-## PR Reviewer
+## PR Reviewer (Multi-Phase)
 
-You are an automated code review specialist. Your job is to review pull requests and provide constructive feedback.
+You are an automated code review specialist with a strict signal-to-noise requirement.
 
-## Review Criteria
+## Phase 1 — Context Gathering (No Findings Yet)
 
-Focus on these key areas:
+Collect project context before reviewing changed code:
 
-### 1. Code Style & Formatting
-- Consistent indentation and spacing
-- Naming conventions (variables, functions, classes)
-- Code organization and structure
-- Comments and documentation
+1. Tech stack and key libraries
+2. Linting/formatting rules (what is already enforced)
+3. Project patterns (error handling, naming, testing conventions)
+4. Project review rules (`.routa/review-rules.md` if present)
 
-### 2. Logic & Correctness
-- Potential bugs or edge cases
-- Error handling
-- Null/undefined checks
-- Type safety issues
+Output as structured context:
 
-### 3. Best Practices
-- DRY (Don't Repeat Yourself)
-- SOLID principles
-- Security concerns (SQL injection, XSS, etc.)
-- Performance issues
+- Tech stack
+- Linter-covered concerns (do NOT report these later)
+- Project conventions
+- Custom review constraints
 
-### 4. Testing
-- Missing test coverage
-- Test quality and completeness
-- Edge case testing
+## Phase 2 — Raw Diff Analysis
 
-## Review Process
+Review only PR-introduced changes. For each potential issue output a raw finding:
 
-1. **Analyze the PR**:
-   - Read the PR title and description
-   - Understand the purpose and scope
-   - Review the changed files
+- `file:line`
+- `category`
+- `severity` (`CRITICAL` | `WARNING` | `SUGGESTION`)
+- `raw_confidence` (1-10)
+- `description`
+- `suggestion`
 
-2. **Identify Issues**:
-   - List specific issues with file paths and line numbers
-   - Categorize by severity: CRITICAL, WARNING, SUGGESTION
-   - Provide clear explanations
+Focus areas:
 
-3. **Provide Feedback**:
-   - Be constructive and specific
-   - Suggest improvements with code examples
-   - Acknowledge good practices
+- Logic and correctness
+- Security with concrete exploit/failure paths only
+- Performance in realistic hot paths
+- API compatibility and boundary validation
+- Missing branch/error-path tests
 
-4. **Summary**:
-   - Overall assessment
-   - Key concerns
-   - Recommendations
+## Phase 3 — False-Positive Filter + Confidence Validation
 
-## Output Format
+Validate every raw finding. Reject if any hard exclusion applies:
 
-Structure your review as:
+1. Test-file findings about missing error handling or input validation
+2. Style/formatting/type issues already covered by linting
+3. Missing TypeScript types in JS-only code
+4. Framework-handled concerns without concrete unsafe usage
+5. Theoretical/speculative findings without clear failure path
+6. TODO/FIXME/HACK marker-only findings
+7. Missing logging/audit-trail-only findings
+8. Subjective variable naming preferences
+
+Validation output per finding:
+
+- `verdict`: `KEEP` | `REJECT`
+- `validated_confidence`: 1-10
+- `reasoning`: one concise sentence
+
+## Phase 4 — Final Report
+
+Only include findings where:
+
+- `verdict = KEEP`
+- `validated_confidence >= 7`
+
+If none survive, output:
+
+`No significant issues found.`
+
+Otherwise, format:
 
 ```markdown
-# PR Review: [PR Title]
+# PR Review Report
 
 ## Summary
-[Brief overview of the PR and overall assessment]
+- Overall quality assessment
+- Number of raw findings vs kept findings
 
-## Issues Found
+## Actionable Findings
+### [SEVERITY] path/to/file.ts:123
+- Category: ...
+- Confidence: .../10
+- Issue: ...
+- Suggestion: ...
 
-### CRITICAL
-- **File**: `path/to/file.ts` (Line X)
-  - **Issue**: [Description]
-  - **Suggestion**: [How to fix]
+## Rejected Findings (brief)
+- Count and reason categories only
 
-### WARNING
-- **File**: `path/to/file.ts` (Line Y)
-  - **Issue**: [Description]
-  - **Suggestion**: [How to fix]
-
-### SUGGESTION
-- **File**: `path/to/file.ts` (Line Z)
-  - **Issue**: [Description]
-  - **Suggestion**: [How to fix]
-
-## Positive Observations
-- [Good practices found]
-
-## Recommendations
-- [Overall recommendations]
-
-## Verdict
-- ✅ APPROVE (no critical issues)
-- ⚠️ REQUEST CHANGES (critical issues found)
-- 💬 COMMENT (suggestions only)
+## Final Verdict
+- ✅ APPROVE / ⚠️ REQUEST CHANGES / 💬 COMMENT
 ```
 
 ## Hard Rules
 
-1. **Be Constructive** — Focus on helping, not criticizing
-2. **Be Specific** — Always include file paths and line numbers
-3. **Be Actionable** — Provide clear suggestions for improvement
-4. **Be Balanced** — Acknowledge good code as well as issues
-5. **No Implementation** — You only review, never edit code directly
-
-## Tools Available
-
-You have access to:
-- GitHub API for fetching PR details and files
-- Code analysis tools
-- File reading capabilities
-
-When reviewing, always:
-- Check the PR diff for all changed files
-- Look for patterns across multiple files
-- Consider the broader context of the codebase
-- Verify that changes align with the PR description
-
+1. Review only PR-introduced changes
+2. Prefer precision over volume
+3. Never duplicate linter output
+4. Be explicit about uncertainty
+5. No implementation; review only

--- a/src/core/review/__tests__/multi-phase-review.test.ts
+++ b/src/core/review/__tests__/multi-phase-review.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterValidatedFindings,
+  isTestFile,
+  validateReviewFinding,
+  type RawReviewFinding,
+} from "../multi-phase-review";
+
+function finding(partial: Partial<RawReviewFinding>): RawReviewFinding {
+  return {
+    file: "src/app/api/review/route.ts",
+    line: 10,
+    category: "logic",
+    severity: "WARNING",
+    rawConfidence: 7,
+    description: "Potential null dereference when parsing response payload",
+    suggestion: "Guard payload before dereferencing nested fields",
+    ...partial,
+  };
+}
+
+describe("isTestFile", () => {
+  it("detects common test file patterns", () => {
+    expect(isTestFile("src/foo/__tests__/a.test.ts")).toBe(true);
+    expect(isTestFile("e2e/specs/login.spec.ts")).toBe(true);
+    expect(isTestFile("src/a/b/c.test.tsx")).toBe(true);
+    expect(isTestFile("src/core/logic.ts")).toBe(false);
+  });
+});
+
+describe("validateReviewFinding", () => {
+  it("rejects validation-only issues in test files", () => {
+    const result = validateReviewFinding(
+      finding({
+        file: "src/core/__tests__/validator.test.ts",
+        category: "input validation",
+        description: "missing input validation in test",
+      }),
+    );
+
+    expect(result.verdict).toBe("REJECT");
+    expect(result.validatedConfidence).toBe(3);
+  });
+
+  it("rejects style/lint covered findings", () => {
+    const result = validateReviewFinding(
+      finding({
+        category: "style formatting",
+        description: "inconsistent spacing",
+      }),
+      { linterCoveredCategories: ["formatting"] },
+    );
+
+    expect(result.verdict).toBe("REJECT");
+    expect(result.reasoning).toContain("linting");
+  });
+
+  it("rejects framework-handled findings when no concrete unsafe usage", () => {
+    const result = validateReviewFinding(
+      finding({
+        category: "security",
+        description: "possible xss in react output rendering",
+        suggestion: "react should escape this by default",
+      }),
+    );
+
+    expect(result.verdict).toBe("REJECT");
+  });
+
+  it("keeps dangerous React finding when dangerouslySetInnerHTML is explicitly mentioned", () => {
+    const result = validateReviewFinding(
+      finding({
+        category: "security",
+        rawConfidence: 8,
+        concreteEvidence: true,
+        description: "User content flows into dangerouslySetInnerHTML without sanitization.",
+        suggestion: "sanitize content before dangerouslySetInnerHTML.",
+      }),
+    );
+
+    expect(result.verdict).toBe("KEEP");
+    expect(result.validatedConfidence).toBe(10);
+  });
+
+  it("rejects TODO/FIXME/HACK marker findings", () => {
+    const result = validateReviewFinding(
+      finding({
+        category: "maintainability",
+        description: "TODO marker found in prod code",
+      }),
+    );
+
+    expect(result.verdict).toBe("REJECT");
+    expect(result.validatedConfidence).toBe(2);
+  });
+
+  it("rejects missing logging findings", () => {
+    const result = validateReviewFinding(
+      finding({
+        category: "observability",
+        description: "missing audit trail when deleting workspace",
+      }),
+    );
+
+    expect(result.verdict).toBe("REJECT");
+  });
+
+  it("reduces speculative findings below threshold", () => {
+    const result = validateReviewFinding(
+      finding({
+        rawConfidence: 8,
+        description: "This might be a possible issue and could potentially fail.",
+      }),
+    );
+
+    expect(result.verdict).toBe("REJECT");
+    expect(result.validatedConfidence).toBe(5);
+  });
+
+  it("keeps concrete high-confidence findings", () => {
+    const result = validateReviewFinding(
+      finding({
+        rawConfidence: 7,
+        concreteEvidence: true,
+      }),
+    );
+
+    expect(result.verdict).toBe("KEEP");
+    expect(result.validatedConfidence).toBe(9);
+  });
+
+  it("clamps confidence to lower bound", () => {
+    const result = validateReviewFinding(
+      finding({
+        rawConfidence: 0,
+        description: "theoretical and speculative",
+      }),
+    );
+
+    expect(result.validatedConfidence).toBe(1);
+  });
+
+  it("clamps confidence to upper bound", () => {
+    const result = validateReviewFinding(
+      finding({
+        rawConfidence: 10,
+        concreteEvidence: true,
+      }),
+    );
+
+    expect(result.validatedConfidence).toBe(10);
+  });
+});
+
+describe("filterValidatedFindings", () => {
+  it("returns only KEEP findings", () => {
+    const findings: RawReviewFinding[] = [
+      finding({ rawConfidence: 8, concreteEvidence: true }),
+      finding({ category: "style", description: "formatting mismatch" }),
+      finding({ rawConfidence: 6, description: "possible issue maybe" }),
+    ];
+
+    const result = filterValidatedFindings(findings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.verdict).toBe("KEEP");
+  });
+});

--- a/src/core/review/multi-phase-review.ts
+++ b/src/core/review/multi-phase-review.ts
@@ -1,0 +1,157 @@
+export type ReviewSeverity = "CRITICAL" | "WARNING" | "SUGGESTION";
+export type ReviewVerdict = "KEEP" | "REJECT";
+
+export interface RawReviewFinding {
+  file: string;
+  line: number;
+  category: string;
+  severity: ReviewSeverity;
+  rawConfidence: number;
+  description: string;
+  suggestion: string;
+  concreteEvidence?: boolean;
+}
+
+export interface ReviewContext {
+  linterCoveredCategories?: string[];
+}
+
+export interface ValidatedReviewFinding extends RawReviewFinding {
+  validatedConfidence: number;
+  verdict: ReviewVerdict;
+  reasoning: string;
+}
+
+const STYLE_CATEGORY_KEYWORDS = [
+  "style",
+  "format",
+  "naming",
+  "lint",
+  "typescript type",
+];
+
+const FRAMEWORK_HANDLED_KEYWORDS = [
+  "xss",
+  "body parsing",
+  "next.js api",
+  "react",
+  "framework",
+  "dangerouslysetinnerhtml",
+];
+
+const NON_ACTIONABLE_KEYWORDS = [
+  "theoretical",
+  "speculative",
+  "could potentially",
+  "might",
+  "possible",
+];
+
+const TODO_KEYWORDS = ["todo", "fixme", "hack"];
+const LOGGING_KEYWORDS = ["logging", "audit trail", "telemetry"];
+
+const clampConfidence = (value: number): number => Math.max(1, Math.min(10, Math.round(value)));
+
+export const isTestFile = (filePath: string): boolean =>
+  /(\/|^)(test|tests|__tests__|e2e)(\/|$)/i.test(filePath) || /\.(test|spec)\.[a-z]+$/i.test(filePath);
+
+export function validateReviewFinding(
+  finding: RawReviewFinding,
+  context: ReviewContext = {},
+): ValidatedReviewFinding {
+  const normalizedCategory = finding.category.toLowerCase();
+  const normalizedDescription = finding.description.toLowerCase();
+  const normalizedSuggestion = finding.suggestion.toLowerCase();
+
+  const isMissingValidationInTestFile =
+    isTestFile(finding.file) &&
+    (normalizedCategory.includes("validation") ||
+      normalizedDescription.includes("missing error handling") ||
+      normalizedDescription.includes("missing input validation"));
+
+  if (isMissingValidationInTestFile) {
+    return {
+      ...finding,
+      verdict: "REJECT",
+      validatedConfidence: 3,
+      reasoning: "Test file finding about validation/error handling is an explicit hard exclusion.",
+    };
+  }
+
+  const linterCovered =
+    STYLE_CATEGORY_KEYWORDS.some((keyword) => normalizedCategory.includes(keyword)) ||
+    (context.linterCoveredCategories ?? []).some((covered) =>
+      normalizedCategory.includes(covered.toLowerCase()),
+    );
+
+  if (linterCovered) {
+    return {
+      ...finding,
+      verdict: "REJECT",
+      validatedConfidence: 4,
+      reasoning: "Style/formatting/type finding is likely covered by linting and should be filtered out.",
+    };
+  }
+
+  const isFrameworkHandled = FRAMEWORK_HANDLED_KEYWORDS.some(
+    (keyword) => normalizedDescription.includes(keyword) || normalizedSuggestion.includes(keyword),
+  );
+
+  if (isFrameworkHandled && !normalizedDescription.includes("dangerouslysetinnerhtml")) {
+    return {
+      ...finding,
+      verdict: "REJECT",
+      validatedConfidence: 3,
+      reasoning: "Potential issue appears framework-handled without concrete unsafe usage.",
+    };
+  }
+
+  if (TODO_KEYWORDS.some((k) => normalizedDescription.includes(k))) {
+    return {
+      ...finding,
+      verdict: "REJECT",
+      validatedConfidence: 2,
+      reasoning: "TODO/FIXME/HACK-only findings are intentionally excluded.",
+    };
+  }
+
+  if (LOGGING_KEYWORDS.some((k) => normalizedDescription.includes(k))) {
+    return {
+      ...finding,
+      verdict: "REJECT",
+      validatedConfidence: 3,
+      reasoning: "Missing logging/audit findings are excluded by design.",
+    };
+  }
+
+  let validatedConfidence = finding.rawConfidence;
+
+  if (NON_ACTIONABLE_KEYWORDS.some((k) => normalizedDescription.includes(k))) {
+    validatedConfidence -= 3;
+  }
+
+  if (finding.concreteEvidence) {
+    validatedConfidence += 2;
+  }
+
+  const clamped = clampConfidence(validatedConfidence);
+
+  return {
+    ...finding,
+    verdict: clamped >= 7 ? "KEEP" : "REJECT",
+    validatedConfidence: clamped,
+    reasoning:
+      clamped >= 7
+        ? "Finding is concrete, actionable, and passes the confidence threshold."
+        : "Finding confidence is below threshold or too speculative for high-signal review output.",
+  };
+}
+
+export function filterValidatedFindings(
+  findings: RawReviewFinding[],
+  context: ReviewContext = {},
+): ValidatedReviewFinding[] {
+  return findings
+    .map((finding) => validateReviewFinding(finding, context))
+    .filter((finding) => finding.verdict === "KEEP");
+}


### PR DESCRIPTION
### Motivation
- Reduce noisy AI code-review output by introducing a multi-phase review that prioritizes high-signal findings and suppresses common false positives as described in issue #136.
- Make review results actionable by assigning per-finding confidence scores and enforcing a reporting threshold (validated confidence >= 7). 
- Integrate the filter into Routa's existing specialist/workflow model so the coordinator → reviewer → gate flow can produce a final verified report. 

### Description
- Add a four-phase review workflow `resources/flows/code-review.yaml` (context gathering → raw diff analysis → finding validation → final report). 
- Replace the reviewer specialist prompt with `resources/specialists/pr-reviewer.md` that documents phased behavior, hard exclusion rules, and final report format. 
- Implement reusable validation/filtering utilities in `src/core/review/multi-phase-review.ts` that detect test files, apply hard exclusions (lint-covered, TODO/logging-only, framework-handled, etc.), rescore confidence, clamp bounds, and emit `KEEP/REJECT` verdicts. 
- Add comprehensive unit tests in `src/core/review/__tests__/multi-phase-review.test.ts` (12 cases) covering exclusions, framework-handled edge cases, speculative downgrade, confidence clamping, and aggregation. 

### Testing
- Ran the new unit tests with `npm run test:run -- src/core/review/__tests__/multi-phase-review.test.ts`, which passed. 
- Ran the full JS test suite with `npm run test:run` and observed the test run complete (`44 files`, `498 tests` passed). 
- Executed linting with `npm run lint` (pre-commit/husky ran during commit and completed). 
- Verified API parity with `npx tsx scripts/check-api-parity.ts` which passed as a workaround for `npm run api:check` (the latter failed here due to an unsupported Node flag). 
- Validated `npx codex --help` to exercise the requested `codex` CLI usage via `npx`, which returned the help output. 
- Attempted `cargo test --workspace` but it failed in this environment due to a missing system dependency (`glib-2.0`), so Rust tests were not completed here. 
- Ran the fitness script in `--dry-run` which passed; running the full `docs/fitness/scripts/fitness.py` executed but reported several environment/tooling command failures (these are environment-specific and not caused by the code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51352793883269dab5307d51304de)