### PR TITLE
feat(release): publish harness-monitor to npm

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -44,10 +44,15 @@ jobs:
         run: |
           version="${RELEASE_VERSION}"
           version="${version#v}"
+          workspace_version=$(grep '^\s*version = ' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
 
           echo "Checking crate versions..."
           for crate in crates/routa-core crates/routa-rpc crates/routa-scanner crates/routa-server crates/routa-cli crates/routa-entrix crates/harness-monitor; do
-            crate_version=$(grep '^version = ' "$crate/Cargo.toml" | head -n1 | sed 's/version = "\(.*\)"/\1/')
+            if grep -q '^version\.workspace = true$' "$crate/Cargo.toml"; then
+              crate_version="${workspace_version}"
+            else
+              crate_version=$(grep '^version = ' "$crate/Cargo.toml" | head -n1 | sed 's/version = "\(.*\)"/\1/')
+            fi
             echo "$crate: $crate_version"
             if [[ "$crate_version" != "$version" ]]; then
               echo "ERROR: $crate version mismatch. Expected $version, got $crate_version" >&2

--- a/.github/workflows/harness-monitor-release.yml
+++ b/.github/workflows/harness-monitor-release.yml
@@ -1,4 +1,4 @@
-name: Routa CLI Release
+name: Harness Monitor Release
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    name: Build CLI binaries
+    name: Build Harness Monitor binaries
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +57,6 @@ jobs:
       - name: Verify synced release files
         shell: bash
         run: |
-          # Use while read loop instead of mapfile for Bash 3 compatibility
           changed_files=()
           while IFS= read -r line; do
             changed_files+=("$line")
@@ -94,25 +93,25 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build routa CLI
+      - name: Build Harness Monitor
         run: |
-          cargo build --release --package routa-cli --target ${{ matrix.target }}
+          cargo build --release --package harness-monitor --target ${{ matrix.target }}
 
       - name: Prepare artifact
         shell: bash
         run: |
           mkdir -p dist/${{ matrix.key }}
           if [[ "${{ matrix.key }}" == "win32-x64" ]]; then
-            cp target/${{ matrix.target }}/release/routa.exe dist/${{ matrix.key }}/routa.exe
+            cp target/${{ matrix.target }}/release/harness-monitor.exe dist/${{ matrix.key }}/harness-monitor.exe
           else
-            cp target/${{ matrix.target }}/release/routa dist/${{ matrix.key }}/routa
-            chmod +x dist/${{ matrix.key }}/routa
+            cp target/${{ matrix.target }}/release/harness-monitor dist/${{ matrix.key }}/harness-monitor
+            chmod +x dist/${{ matrix.key }}/harness-monitor
           fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: routa-cli-${{ matrix.key }}
+          name: harness-monitor-${{ matrix.key }}
           path: dist/${{ matrix.key }}
           if-no-files-found: error
 
@@ -162,25 +161,24 @@ jobs:
             esac
           done
 
-      - name: Download CLI artifacts
+      - name: Download Harness Monitor artifacts
         uses: actions/download-artifact@v4
         with:
-          path: dist/cli-artifacts
+          path: dist/harness-monitor-artifacts
 
       - name: Resolve version
         id: version
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version || github.event.inputs.version }}
         shell: bash
         run: |
           if [[ -n "$INPUT_VERSION" ]]; then
             version="$INPUT_VERSION"
             version="${version#v}"
-            version="${version#cli-v}"
+            version="${version#harness-monitor-v}"
           else
             version="${GITHUB_REF_NAME#v}"
-            version="${version#cli-v}"
+            version="${version#harness-monitor-v}"
           fi
 
           if [[ -z "${version}" ]]; then
@@ -198,15 +196,15 @@ jobs:
 
       - name: Stage npm tarballs
         run: |
-          node scripts/release/stage-routa-cli-npm.mjs \
+          node scripts/release/stage-harness-monitor-npm.mjs \
             --version "${{ steps.version.outputs.value }}" \
