### PR TITLE
docs: add i18n rule to coding standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ When starting work on this repository, read in this order:
 - Apply the same pattern to oversized API routes: thin top-level route, extract workflow branches (session creation, streaming, provider dispatch, etc.).
 - Split route refactors by workflow branch before shared helpers; avoid premature generic `utils`.
 - Before large behavior refactors, add or extend characterization tests that lock routing/lifecycle/persistence/recovery behavior.
+- All UI-facing strings must go through the i18n system (e.g., `t('key')`). Do not hardcode English or Chinese literals in components.
 
 ## Testing and Debugging
 


### PR DESCRIPTION
## Summary

- Add i18n rule to `Coding Standards` section in AGENTS.md / CLAUDE.md
- All UI-facing strings must go through the i18n system (e.g., `t('key')`), no hardcoding English or Chinese literals in components

## Test plan

- [x] Verify the new rule appears in both AGENTS.md and CLAUDE.md Coding Standards section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development standards documentation to clarify internationalization requirements for user-facing text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->