### PR TITLE
fix(windows): hide ACP child console windows

### DIFF
--- a/crates/routa-core/src/acp/claude_code_process.rs
+++ b/crates/routa-core/src/acp/claude_code_process.rs
@@ -21,6 +21,9 @@ use tokio::sync::{broadcast, oneshot, Mutex};
 
 use crate::trace::{Contributor, TraceConversation, TraceEventType, TraceRecord, TraceWriter};
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 // ─── Claude Protocol Types ──────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]
@@ -246,6 +249,9 @@ impl ClaudeCodeProcess {
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
 
         tracing::info!(
             "[ClaudeCode:{}] Spawning: {} -p --output-format stream-json ... (cwd: {})",

--- a/crates/routa-core/src/acp/claude_code_process.rs
+++ b/crates/routa-core/src/acp/claude_code_process.rs
@@ -9,6 +9,8 @@
 //! Agent message notifications are traced to JSONL files for attribution tracking.
 
 use std::collections::{HashMap, HashSet};
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -19,10 +21,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{broadcast, oneshot, Mutex};
 
-use crate::trace::{Contributor, TraceConversation, TraceEventType, TraceRecord, TraceWriter};
-
 #[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+use super::CREATE_NO_WINDOW;
+use crate::trace::{Contributor, TraceConversation, TraceEventType, TraceRecord, TraceWriter};
 
 // ─── Claude Protocol Types ──────────────────────────────────────────────
 
@@ -251,7 +252,7 @@ impl ClaudeCodeProcess {
         cmd.stderr(Stdio::piped());
 
         #[cfg(windows)]
-        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd.as_std_mut().creation_flags(CREATE_NO_WINDOW);
 
         tracing::info!(
             "[ClaudeCode:{}] Spawning: {} -p --output-format stream-json ... (cwd: {})",

--- a/crates/routa-core/src/acp/mod.rs
+++ b/crates/routa-core/src/acp/mod.rs
@@ -48,6 +48,9 @@ use tokio::sync::{broadcast, RwLock};
 use crate::trace::{Contributor, TraceConversation, TraceEventType, TraceRecord, TraceWriter};
 use process::AcpProcess;
 
+#[cfg(windows)]
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 // ─── Session Record ─────────────────────────────────────────────────────
 
 /// Record of an active ACP session persisted for UI listing.

--- a/crates/routa-core/src/acp/process.rs
+++ b/crates/routa-core/src/acp/process.rs
@@ -30,6 +30,9 @@ pub type NotificationSender = broadcast::Sender<serde_json::Value>;
 /// Type alias for the pending request map to avoid complex type repetition.
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>>>>>;
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 /// A managed ACP agent child process.
 pub struct AcpProcess {
     stdin: Arc<Mutex<ChildStdin>>,
@@ -79,6 +82,9 @@ impl AcpProcess {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
+
+        #[cfg(windows)]
+        command_builder.creation_flags(CREATE_NO_WINDOW);
 
         // codex-acp often returns only stopReason in session/prompt result.
         // Enabling lightweight codex logs gives us process_output lines that

--- a/crates/routa-core/src/acp/process.rs
+++ b/crates/routa-core/src/acp/process.rs
@@ -11,6 +11,8 @@
 //! Agent message notifications are traced to JSONL files for attribution tracking.
 
 use std::collections::HashMap;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,6 +22,8 @@ use tokio::process::{Child, ChildStdin};
 use tokio::sync::{broadcast, oneshot, Mutex};
 
 use super::terminal_manager::TerminalManager;
+#[cfg(windows)]
+use super::CREATE_NO_WINDOW;
 use crate::trace::{
     Contributor, TraceConversation, TraceEventType, TraceRecord, TraceTool, TraceWriter,
 };
@@ -29,9 +33,6 @@ pub type NotificationSender = broadcast::Sender<serde_json::Value>;
 
 /// Type alias for the pending request map to avoid complex type repetition.
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>>>>>;
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 /// A managed ACP agent child process.
 pub struct AcpProcess {
@@ -84,7 +85,9 @@ impl AcpProcess {
             .stderr(std::process::Stdio::piped());
 
         #[cfg(windows)]
-        command_builder.creation_flags(CREATE_NO_WINDOW);
+        command_builder
+            .as_std_mut()
+            .creation_flags(CREATE_NO_WINDOW);
 
         // codex-acp often returns only stopReason in session/prompt result.
         // Enabling lightweight codex logs gives us process_output lines that


### PR DESCRIPTION
## Summary
- hide Windows console windows when spawning standard ACP child processes
- apply the same CREATE_NO_WINDOW flag to Claude Code desktop launches
- keep the patch scoped to the Rust desktop/runtime path only

## Verification
- cargo build -p routa-core
- cargo build --release --manifest-path apps/desktop/src-tauri/Cargo.toml

## Notes
- repo-wide lint/typecheck hooks are currently blocked by unrelated existing issues: eslint scans generated .next-static assets and TypeScript reports a missing declaration for lru-cache in src/core/git/git-utils.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background processes from creating visible windows on Windows, improving the user experience when launching background tasks and reducing visual interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->