### PR TITLE
refine(harness): merge agent hook basic hooks tab

### DIFF
--- a/src/client/components/__tests__/harness-agent-hook-workbench.test.tsx
+++ b/src/client/components/__tests__/harness-agent-hook-workbench.test.tsx
@@ -69,7 +69,7 @@ describe("HarnessAgentHookWorkbench", () => {
     expect(within(flow).getByText("Allow")).not.toBeNull();
     expect(within(flow).getByText("Block")).not.toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Hooks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Basic" }));
     expect(screen.getAllByText("Guard dangerous shell commands").length).toBeGreaterThan(0);
   });
 
@@ -80,7 +80,7 @@ describe("HarnessAgentHookWorkbench", () => {
 
     const flow = screen.getByTestId("agent-hook-flow");
 
-    fireEvent.click(screen.getByRole("button", { name: "Hooks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Basic" }));
     expect(screen.getAllByText("Audit tool results").length).toBeGreaterThan(0);
     expect(within(flow).getByText("Signal")).not.toBeNull();
   });

--- a/src/client/components/harness-agent-hook-workbench.tsx
+++ b/src/client/components/harness-agent-hook-workbench.tsx
@@ -349,7 +349,7 @@ function AgentHookFlowCanvas() {
 
 function AgentHookInspector() {
   const { activeEntry, data } = useWorkbenchContext();
-  const [activeTab, setActiveTab] = useState<"basic" | "hooks" | "source">("basic");
+  const [activeTab, setActiveTab] = useState<"basic" | "source">("basic");
 
   const configSource = useMemo(() => {
     if (!activeEntry) return "";
@@ -369,13 +369,12 @@ function AgentHookInspector() {
         <div className="flex flex-wrap gap-1 rounded-xl border border-desktop-border bg-desktop-bg-primary/80 p-1">
           {[
             { id: "basic", label: "Basic" },
-            { id: "hooks", label: "Hooks" },
             { id: "source", label: "Source" },
           ].map((tab) => (
             <button
               key={tab.id}
               type="button"
-              onClick={() => setActiveTab(tab.id as "basic" | "hooks" | "source")}
+              onClick={() => setActiveTab(tab.id as "basic" | "source")}
               className={`rounded-lg px-2.5 py-1 text-[10px] font-medium transition ${
                 activeTab === tab.id
                   ? "border border-sky-200 bg-sky-50 text-sky-700"
@@ -399,54 +398,59 @@ function AgentHookInspector() {
         ) : null}
 
         {activeTab === "basic" && activeEntry ? (
-          <div className="rounded-xl border border-desktop-border bg-desktop-bg-primary/80 p-3 text-[11px] text-desktop-text-secondary">
-            <div>Lifecycle: <span className="font-medium text-desktop-text-primary">{activeEntry.lifecycleLabel}</span></div>
-            <div className="mt-1">Can block: <span className="font-medium text-desktop-text-primary">{activeEntry.canBlock ? "yes" : "no"}</span></div>
-            <div className="mt-1">Hint: {activeEntry.hint}</div>
-            <div className="mt-1">Description: {activeEntry.lifecycleDescription}</div>
-          </div>
-        ) : null}
-
-        {activeTab === "hooks" && activeEntry ? (
-          activeEntry.hooks.length === 0 ? (
+          <div className="space-y-2">
             <div className="rounded-xl border border-desktop-border bg-desktop-bg-primary/80 p-3 text-[11px] text-desktop-text-secondary">
-              No hooks configured for this event.
+              <div>Lifecycle: <span className="font-medium text-desktop-text-primary">{activeEntry.lifecycleLabel}</span></div>
+              <div className="mt-1">Can block: <span className="font-medium text-desktop-text-primary">{activeEntry.canBlock ? "yes" : "no"}</span></div>
+              <div className="mt-1">Hint: {activeEntry.hint}</div>
+              <div className="mt-1">Description: {activeEntry.lifecycleDescription}</div>
             </div>
-          ) : (
-            activeEntry.hooks.map((hook, index) => (
-              <div key={`${hook.event}:${index}`} className="rounded-xl border border-desktop-border bg-desktop-bg-primary/80 p-3">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="min-w-0">
-                    <div className="text-[12px] font-semibold text-desktop-text-primary">
-                      {hook.description || `${hook.type} hook`}
-                    </div>
-                    {hook.matcher ? (
-                      <div className="mt-0.5 text-[10px] text-desktop-text-secondary">
-                        matcher: <code className="rounded bg-slate-100 px-1 py-0.5 text-[10px]">{hook.matcher}</code>
+
+            <div>
+              <div className="text-[12px] font-semibold text-desktop-text-primary">Hooks</div>
+              {activeEntry.hooks.length === 0 ? (
+                <div className="mt-2 rounded-lg border border-desktop-border bg-desktop-bg-primary/70 p-2.5 text-[11px] text-desktop-text-secondary">
+                  No hooks configured for this event.
+                </div>
+              ) : (
+                <ul className="mt-2 divide-y divide-desktop-border rounded-xl border border-desktop-border bg-desktop-bg-primary/80">
+                  {activeEntry.hooks.map((hook, index) => (
+                    <li key={`${hook.event}:${index}`} className="px-3 py-2.5">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="text-[12px] font-semibold text-desktop-text-primary">
+                            {hook.description || `${hook.type} hook`}
+                          </div>
+                          {hook.matcher ? (
+                            <div className="mt-0.5 text-[10px] text-desktop-text-secondary">
+                              matcher: <code className="rounded bg-slate-100 px-1 py-0.5 text-[10px]">{hook.matcher}</code>
+                            </div>
+                          ) : null}
+                        </div>
+                        <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                          {hook.blocking ? (
+                            <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] text-amber-800">blocking</span>
+                          ) : null}
+                          <span className="rounded-full border border-desktop-border bg-desktop-bg-secondary px-2 py-0.5 text-[10px] text-desktop-text-secondary">
+                            {hook.type}
+                          </span>
+                        </div>
                       </div>
-                    ) : null}
-                  </div>
-                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
-                    {hook.blocking ? (
-                      <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] text-amber-800">blocking</span>
-                    ) : null}
-                    <span className="rounded-full border border-desktop-border bg-desktop-bg-secondary px-2 py-0.5 text-[10px] text-desktop-text-secondary">
-                      {hook.type}
-                    </span>
-                  </div>
-                </div>
-                <div className="mt-2 space-y-0.5 text-[10px] text-desktop-text-secondary">
-                  {hook.command ? <div>command: <code className="break-all rounded bg-slate-100 px-1 py-0.5">{hook.command}</code></div> : null}
-                  {hook.url ? <div>url: <code className="rounded bg-slate-100 px-1 py-0.5">{hook.url}</code></div> : null}
-                  {hook.prompt ? <div>prompt: <code className="rounded bg-slate-100 px-1 py-0.5">{hook.prompt}</code></div> : null}
-                  <div>timeout: {hook.timeout}s</div>
-                  {hook.source ? (
-                    <div>source: <span className="font-medium text-sky-600">{hook.source}</span></div>
-                  ) : null}
-                </div>
-              </div>
-            ))
-          )
+                      <div className="mt-2 space-y-0.5 text-[10px] text-desktop-text-secondary">
+                        {hook.command ? <div>command: <code className="break-all rounded bg-slate-100 px-1 py-0.5">{hook.command}</code></div> : null}
+                        {hook.url ? <div>url: <code className="rounded bg-slate-100 px-1 py-0.5">{hook.url}</code></div> : null}
+                        {hook.prompt ? <div>prompt: <code className="rounded bg-slate-100 px-1 py-0.5">{hook.prompt}</code></div> : null}
+                        <div>timeout: {hook.timeout}s</div>
+                        {hook.source ? (
+                          <div>source: <span className="font-medium text-sky-600">{hook.source}</span></div>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
         ) : null}
 
         {activeTab === "source" && activeEntry && configSource ? (

--- a/src/client/components/harness-release-triggers-panel.tsx
+++ b/src/client/components/harness-release-triggers-panel.tsx
@@ -26,6 +26,7 @@ type ReleaseDimensionCard = {
   barValue: number;
   tone: ReleaseDimensionTone;
   rules: ReleaseTriggerRuleSummary[];
+  detailClass?: string;
 };
 
 const TONE_STYLES: Record<
@@ -173,6 +174,7 @@ function buildReleaseDimensionCards(rules: ReleaseTriggerRuleSummary[]): Release
       barValue: driftScore,
       tone: driftRules.length ? toneFromScore(driftScore) : "info",
       rules: driftRules,
+      detailClass: "max-h-52 overflow-y-auto pr-0.5",
     },
     {
       key: "boundary",
@@ -357,8 +359,8 @@ function DimensionCard({
         />
       </div>
 
-      {showDetails && card.rules.length > 0 && (
-        <div className="mt-2.5 space-y-2">
+        {showDetails && card.rules.length > 0 && (
+        <div className={`mt-2.5 space-y-2 ${card.detailClass ?? ""}`}>
           {card.rules.map((rule) => (
             <RuleDetailCard key={rule.name} rule={rule} tone={card.tone} />
           ))}

--- a/src/client/components/harness-review-triggers-panel.tsx
+++ b/src/client/components/harness-review-triggers-panel.tsx
@@ -138,7 +138,9 @@ function takeLabels(values: string[], limit: number): string[] {
 }
 
 function cardGridClass(compactMode: boolean): string {
-  return compactMode ? "mt-2.5 grid grid-cols-1 gap-2.5" : "mt-2.5 grid gap-2.5 md:grid-cols-2 xl:grid-cols-4";
+  return compactMode
+    ? "mt-2.5 grid grid-cols-1 gap-2.5 sm:grid-cols-2"
+    : "mt-2.5 grid gap-2.5 md:grid-cols-2 xl:grid-cols-4";
 }
 
 function isRiskRule(rule: ReviewTriggerRuleSummary): boolean {


### PR DESCRIPTION
- Make Governance Loop review card grid adaptive 2-col for compact mode.\n- Merge Agent Hook inspector Basic and Hooks into one tab.\n- Remove separate Hook cards into one embedded hook list in Basic tab.\n- keep Source tab for raw config view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized agent hook workbench inspector to integrate hooks information into the Basic panel instead of a separate tab.

* **Style**
  * Improved scrollability and spacing in release triggers drift card details.
  * Enhanced responsive grid layout for review triggers in compact mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->