### PR TITLE
docs: fix broken links in README and add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 Routa Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ automation, and recurring maintenance workflows:
 ## 📄 License
 
 - Built with [Model Context Protocol](https://modelcontextprotocol.io/) by Anthropic
-- Uses [Agent Client Protocol](https://github.com/agentclientprotocol/sdk) for agent communication
-- Uses [A2A Protocol](https://a2a-js.github.io/sdk/) for agent federation
+- Uses [Agent Client Protocol](https://github.com/agentclientprotocol/typescript-sdk) for agent communication
+- Uses [A2A Protocol](https://a2aprotocol.ai/) for agent federation
 - Inspired by the [Intent](https://www.augmentcode.com/product/intent) - multi-agent coordination patterns in modern AI
   systems
 


### PR DESCRIPTION
- Update ACP link to https://github.com/agentclientprotocol/typescript-sdk
- Update A2A link to https://a2aprotocol.ai/
- Add missing MIT LICENSE file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license section links in documentation to reflect new URLs for Agent Client Protocol and A2A Protocol resources.

* **Chores**
  * Added MIT License file with copyright notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->