### PR TITLE
chore(deps): upgrade @ag-ui/encoder to 0.0.51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",
         "@ag-ui/core": "^0.0.46",
-        "@ag-ui/encoder": "^0.0.46",
+        "@ag-ui/encoder": "^0.0.51",
         "@agentclientprotocol/sdk": "^0.14.1",
         "@ai-sdk/anthropic": "^3.0.49",
         "@ai-sdk/openai": "^3.0.36",
@@ -213,22 +213,56 @@
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.46.tgz",
-      "integrity": "sha512-XU6dTgUOFZsXeO+CxCMNl5R8NCbdUyifWP7sRNIi61Et3F/0d0JotLo1y1/9GMGfsJNnP7bjb4YYsx21R7YMlw==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.51.tgz",
+      "integrity": "sha512-cZ+cSo4Wlksrv8Q4Kk/LrjdtF7SjXlc8/FPnZvAHuNUthmrBj57SNFhtgCXvjWyGxC6vWJp9QRRLM4VGkvlMfw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.46",
-        "@ag-ui/proto": "0.0.46"
+        "@ag-ui/core": "0.0.51",
+        "@ag-ui/proto": "0.0.51"
+      }
+    },
+    "node_modules/@ag-ui/encoder/node_modules/@ag-ui/core": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.51.tgz",
+      "integrity": "sha512-/n7k/s9aGWW7a81+K/GTurYoQ9LoFEukEtWz9Z8mJ5D5nCdsUDAf/ZWleCI8NbD9xO0ImVw2Wlyye0ORrTv7Mw==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/encoder/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.46.tgz",
-      "integrity": "sha512-+FfVhB1OP5A1+5BrEccQnwfODTbfBRWT3+NVnbW4RDFUDVmO9EUA+XPuO1ZxWcDfziTvQriwm0vNyaXGidSIhw==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.51.tgz",
+      "integrity": "sha512-aQC9eOU54zKnho3xOmBEPWRegdqdJ8yXWxBFoqPPB0oh8J/kB4JzecRybp9BfleyqaIGGnzn/yC7TsXh1Ir7Kw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.46",
+        "@ag-ui/core": "0.0.51",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
+      }
+    },
+    "node_modules/@ag-ui/proto/node_modules/@ag-ui/core": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.51.tgz",
+      "integrity": "sha512-/n7k/s9aGWW7a81+K/GTurYoQ9LoFEukEtWz9Z8mJ5D5nCdsUDAf/ZWleCI8NbD9xO0ImVw2Wlyye0ORrTv7Mw==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/proto/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
     "@ag-ui/core": "^0.0.46",
-    "@ag-ui/encoder": "^0.0.46",
+    "@ag-ui/encoder": "^0.0.51",
     "@agentclientprotocol/sdk": "^0.14.1",
     "@ai-sdk/anthropic": "^3.0.49",
     "@ai-sdk/openai": "^3.0.36",


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

## Notes

- Related issue:
- Risks or follow-up work:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core library dependency to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->