### PR TITLE
feat(fitness): add graph-backed change impact probe

### DIFF
--- a/docs/fitness/README.md
+++ b/docs/fitness/README.md
@@ -59,17 +59,18 @@ Fitness = Σ (Weight_i × Score_i) / 100
 阻断: < 80 | 强告警: 80-90 | 通过: ≥ 90
 ```
 
-## Dimensions (七大维度)
+## Dimensions (八大维度)
 
 | 维度 | 权重 | 描述 | 关键指标 | 证据文件 |
 |------|------|------|----------|----------|
-| code_quality | 24% | 代码质量与架构 | Lint通过, 无循环依赖, 文件≤1000行 | [code-quality.md](code-quality.md) |
+| code_quality | 18% | 代码质量与架构 | Lint通过, 无循环依赖, 文件≤1000行 | [code-quality.md](code-quality.md) |
 | testability | 20% | 测试覆盖与通过率 | 覆盖率≥80%, 通过率100% | [unit-test.md](unit-test.md) |
 | security | 20% | 依赖漏洞与安全扫描 | critical=0, high≤阈值 | [security.md](security.md) |
 | api_contract | 10% | API 契约测试 | Rust API 测试通过, 契约同步 | [rust-api-test.md](rust-api-test.md) |
 | design_system | 10% | 设计系统质量 | 视觉回归, 可访问性, 性能 | [design-system-quality-layers.md](design-system-quality-layers.md) |
 | evolvability | 8% | API 兼容性与契约 | breaking changes=0, parity=100% | [api-contract.md](api-contract.md) |
 | ui_consistency | 8% | UI 一致性 | Shell 组件覆盖, Token 接入 | [design-system-shell.md](design-system-shell.md) |
+| change_impact | 6% | 变更影响与爆炸半径 | graph probe 可运行, 宽 blast radius 告警 | [change-impact.md](change-impact.md) |
 
 **Total: 100%**
 

--- a/docs/fitness/change-impact.md
+++ b/docs/fitness/change-impact.md
@@ -1,0 +1,40 @@
+---
+dimension: change_impact
+weight: 6
+tier: normal
+threshold:
+  pass: 90
+  warn: 75
+
+metrics:
+  - name: graph_probe_runs
+    command: python3 docs/fitness/scripts/graph_fitness.py --base HEAD --max-depth 2 --max-impacted-files 250 2>&1
+    pattern: "graph_probe_status: ok|graph_probe_status: skipped"
+    hard_gate: false
+    tier: normal
+    description: "验证 graph-backed change impact probe 可以在当前仓库运行；依赖缺失时允许跳过"
+
+  - name: graph_blast_radius_threshold
+    command: python3 docs/fitness/scripts/graph_fitness.py --base HEAD --max-depth 2 --max-impacted-files 250 2>&1
+    pattern: "graph_wide_blast_radius: no|graph_wide_blast_radius: skipped"
+    hard_gate: false
+    tier: normal
+    description: "如果本次改动影响过多文件，则标记为宽 blast radius；依赖缺失时跳过"
+---
+
+# Change Impact 证据
+
+> Spike 维度：验证 code-review-graph 是否可以作为 fitness 的变更影响证明器。
+
+## 当前目标
+
+- 能在 Routa 仓库上完成建图或增量更新
+- 能针对本次代码改动给出 impacted files 数量
+- 能输出适合 frontmatter runner 消费的纯文本指标
+
+## 当前边界
+
+- 这是本地 spike，不是正式门禁
+- 当前命令优先尝试导入已安装的 `code_review_graph`
+- 需要调试本地源码版时，可设置 `ROUTA_CODE_REVIEW_GRAPH_SOURCE=/abs/path/to/code-review-graph`
+- 后续若正式接入，需要把运行时依赖和缓存路径收敛成仓库级约定

--- a/docs/fitness/code-quality.md
+++ b/docs/fitness/code-quality.md
@@ -1,6 +1,6 @@
 ---
 dimension: code_quality
-weight: 24
+weight: 18
 tier: normal
 threshold:
   pass: 90

--- a/docs/fitness/scripts/graph_fitness.py
+++ b/docs/fitness/scripts/graph_fitness.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Graph-backed fitness probe for Routa.
+
+This is a spike helper that adapts code-review-graph output into plain text
+metrics that docs/fitness/scripts/fitness.py can consume with regex patterns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GRAPH_DB = ".code-review-graph/graph.db"
+CODE_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".rs", ".py", ".go", ".java", ".kt", ".swift", ".php", ".c", ".cpp"}
+
+
+def load_code_review_graph() -> tuple[object, object]:
+    source = os.environ.get("ROUTA_CODE_REVIEW_GRAPH_SOURCE")
+    if source:
+        sys.path.insert(0, source)
+
+    from code_review_graph.tools import build_or_update_graph, get_impact_radius
+
+    return build_or_update_graph, get_impact_radius
+
+
+def emit_skipped(reason: str) -> int:
+    print(f"graph_probe_status: skipped reason={reason}")
+    print("graph_changed_files: 0")
+    print("graph_impacted_files: 0")
+    print("graph_impacted_test_files: 0")
+    print("graph_wide_blast_radius: skipped")
+    return 0
+
+
+def git_changed_files(base: str) -> list[str]:
+    diff_cmd = ["git", "diff", "--name-only", "--diff-filter=ACMR", base, "--", "src", "apps", "crates"]
+    result = subprocess.run(diff_cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    unstaged_cmd = ["git", "diff", "--name-only", "--diff-filter=ACMR", "--", "src", "apps", "crates"]
+    unstaged = subprocess.run(unstaged_cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    files.extend(line.strip() for line in unstaged.stdout.splitlines() if line.strip())
+
+    untracked_cmd = ["git", "ls-files", "--others", "--exclude-standard", "src", "apps", "crates"]
+    untracked = subprocess.run(untracked_cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    files.extend(line.strip() for line in untracked.stdout.splitlines() if line.strip())
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for file_path in files:
+      if file_path in seen:
+          continue
+      seen.add(file_path)
+      deduped.append(file_path)
+    return deduped
+
+
+def filter_code_files(files: list[str]) -> list[str]:
+    kept: list[str] = []
+    for rel in files:
+        if Path(rel).suffix.lower() not in CODE_EXTENSIONS:
+            continue
+        if (REPO_ROOT / rel).exists():
+            kept.append(rel)
+    return kept
+
+
+def classify_test_file(file_path: str) -> bool:
+    lowered = file_path.lower()
+    return (
+        "/tests/" in lowered
+        or "/__tests__/" in lowered
+        or ".test." in lowered
+        or ".spec." in lowered
+        or lowered.endswith("_test.rs")
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe change impact via code-review-graph")
+    parser.add_argument("--base", default="HEAD", help="Git diff base to inspect")
+    parser.add_argument("--max-depth", type=int, default=2, help="Graph traversal depth")
+    parser.add_argument("--max-impacted-files", type=int, default=200, help="Warn threshold for impacted files")
+    parser.add_argument("--build-mode", choices=["auto", "full"], default="auto")
+    parser.add_argument(
+        "--require-graph",
+        action="store_true",
+        help="Fail instead of skipping when code-review-graph is unavailable",
+    )
+    args = parser.parse_args()
+
+    try:
+        build_or_update_graph, get_impact_radius = load_code_review_graph()
+    except Exception as exc:
+        if args.require_graph:
+            print(f"graph_probe_status: blocked import_error={type(exc).__name__}")
+            print("graph_changed_files: 0")
+            print("graph_impacted_files: 0")
+            print("graph_impacted_test_files: 0")
+            print("graph_wide_blast_radius: unknown")
+            return 1
+        return emit_skipped(f"import_error={type(exc).__name__}")
+
+    changed_files = filter_code_files(git_changed_files(args.base))
+    if not changed_files:
+        print("graph_probe_status: ok")
+        print("graph_changed_files: 0")
+        print("graph_impacted_files: 0")
+        print("graph_impacted_test_files: 0")
+        print("graph_wide_blast_radius: no")
+        return 0
+
+    build_kwargs = {
+        "repo_root": str(REPO_ROOT),
+        "base": args.base,
+        "full_rebuild": args.build_mode == "full" or not (REPO_ROOT / GRAPH_DB).exists(),
+    }
+    try:
+        build_result = build_or_update_graph(**build_kwargs)
+        impact = get_impact_radius(
+            changed_files=changed_files,
+            max_depth=args.max_depth,
+            repo_root=str(REPO_ROOT),
+            base=args.base,
+        )
+    except Exception as exc:
+        if args.require_graph:
+            print(f"graph_probe_status: blocked runtime_error={type(exc).__name__}")
+            print(f"graph_changed_files: {len(changed_files)}")
+            print("graph_impacted_files: 0")
+            print("graph_impacted_test_files: 0")
+            print("graph_wide_blast_radius: unknown")
+            return 1
+        return emit_skipped(f"runtime_error={type(exc).__name__}")
+
+    impacted_files = impact.get("impacted_files", [])
+    impacted_test_files = [path for path in impacted_files if classify_test_file(path)]
+    wide_blast_radius = "yes" if len(impacted_files) > args.max_impacted_files else "no"
+
+    print(f"graph_probe_status: {impact.get('status', 'unknown')}")
+    print(f"graph_build_type: {build_result.get('build_type', 'unknown')}")
+    print(f"graph_changed_files: {len(changed_files)}")
+    print(f"graph_impacted_files: {len(impacted_files)}")
+    print(f"graph_impacted_test_files: {len(impacted_test_files)}")
+    print(f"graph_wide_blast_radius: {wide_blast_radius}")
+
+    if impacted_files:
+        sample = ",".join(Path(path).name for path in impacted_files[:5])
+        print(f"graph_impacted_sample: {sample}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a graph-backed `change_impact` fitness dimension
- add `docs/fitness/scripts/graph_fitness.py` to adapt `code-review-graph` output into regex-friendly fitness metrics
- rebalance fitness weights so the total remains 100
- keep the graph probe opt-in friendly: if `code_review_graph` is unavailable, the metric reports `skipped` instead of breaking normal-tier fitness

## Why

Issue phodal/entrix#4 proposes using `code-review-graph` as a low-noise structural review and fitness signal. This PR implements the first feasible slice on the fitness side: turn blast-radius analysis into executable fitness metrics without changing the existing fitness runner.

## Testing

- `python3 -m py_compile docs/fitness/scripts/graph_fitness.py`
- `python3 scripts/check-fitness-weights.py`
- `python3 docs/fitness/scripts/graph_fitness.py --base HEAD --max-depth 2 --max-impacted-files 250`
- `ROUTA_CODE_REVIEW_GRAPH_SOURCE=/Users/phodal/test/code-review-graph ./.venv/bin/python docs/fitness/scripts/graph_fitness.py --base HEAD --max-depth 2 --max-impacted-files 250 --require-graph`
- `python3 docs/fitness/scripts/fitness.py --dry-run --tier normal`

## Screenshots / Recordings

- N/A. No UI changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change impact as a new fitness dimension for project evaluation.

* **Documentation**
  * Updated fitness dimensions framework from seven to eight dimensions; code quality weight adjusted to 18% to accommodate new change impact metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->