### PR TITLE
fix: strip colons from folder slug for Windows drive letter paths

### DIFF
--- a/crates/routa-core/src/storage/folder_slug.rs
+++ b/crates/routa-core/src/storage/folder_slug.rs
@@ -35,6 +35,10 @@ pub fn to_folder_slug(absolute_path: &str) -> String {
     let mut result = String::with_capacity(cleaned.len());
     let mut last_was_sep = false;
     for c in cleaned.chars() {
+        if c == ':' {
+            // Skip colons (Windows drive letters like C: or E:)
+            continue;
+        }
         if c == '/' || c == '\\' {
             if !last_was_sep {
                 result.push('-');
@@ -87,7 +91,7 @@ mod tests {
     fn test_windows_path() {
         assert_eq!(
             to_folder_slug("C:\\Users\\john\\project"),
-            "C:-Users-john-project"
+            "C-Users-john-project"
         );
     }
 
@@ -130,5 +134,25 @@ mod tests {
         let dir = get_project_storage_dir("/Users/john/my-project");
         assert!(dir.to_string_lossy().contains("Users-john-my-project"));
         assert!(dir.to_string_lossy().contains(".routa/projects"));
+    }
+    
+    #[test]
+    fn test_windows_drive_letter_colon_stripped() {
+        assert_eq!(to_folder_slug("E:\\routa"), "E-routa");
+        assert_eq!(to_folder_slug("D:\\my-workspace\\app"), "D-my-workspace-app");
+    }
+
+    #[test]
+    fn test_windows_drive_colon_consistency() {
+        // With or without drive letter should produce a valid slug (no colons)
+        let slug = to_folder_slug("E:\\routa\\.routa\\repos\\keepongo--routa-project");
+        assert!(!slug.contains(':'), "slug must not contain colons: {slug}");
+        assert_eq!(slug, "E-routa-.routa-repos-keepongo--routa-project");
+    }
+
+    #[test]
+    fn test_multiple_colons_stripped() {
+        // Edge case: path with multiple colons
+        assert_eq!(to_folder_slug("C:\\foo:bar\\baz"), "C-foobar-baz");
     }
 }

--- a/src/core/storage/folder-slug.ts
+++ b/src/core/storage/folder-slug.ts
@@ -27,6 +27,8 @@ export function toFolderSlug(absolutePath: string): string {
   let cleaned = absolutePath.replace(/^[/\\]+/, "");
   // Strip trailing separators (avoids trailing hyphen in slug)
   cleaned = cleaned.replace(/[/\\]+$/, "");
+  // Windows: strip drive colons so slug is a valid directory name (E:\foo -> E-foo, not E:-foo)
+  cleaned = cleaned.replace(/:/g, "");
   // Replace all path separators (including consecutive) with a single hyphen
   cleaned = cleaned.replace(/[/\\]+/g, "-");
   return cleaned;


### PR DESCRIPTION
Closes #209

## Summary
- Strip `:` from folder slug to fix `mkdir` failure on Windows when workspace is on a non-C drive (e.g. `E:\routa` → slug `E:-routa` contains illegal colon)
- Fixed both TypeScript (`src/core/storage/folder-slug.ts`) and Rust (`crates/routa-core/src/storage/folder_slug.rs`)
- Added unit tests for Windows drive letter paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling in folder slug generation by removing colon characters from the output. This ensures drive letters and other path separators generate cleaner, more compatible directory names that work reliably across all supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->