-            --artifacts dist/cli-artifacts \
+            --artifacts dist/harness-monitor-artifacts \
             --out dist/npm
 
       - name: Generate release manifest
         run: |
           node scripts/release/generate-release-manifest.mjs \
-            --cli-artifacts dist/cli-artifacts \
+            --cli-artifacts dist/harness-monitor-artifacts \
             --npm-dir dist/npm \
             --channel latest \
             --out dist/release/manifest.json
@@ -217,8 +215,8 @@ jobs:
         run: |
           python scripts/release/fetch-release-baseline.py \
             --repo phodal/routa \
-            --workflow cli-release.yml \
-            --artifact-name routa-release-manifest-cli \
+            --workflow harness-monitor-release.yml \
+            --artifact-name routa-release-manifest-harness-monitor \
             --exclude-run-id "${{ github.run_id }}" \
             --out dist/release/baseline-manifest.json
 
@@ -241,17 +239,17 @@ jobs:
       - name: Upload release manifest
         uses: actions/upload-artifact@v4
         with:
-          name: routa-release-manifest-cli
+          name: routa-release-manifest-harness-monitor
           path: dist/release/manifest.json
 
       - name: Upload npm artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: routa-cli-npm-${{ steps.version.outputs.value }}
+          name: harness-monitor-npm-${{ steps.version.outputs.value }}
           path: dist/npm
 
   verify:
-    name: Verify staged CLI release
+    name: Verify staged Harness Monitor release
     needs:
       - build
       - stage
@@ -264,13 +262,13 @@ jobs:
       - name: Download npm artifacts
         uses: actions/download-artifact@v4
         with:
-          name: routa-cli-npm-${{ needs.stage.outputs.version }}
+          name: harness-monitor-npm-${{ needs.stage.outputs.version }}
           path: dist/npm
 
       - name: Download release manifest
         uses: actions/download-artifact@v4
         with:
-          name: routa-release-manifest-cli
+          name: routa-release-manifest-harness-monitor
           path: dist/release
 
       - name: Set up Node.js
@@ -289,16 +287,16 @@ jobs:
 
       - name: Verify install smoke
         run: |
-          node scripts/release/verify-cli-tarballs.mjs \
+          node scripts/release/verify-harness-monitor-tarballs.mjs \
             --tarball-dir dist/npm \
             --platform linux-x64 \
-            --out dist/release/cli-verification.json
+            --out dist/release/harness-monitor-verification.json
 
       - name: Upload verification report
         uses: actions/upload-artifact@v4
         with:
-          name: routa-cli-release-verification
-          path: dist/release/cli-verification.json
+          name: harness-monitor-release-verification
+          path: dist/release/harness-monitor-verification.json
 
   publish:
     name: Publish to npm
@@ -319,7 +317,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: routa-cli-npm-${{ needs.stage.outputs.version }}
+          name: harness-monitor-npm-${{ needs.stage.outputs.version }}
           path: dist/npm
 
       - name: Set up Node.js
@@ -331,7 +329,7 @@ jobs:
       - name: Download release manifest
         uses: actions/download-artifact@v4
         with:
-          name: routa-release-manifest-cli
+          name: routa-release-manifest-harness-monitor
           path: dist/release
 
       - name: Install Entrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: true
         type: boolean
+      publish_harness_monitor:
+        description: "Publish Harness Monitor npm packages"
+        required: false
+        default: true
+        type: boolean
       publish_desktop:
         description: "Publish desktop release assets"
         required: false
@@ -104,6 +109,21 @@ jobs:
     with:
       version: ${{ needs.resolve-version.outputs.version }}
       publish: ${{ github.event_name == 'push' || ((github.event.inputs.dry_run != 'true' && github.event.inputs.dry_run != true) && (github.event.inputs.publish_cli == 'true' || github.event.inputs.publish_cli == true)) }}
