### PR TITLE
chore(deps): bump adm-zip to 0.5.17 in JS dependency manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.10.2",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.5.17",
         "ai": "^6.0.104",
         "bufferutil": "^4.1.0",
         "dagre": "^0.8.5",
@@ -14233,9 +14233,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.5.17",
     "ai": "^6.0.104",
     "bufferutil": "^4.1.0",
     "dagre": "^0.8.5",


### PR DESCRIPTION
## Summary
- Bumped JavaScript dependency `adm-zip` from `0.5.16` to `0.5.17` in `package.json`.
- Regenerated `package-lock.json` to resolve `adm-zip@0.5.17` with updated integrity and resolved metadata.
- Kept scope limited to dependency manifests and lockfile only.

## Evidence
- Review verdict: APPROVED in Kanban card.
- Test result artifacts: `e21a8d5b-78d3-4af3-a016-5b177ddfaf01`, `bba2ccab-e95c-4fb9-b0fa-d53d1f3a25fc`
- Screenshot artifact: `0a4b56ef-5e2e-45df-9296-e44784b3d4c2`

## Related
- Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated project dependencies for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->