### PR TITLE
chore(deps): update sha2 requirement from 0.10 to 0.11

### DIFF
--- a/crates/routa-core/Cargo.toml
+++ b/crates/routa-core/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1"
 dirs = "5"
 
 # Hashing (template drift checksums)
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Logging
 tracing = "0.1"

--- a/crates/routa-core/src/harness_template.rs
+++ b/crates/routa-core/src/harness_template.rs
@@ -754,7 +754,7 @@ fn path_exists(repo_root: &Path, rel_path: &str) -> bool {
 fn file_sha256(path: &PathBuf) -> Result<String, String> {
     let bytes = fs::read(path).map_err(|e| e.to_string())?;
     let hash = Sha256::digest(&bytes);
-    Ok(format!("{:x}", hash))
+    Ok(hash.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

## Notes

- Related issue:
- Risks or follow-up work:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core cryptographic library dependencies to the latest compatible versions for enhanced security and platform stability.

* **Bug Fixes**
  * Fixed SHA-256 hash generation to ensure all hash outputs are consistently formatted as lowercase hexadecimal strings, improving consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->