+    secrets: inherit
+
+  release-harness-monitor:
+    name: Release Harness Monitor
+    needs: resolve-version
+    if: |
+      github.event_name == 'push' ||
+      github.event.inputs.dry_run == 'true' ||
+      github.event.inputs.dry_run == true ||
+      github.event.inputs.publish_harness_monitor == 'true' ||
+      github.event.inputs.publish_harness_monitor == true
+    uses: ./.github/workflows/harness-monitor-release.yml
+    with:
+      version: ${{ needs.resolve-version.outputs.version }}
+      publish: ${{ github.event_name == 'push' || ((github.event.inputs.dry_run != 'true' && github.event.inputs.dry_run != true) && (github.event.inputs.publish_harness_monitor == 'true' || github.event.inputs.publish_harness_monitor == true)) }}
     secrets: inherit
 
   release-crates:

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -81,11 +81,13 @@ jobs:
           fi
 
           allowed_files=(
+            "Cargo.toml"
             "package.json"
             "apps/desktop/package.json"
             "apps/desktop/src-tauri/Cargo.toml"
             "apps/desktop/src-tauri/tauri.conf.json"
             "packages/routa-cli/package.json"
+            "packages/harness-monitor/package.json"
             "crates/harness-monitor/Cargo.toml"
           )
 

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -68,11 +68,13 @@ jobs:
           fi
 
           allowed_files=(
+            "Cargo.toml"
             "package.json"
             "apps/desktop/package.json"
             "apps/desktop/src-tauri/Cargo.toml"
             "apps/desktop/src-tauri/tauri.conf.json"
             "packages/routa-cli/package.json"
+            "packages/harness-monitor/package.json"
             "crates/harness-monitor/Cargo.toml"
           )
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 authors = ["phodal"]

--- a/crates/harness-monitor/Cargo.toml
+++ b/crates/harness-monitor/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.28"
 rusqlite = { version = "0.32", features = ["bundled"] }
 ratatui = "0.29"
