### PR TITLE
chore(desktop): bump portable-pty to 0.9

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1"
 dirs = "5"
 
 # PTY support for interactive terminals
-portable-pty = "0.8"
+portable-pty = "0.9"
 
 # Routa Server (extracted crate)
 routa-server = { path = "../../../crates/routa-server" }


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

## Notes

- Related issue:
- Risks or follow-up work:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated terminal support library dependency to latest version for the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->