### PR TITLE
fix: hide and coalesce Docker background checks on Windows desktop

### DIFF
--- a/crates/routa-core/src/acp/docker/detector.rs
+++ b/crates/routa-core/src/acp/docker/detector.rs
@@ -20,7 +20,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 pub struct DockerDetector {
     cached_status: Arc<RwLock<Option<DockerStatus>>>,
     cached_at: Arc<RwLock<Instant>>,
-    in_flight: Arc<Mutex<Option<Arc<Notify>>>>,
+    refresh_lock: Arc<Mutex<()>>,
 }
 
 impl Default for DockerDetector {
@@ -35,8 +35,21 @@ impl DockerDetector {
         Self {
             cached_status: Arc::new(RwLock::new(None)),
             cached_at: Arc::new(RwLock::new(Instant::now() - Duration::from_secs(3600))),
-            in_flight: Arc::new(Mutex::new(None)),
+            refresh_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    async fn cached_status_if_fresh(&self, now: Instant) -> Option<DockerStatus> {
+        let cached = self.cached_status.read().await;
+        let cached_time = *self.cached_at.read().await;
+
+        cached.as_ref().and_then(|status| {
+            if now.duration_since(cached_time).as_millis() < CACHE_TTL_MS as u128 {
+                Some(status.clone())
+            } else {
+                None
+            }
+        })
     }
 
     /// Check Docker availability, using cache if valid.
@@ -56,52 +69,35 @@ impl DockerDetector {
         F: FnOnce(String) -> Fut,
         Fut: std::future::Future<Output = DockerStatus>,
     {
-        loop {
-            let now = Instant::now();
+        let started_at = Instant::now();
 
-            if !force_refresh {
-                let cached = self.cached_status.read().await;
-                let cached_time = *self.cached_at.read().await;
-
-                if let Some(status) = cached.as_ref() {
-                    if now.duration_since(cached_time).as_millis() < CACHE_TTL_MS as u128 {
-                        return status.clone();
-                    }
-                }
+        if !force_refresh {
+            if let Some(status) = self.cached_status_if_fresh(started_at).await {
+                return status;
             }
 
-            let notify = {
-                let mut in_flight = self.in_flight.lock().await;
-                if let Some(existing) = in_flight.as_ref() {
-                    Some(existing.clone())
-                } else {
-                    let created = Arc::new(Notify::new());
-                    *in_flight = Some(created.clone());
-                    None
-                }
-            };
-
-            if let Some(existing) = notify {
-                existing.notified().await;
-                continue;
+            let _refresh_guard = self.refresh_lock.lock().await;
+            let refreshed_at = Instant::now();
+            if let Some(status) = self.cached_status_if_fresh(refreshed_at).await {
+                return status;
             }
 
             let checked_at = Utc::now().to_rfc3339();
             let status = runner(checked_at).await;
 
             *self.cached_status.write().await = Some(status.clone());
-            *self.cached_at.write().await = now;
-
-            let notify = {
-                let mut in_flight = self.in_flight.lock().await;
-                in_flight.take()
-            };
-            if let Some(notify) = notify {
-                notify.notify_waiters();
-            }
+            *self.cached_at.write().await = refreshed_at;
 
             return status;
         }
+
+        let checked_at = Utc::now().to_rfc3339();
+        let status = runner(checked_at).await;
+
+        *self.cached_status.write().await = Some(status.clone());
+        *self.cached_at.write().await = started_at;
+
+        status
     }
 
     /// Run `docker info` and parse the result.
@@ -259,6 +255,7 @@ impl DockerDetector {
 
 fn docker_command() -> Command {
     let mut command = Command::new("docker");
+    command.kill_on_drop(true);
 
     #[cfg(windows)]
     {
@@ -310,10 +307,81 @@ mod tests {
             }
         });
 
-        let (left, right) = tokio::join!(first, second);
+        let (left, right) = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(first, second)
+        })
+        .await
+        .expect("concurrent availability checks should complete");
 
         assert!(left.available);
         assert!(right.available);
         assert_eq!(invocations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn force_refresh_bypasses_in_flight_probe() {
+        let detector = Arc::new(DockerDetector::new());
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let background_started = Arc::new(Notify::new());
+        let background_release = Arc::new(Notify::new());
+
+        let background_detector = detector.clone();
+        let background_counter = invocations.clone();
+        let background_started_signal = background_started.clone();
+        let background_release_signal = background_release.clone();
+        let background = tokio::spawn(async move {
+            background_detector
+                .check_availability_with_runner(false, move |checked_at| {
+                    let counter = background_counter.clone();
+                    let started = background_started_signal.clone();
+                    let release = background_release_signal.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        started.notify_waiters();
+                        release.notified().await;
+                        DockerStatus {
+                            available: true,
+                            daemon_running: true,
+                            checked_at,
+                            ..Default::default()
+                        }
+                    }
+                })
+                .await
+        });
+
+        background_started.notified().await;
+
+        let refresh_detector = detector.clone();
+        let refresh_counter = invocations.clone();
+        let refresh = tokio::spawn(async move {
+            refresh_detector
+                .check_availability_with_runner(true, move |checked_at| {
+                    let counter = refresh_counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        DockerStatus {
+                            available: true,
+                            daemon_running: true,
+                            checked_at,
+                            ..Default::default()
+                        }
+                    }
+                })
+                .await
+        });
+
+        let refreshed = tokio::time::timeout(Duration::from_millis(50), refresh)
+            .await
+            .expect("force refresh should not wait for in-flight background probe")
+            .expect("force refresh task should complete");
+
+        assert!(refreshed.available);
+
+        background_release.notify_waiters();
+        let background = background.await.expect("background task should complete");
+
+        assert!(background.available);
+        assert_eq!(invocations.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
Closes #292.

## Summary
- hide Windows desktop Docker background checks by spawning docker commands with CREATE_NO_WINDOW
- coalesce concurrent background availability checks into a single in-flight probe
- keep explicit pull and availability behavior unchanged outside the background startup path

## Validation
- cargo test -p routa-core check_availability_coalesces_concurrent_requests -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance of concurrent Docker availability checks by efficiently coalescing simultaneous requests into a single operation, reducing unnecessary overhead.
  * Enhanced Windows platform support for Docker command execution through improved configuration.

* **Tests**
  * Added unit test to verify concurrent request coalescing functions correctly under simultaneous access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->