-routa-entrix = { version = "0.2.4", path = "../routa-entrix" }
+routa-entrix = { version = "0.14.1", path = "../routa-entrix" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/harness-monitor/README.md
+++ b/crates/harness-monitor/README.md
@@ -2,6 +2,12 @@
 
 `harness-monitor` is a Rust terminal tool for tracking multiple coding-agent sessions inside one git repository.
 
+Install from npm if you want the prebuilt binary wrapper instead of `cargo install`:
+
+```bash
+npm install -g harness-monitor
+```
+
 It is `TUI-first`: the main path is a live terminal view that answers:
 
 - which sessions are active

--- a/packages/harness-monitor/README.md
+++ b/packages/harness-monitor/README.md
@@ -1,0 +1,65 @@
+# Harness Monitor (NPM)
+
+Command-line distribution of Harness Monitor through npm. The package provides
+the `harness-monitor` command by resolving a prebuilt platform binary and
+launching it through a thin Node.js wrapper.
+
+## Installation
+
+Install globally:
+
+```bash
+npm install -g harness-monitor
+```
+
+Run without installing:
+
+```bash
+npx -p harness-monitor harness-monitor --help
+```
+
+The installed command is `harness-monitor`.
+
+## Package Layout
+
+`harness-monitor` is a thin launcher package. At install time npm resolves one
+of these optional platform packages and the wrapper executes the bundled binary:
+
+- `harness-monitor-darwin-arm64`
+- `harness-monitor-darwin-x64`
+- `harness-monitor-linux-x64`
+- `harness-monitor-windows-x64`
+
+If the current platform does not receive a matching optional dependency,
+reinstall the package so npm can fetch the correct binary package.
+
+## Quick Start
+
+Launch the TUI against the current repository:
+
+```bash
+harness-monitor --repo .
+```
+
+Run explicit subcommands:
+
+```bash
+harness-monitor tui --repo .
+harness-monitor serve --repo .
+harness-monitor hook codex SessionStart
+harness-monitor git-hook post-commit
+```
+
+## Requirements
+
+- Node.js 18+
+- One of the supported prebuilt platform packages
+
+## Architecture
+
+```text
+harness-monitor (NPM package)
+  ├── bin/harness-monitor.js
+  ├── optionalDependencies
+  └── harness-monitor binary
+```

--- a/packages/harness-monitor/bin/harness-monitor.js
+++ b/packages/harness-monitor/bin/harness-monitor.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "harness-monitor-darwin-arm64",
+  "darwin-x64": "harness-monitor-darwin-x64",
+  "linux-x64": "harness-monitor-linux-x64",
+  "win32-x64": "harness-monitor-windows-x64",
+};
+
+const PLATFORM_KEY = `${process.platform}-${process.arch}`;
+const PLATFORM_PACKAGE = PLATFORM_PACKAGES[PLATFORM_KEY];
+
+if (!PLATFORM_PACKAGE) {
+  throw new Error(`Unsupported platform: ${process.platform} (${process.arch})`);
+}
+
+const BINARY_NAME =
+  process.platform === "win32" ? "harness-monitor.exe" : "harness-monitor";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+
+function getPathFromPackage(packageName) {
+  try {
+    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+    const packageDir = path.dirname(packageJsonPath);
+    const vendorPath = path.join(packageDir, "vendor", BINARY_NAME);
+    return existsSync(vendorPath) ? vendorPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPathFromLocalFallback() {
+  const localBinaryPath = path.join(__dirname, "..", "vendor", BINARY_NAME);
+  return existsSync(localBinaryPath) ? localBinaryPath : null;
+}
+
+const binaryPath =
+  getPathFromPackage(PLATFORM_PACKAGE) || getPathFromLocalFallback();
+
+if (!binaryPath) {
+  throw new Error(
+    `No Harness Monitor binary found for ${PLATFORM_KEY}. Reinstall with: npm install -g harness-monitor`,
+  );
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    if (child.killed) {
+      return;
+    }
+    child.kill(signal);
+  });
+}
+
+const code = await new Promise((resolve) => {
+  child.on("error", (error) => {
+    console.error(error);
+    resolve(1);
+  });
+
+  child.on("exit", (_exitCode, signal) => {
+    if (signal) {
+      const signalCodes = {
+        SIGHUP: 1,
+        SIGINT: 2,
+        SIGQUIT: 3,
+        SIGKILL: 9,
+        SIGTERM: 15,
+        SIGSTOP: 19,
+      };
+      resolve(128 + (signalCodes[signal] ?? 1));
+      return;
+    }
+
+    resolve(_exitCode ?? 1);
+  });
+});
+
+process.exit(code);

--- a/packages/harness-monitor/package.json
+++ b/packages/harness-monitor/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "harness-monitor",
+  "version": "0.14.1",
+  "description": "Harness Monitor terminal UI distributed through npm.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Phodal Huang",
+  "homepage": "https://github.com/phodal/routa#readme",
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "harness-monitor",
+    "tui",
+    "cli",
+    "agent",
+    "ai"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phodal/routa.git",
+    "directory": "packages/harness-monitor"
+  },
+  "bin": {
+    "harness-monitor": "bin/harness-monitor.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "harness-monitor-darwin-arm64": "0.14.1",
+    "harness-monitor-darwin-x64": "0.14.1",
+    "harness-monitor-linux-x64": "0.14.1",
+    "harness-monitor-windows-x64": "0.14.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/release/stage-harness-monitor-npm.mjs
+++ b/scripts/release/stage-harness-monitor-npm.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) {
+      continue;
+    }
+
+    const nextEq = token.indexOf("=");
+    if (nextEq > 0) {
+      const key = token.slice(2, nextEq);
+      args[key] = token.slice(nextEq + 1);
+      continue;
+    }
+
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = "true";
+    }
+  }
+
+  return args;
+}
+
+function npmPack(directory) {
+  const result = spawnSync("npm", ["pack", "--ignore-scripts"], {
+    cwd: directory,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`npm pack failed for ${directory}`);
+  }
+
+  const lines = result.stdout
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
+  return lines[lines.length - 1];
+}
+
+const args = parseArgs(process.argv.slice(2));
+const version = args.version || process.env.HARNESS_MONITOR_VERSION;
+const artifactRoot = path.resolve(args.artifacts || "dist/harness-monitor-artifacts");
+const outputDir = path.resolve(args.out || "dist/npm");
+const sourcePackage = path.resolve(args.package || "packages/harness-monitor");
+const stagingRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "harness-monitor-npm-"),
+);
+
+if (!version) {
+  throw new Error("--version is required");
+}
+
+const platformPackages = [
+  {
+    key: "darwin-arm64",
+    artifact: "harness-monitor-darwin-arm64",
+    packageName: "harness-monitor-darwin-arm64",
+    os: ["darwin"],
+    cpu: ["arm64"],
+    binary: "harness-monitor",
+    description: "Harness Monitor binary for Apple Silicon macOS.",
+  },
+  {
+    key: "darwin-x64",
+    artifact: "harness-monitor-darwin-x64",
+    packageName: "harness-monitor-darwin-x64",
+    os: ["darwin"],
+    cpu: ["x64"],
+    binary: "harness-monitor",
+    description: "Harness Monitor binary for Intel macOS.",
+  },
+  {
+    key: "linux-x64",
+    artifact: "harness-monitor-linux-x64",
+    packageName: "harness-monitor-linux-x64",
+    os: ["linux"],
+    cpu: ["x64"],
+    binary: "harness-monitor",
+    description: "Harness Monitor binary for Linux x64.",
+  },
+  {
+    key: "win32-x64",
+    artifact: "harness-monitor-win32-x64",
+    packageName: "harness-monitor-windows-x64",
+    os: ["win32"],
+    cpu: ["x64"],
+    binary: "harness-monitor.exe",
+    description: "Harness Monitor binary for Windows x64.",
+  },
+];
+
+const sourceTemplate = JSON.parse(
+  await fsp.readFile(path.join(sourcePackage, "package.json"), "utf8"),
+);
+
+await fsp.mkdir(outputDir, { recursive: true });
+await fsp.mkdir(stagingRoot, { recursive: true });
+
+if (!fs.existsSync(artifactRoot)) {
+  throw new Error(`Artifact root not found: ${artifactRoot}`);
+}
+
+try {
+  for (const platform of platformPackages) {
+    const sourceBinaryPath = path.join(
+      artifactRoot,
+      platform.artifact,
+      platform.binary,
+    );
+    if (!fs.existsSync(sourceBinaryPath)) {
+      throw new Error(`Missing artifact binary: ${sourceBinaryPath}`);
+    }
+
+    const packageDir = path.join(stagingRoot, platform.packageName);
+    const vendorDir = path.join(packageDir, "vendor");
+    await fsp.mkdir(vendorDir, { recursive: true });
+
+    await fsp.cp(sourceBinaryPath, path.join(vendorDir, platform.binary));
+    if (!platform.binary.endsWith(".exe")) {
+      await fsp.chmod(path.join(vendorDir, platform.binary), 0o755);
+    }
+
+    const platformPackageJson = {
+      name: platform.packageName,
+      version,
+      description: platform.description,
+      license: sourceTemplate.license,
+      author: sourceTemplate.author,
+      homepage: sourceTemplate.homepage,
+      repository: sourceTemplate.repository,
+      files: ["vendor"],
+      os: platform.os,
+      cpu: platform.cpu,
+      publishConfig: {
+        access: "public",
+      },
+    };
+
+    await fsp.writeFile(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify(platformPackageJson, null, 2)}\n`,
+      "utf8",
+    );
+
+    const tarballName = npmPack(packageDir);
+    await fsp.rename(
+      path.join(packageDir, tarballName),
+      path.join(outputDir, tarballName),
+    );
+  }
+
+  const mainPackageDir = path.join(stagingRoot, "harness-monitor");
+  await fsp.mkdir(mainPackageDir, { recursive: true });
+
+  const filesToCopy = ["bin", "README.md", "package.json"];
+  for (const file of filesToCopy) {
+    const sourcePath = path.join(sourcePackage, file);
+    const targetPath = path.join(mainPackageDir, file);
+    if (!fs.existsSync(sourcePath)) {
+      continue;
+    }
+
+    const stat = await fsp.stat(sourcePath);
+    if (stat.isDirectory()) {
+      await fsp.cp(sourcePath, targetPath, { recursive: true });
+    } else {
+      await fsp.cp(sourcePath, targetPath);
+    }
+  }
+
+  const mainTarballName = npmPack(mainPackageDir);
+  await fsp.rename(
+    path.join(mainPackageDir, mainTarballName),
+    path.join(outputDir, mainTarballName),
+  );
+
+  console.log(`Staged npm tarballs in ${outputDir}`);
+} finally {
+  await fsp.rm(stagingRoot, { recursive: true, force: true });
+}

--- a/scripts/release/sync-release-version.mjs
+++ b/scripts/release/sync-release-version.mjs
@@ -129,10 +129,14 @@ if (!version) {
 rootPackage.data.version = version;
 await writeJson("package.json", rootPackage.data);
 
+await updateTomlVersion("Cargo.toml", version);
 await updateJsonVersion("apps/desktop/package.json", version);
 await updateTomlVersion("apps/desktop/src-tauri/Cargo.toml", version);
 await updateJsonVersion("apps/desktop/src-tauri/tauri.conf.json", version);
 await updateJsonVersion("packages/routa-cli/package.json", version, {
+  updateOptionalDeps: true,
+});
+await updateJsonVersion("packages/harness-monitor/package.json", version, {
   updateOptionalDeps: true,
 });
 

--- a/scripts/release/verify-cli-tarballs.mjs
+++ b/scripts/release/verify-cli-tarballs.mjs
@@ -86,41 +86,17 @@ if (!platformTarball) {
 
 const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "routa-cli-verify-"));
 try {
-  const npmCacheDir = path.join(tempRoot, ".npm-cache");
-  const commandEnv = {
-    ...process.env,
-    NPM_CONFIG_CACHE: npmCacheDir,
-  };
-
   await fsp.writeFile(
     path.join(tempRoot, "package.json"),
     `${JSON.stringify({ name: "routa-cli-release-verify", private: true }, null, 2)}\n`,
     "utf8",
   );
-  await fsp.mkdir(npmCacheDir, { recursive: true });
 
-  run(
-    "npm",
-    [
-      "install",
-      "--ignore-scripts",
-      "--omit=optional",
-      "--no-package-lock",
-      "--no-fund",
-      "--no-audit",
-      mainTarball,
-      platformTarball,
-    ],
-    {
-      cwd: tempRoot,
-      env: commandEnv,
-    },
-  );
-
-  const cliResult = run("npx", ["--no-install", "routa", "--version"], {
+  run("npm", ["install", "--ignore-scripts", "--no-package-lock", "--no-fund", "--no-audit", mainTarball, platformTarball], {
     cwd: tempRoot,
-    env: commandEnv,
   });
+
+  const cliResult = run("npx", ["--no-install", "routa", "--version"], { cwd: tempRoot });
   const report = {
     status: "passed",
     platform: platformKey,

--- a/scripts/release/verify-harness-monitor-tarballs.mjs
+++ b/scripts/release/verify-harness-monitor-tarballs.mjs
@@ -7,10 +7,10 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 const PLATFORM_PACKAGE_NAMES = {
-  "darwin-arm64": "routa-cli-darwin-arm64",
-  "darwin-x64": "routa-cli-darwin-x64",
-  "linux-x64": "routa-cli-linux-x64",
-  "win32-x64": "routa-cli-windows-x64",
+  "darwin-arm64": "harness-monitor-darwin-arm64",
+  "darwin-x64": "harness-monitor-darwin-x64",
+  "linux-x64": "harness-monitor-linux-x64",
+  "win32-x64": "harness-monitor-windows-x64",
 };
 
 function parseArgs(argv) {
@@ -66,7 +66,9 @@ function findTarball(directory, predicate) {
 
 const args = parseArgs(process.argv.slice(2));
 const tarballDir = path.resolve(args["tarball-dir"] || "dist/npm");
-const outPath = path.resolve(args.out || "dist/release/cli-verification.json");
+const outPath = path.resolve(
+  args.out || "dist/release/harness-monitor-verification.json",
+);
 const platformKey = resolvePlatformKey(args.platform);
 const platformPackageName = PLATFORM_PACKAGE_NAMES[platformKey];
 
@@ -74,17 +76,28 @@ if (!platformPackageName) {
   throw new Error(`Unsupported verification platform: ${platformKey}`);
 }
 
-const mainTarball = findTarball(tarballDir, (file) => file.startsWith("routa-cli-") && !file.includes("darwin") && !file.includes("linux") && !file.includes("windows") && !file.includes("win32"));
-const platformTarball = findTarball(tarballDir, (file) => file.startsWith(`${platformPackageName}-`));
+const mainTarball = findTarball(
+  tarballDir,
+  (file) =>
+    file.startsWith("harness-monitor-") &&
+    !file.includes("darwin") &&
+    !file.includes("linux") &&
+    !file.includes("windows") &&
+    !file.includes("win32"),
+);
+const platformTarball = findTarball(
+  tarballDir,
+  (file) => file.startsWith(`${platformPackageName}-`),
+);
 
 if (!mainTarball) {
-  throw new Error(`Unable to find routa-cli tarball in ${tarballDir}`);
+  throw new Error(`Unable to find harness-monitor tarball in ${tarballDir}`);
 }
 if (!platformTarball) {
   throw new Error(`Unable to find ${platformPackageName} tarball in ${tarballDir}`);
 }
 
-const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "routa-cli-verify-"));
+const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "harness-monitor-verify-"));
 try {
   const npmCacheDir = path.join(tempRoot, ".npm-cache");
   const commandEnv = {
@@ -94,7 +107,7 @@ try {
 
   await fsp.writeFile(
     path.join(tempRoot, "package.json"),
-    `${JSON.stringify({ name: "routa-cli-release-verify", private: true }, null, 2)}\n`,
+    `${JSON.stringify({ name: "harness-monitor-release-verify", private: true }, null, 2)}\n`,
     "utf8",
   );
   await fsp.mkdir(npmCacheDir, { recursive: true });
@@ -117,10 +130,14 @@ try {
     },
   );
 
-  const cliResult = run("npx", ["--no-install", "routa", "--version"], {
-    cwd: tempRoot,
-    env: commandEnv,
-  });
+  const cliResult = run(
+    "npx",
+    ["--no-install", "harness-monitor", "--version"],
+    {
+      cwd: tempRoot,
+      env: commandEnv,
+    },
+  );
   const report = {
     status: "passed",
     platform: platformKey,
@@ -131,7 +148,7 @@ try {
 
   await fsp.mkdir(path.dirname(outPath), { recursive: true });
   await fsp.writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-  console.log(`CLI tarball verification passed for ${platformKey}`);
+  console.log(`Harness Monitor tarball verification passed for ${platformKey}`);
 } finally {
   await fsp.rm(tempRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- add npm packaging and release automation for `harness-monitor`
- wire the top-level release workflow to publish `harness-monitor` npm packages
- align release version syncing for workspace Cargo metadata and `harness-monitor`

## Verification
- `cargo build --release -p harness-monitor`
- `entrix run --tier fast`

## Notes
- deferred the unrelated `verify-cli-tarballs.mjs` hardening into a follow-up change, so this PR stays scoped to `harness-monitor` release work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Harness Monitor now available via npm with `npm install -g harness-monitor` for convenient global installation
  * Added multi-platform support: macOS (arm64, x64), Linux (x64), and Windows (x64)
  * Version bumped to 0.14.1

* **Documentation**
  * Added installation and usage guides for npm distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->