### PR TITLE
fix: preserve task worktree truth across lane re-entry

### DIFF
--- a/src/app/api/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/__tests__/route.test.ts
@@ -29,7 +29,7 @@ const system = {
   taskStore,
   kanbanBoardStore: { get: vi.fn() },
   workspaceStore: { get: vi.fn() },
-  worktreeStore: { assignSession: vi.fn() },
+  worktreeStore: { assignSession: vi.fn(), get: vi.fn() },
   codebaseStore: { findByRepoPath: vi.fn(), get: vi.fn(), getDefault: vi.fn() },
   eventBus: {},
   artifactStore: undefined as InMemoryArtifactStore | undefined,
@@ -112,6 +112,10 @@ describe("/api/tasks/[taskId]", () => {
     buildTaskDeliveryTransitionErrorFromRules.mockReturnValue(null);
     taskStore.save.mockResolvedValue();
     system.kanbanBoardStore.get = vi.fn().mockResolvedValue(null);
+    system.worktreeStore.get = vi.fn().mockResolvedValue(undefined);
+    system.codebaseStore.findByRepoPath = vi.fn().mockResolvedValue(undefined);
+    system.codebaseStore.get = vi.fn().mockResolvedValue(undefined);
+    system.codebaseStore.getDefault = vi.fn().mockResolvedValue(undefined);
     system.artifactStore = undefined;
     await artifactStore.deleteByTask("task-1");
     taskStore.get.mockResolvedValue(createTask({
@@ -492,6 +496,57 @@ describe("/api/tasks/[taskId]", () => {
       triggerSessionId: "session-new",
     }));
     expect(data.task.triggerSessionId).toBe("session-new");
+  });
+
+  it("reuses the existing task worktree when retrying a dev trigger", async () => {
+    const existingTask = createTask({
+      id: "task-1",
+      title: "Retry dev on the same worktree",
+      objective: "Keep using the existing dev worktree",
+      workspaceId: "workspace-1",
+      boardId: "board-1",
+      columnId: "dev",
+      status: TaskStatus.IN_PROGRESS,
+      triggerSessionId: "session-dev-old",
+      worktreeId: "wt-1",
+    });
+    taskStore.get.mockResolvedValue(existingTask);
+    system.worktreeStore.get = vi.fn().mockResolvedValue({
+      id: "wt-1",
+      codebaseId: "repo-1",
+      workspaceId: "workspace-1",
+      worktreePath: "/tmp/worktrees/task-1",
+      branch: "issue/task-1",
+      baseBranch: "main",
+      status: "active",
+    });
+    system.codebaseStore.get = vi.fn().mockResolvedValue({
+      id: "repo-1",
+      workspaceId: "workspace-1",
+      repoPath: "/tmp/repos/main",
+      branch: "main",
+    });
+
+    const request = new NextRequest("http://localhost/api/tasks/task-1", {
+      method: "PATCH",
+      body: JSON.stringify({ retryTrigger: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ taskId: "task-1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createWorktree).not.toHaveBeenCalled();
+    expect(capturedEnqueueTask).toMatchObject({
+      id: "task-1",
+      columnId: "dev",
+      worktreeId: "wt-1",
+      triggerSessionId: undefined,
+    });
+    expect(data.task.worktreeId).toBe("wt-1");
   });
 
   it("passes a retry provider override without persisting a card provider override", async () => {
@@ -924,5 +979,82 @@ describe("/api/tasks/[taskId]", () => {
       label: "cf7f1e28",
       baseBranch: "main",
     }));
+    expect(capturedEnqueueTask).toMatchObject({
+      id: taskId,
+      columnId: "dev",
+      worktreeId: "wt-1",
+    });
+  });
+
+  it("returns a review card to dev and reuses the original worktree when review is not approved", async () => {
+    const existingTask = createTask({
+      id: "task-1",
+      title: "Return review feedback to dev",
+      objective: "Send the fix back to dev on the same worktree",
+      workspaceId: "workspace-1",
+      boardId: "board-1",
+      columnId: "review",
+      status: TaskStatus.REVIEW_REQUIRED,
+      triggerSessionId: "session-review-1",
+      worktreeId: "wt-1",
+    });
+    taskStore.get.mockResolvedValue(existingTask);
+    prepareTaskForColumnChange.mockImplementationOnce((_fromColumnId, task) => {
+      if (task) {
+        task.triggerSessionId = undefined;
+        task.lastSyncError = undefined;
+      }
+      return true;
+    });
+    system.worktreeStore.get = vi.fn().mockResolvedValue({
+      id: "wt-1",
+      codebaseId: "repo-1",
+      workspaceId: "workspace-1",
+      worktreePath: "/tmp/worktrees/task-1",
+      branch: "issue/task-1",
+      baseBranch: "main",
+      status: "active",
+    });
+    system.codebaseStore.get = vi.fn().mockResolvedValue({
+      id: "repo-1",
+      workspaceId: "workspace-1",
+      repoPath: "/tmp/repos/main",
+      branch: "main",
+    });
+    system.kanbanBoardStore.get = vi.fn().mockResolvedValue({
+      id: "board-1",
+      columns: [
+        { id: "dev", name: "Dev", position: 1, stage: "dev" },
+        { id: "review", name: "Review", position: 2, stage: "review" },
+      ],
+    });
+
+    const request = new NextRequest("http://localhost/api/tasks/task-1", {
+      method: "PATCH",
+      body: JSON.stringify({
+        verificationVerdict: VerificationVerdict.NOT_APPROVED,
+        verificationReport: "Please address the failing review checks.",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ taskId: "task-1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createWorktree).not.toHaveBeenCalled();
+    expect(capturedEnqueueTask).toMatchObject({
+      id: "task-1",
+      columnId: "dev",
+      worktreeId: "wt-1",
+    });
+    expect(data.task).toMatchObject({
+      columnId: "dev",
+      status: TaskStatus.IN_PROGRESS,
+      verificationVerdict: VerificationVerdict.NOT_APPROVED,
+      worktreeId: "wt-1",
+    });
   });
 });

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { monitorApiRoute } from "@/core/http/api-route-observability";
 import { getRoutaSystem } from "@/core/routa-system";
-import { hydrateTaskComments, TaskPriority, TaskStatus, type Task } from "@/core/models/task";
+import { hydrateTaskComments, TaskPriority, TaskStatus, VerificationVerdict, type Task } from "@/core/models/task";
 import { columnIdToTaskStatus, taskStatusToColumnId } from "@/core/models/kanban";
 import { getKanbanEventBroadcaster } from "@/core/kanban/kanban-event-broadcaster";
 import { ensureTaskBoardContext } from "@/core/kanban/task-board-context";
@@ -49,6 +49,7 @@ import {
   countContractGateFailures,
   resolveCurrentOrNextContractGate,
 } from "@/core/kanban/task-contract-readiness";
+import { resolveTaskWorktreeTruth } from "@/core/kanban/task-worktree-truth";
 
 export const dynamic = "force-dynamic";
 
@@ -212,6 +213,16 @@ export async function PATCH(
   const nextTask: Task = { ...existing, updatedAt: new Date() };
   let transitionDeliveryReadiness: TaskDeliveryReadiness | undefined;
 
+  if (
+    existing.columnId === "review"
+    && body.columnId === undefined
+    && body.status === undefined
+    && body.verificationVerdict === VerificationVerdict.NOT_APPROVED
+  ) {
+    body.columnId = "dev";
+    body.status = TaskStatus.IN_PROGRESS;
+  }
+
   if (body.title !== undefined) nextTask.title = body.title;
   if (body.objective !== undefined) nextTask.objective = body.objective;
   if (body.comment !== undefined) nextTask.comment = body.comment;
@@ -261,8 +272,11 @@ export async function PATCH(
 
   // Check required artifacts before allowing column transition
   if (body.columnId !== undefined && body.columnId !== existing.columnId) {
+    const allowReviewFallbackToDev = existing.columnId === "review"
+      && body.columnId === "dev"
+      && nextTask.verificationVerdict === VerificationVerdict.NOT_APPROVED;
     if (boardId && board) {
-        if (existing.triggerSessionId) {
+        if (existing.triggerSessionId && !allowReviewFallbackToDev) {
           const laneAutomationState = resolveCurrentLaneAutomationState(existing, board.columns, {
             currentSessionId: existing.triggerSessionId,
           });
@@ -473,16 +487,10 @@ export async function PATCH(
     : undefined;
 
   if ((enteringDev || assignedWhileInDev || retryingTrigger) && !nextTask.triggerSessionId) {
-    // Determine which codebase to use: first from task's codebaseIds, else repo path, else default
-    let preferredCodebase = body.repoPath
-      ? await system.codebaseStore.findByRepoPath(nextTask.workspaceId, body.repoPath)
-      : undefined;
-    if (!preferredCodebase && (nextTask.codebaseIds?.length ?? 0) > 0) {
-      preferredCodebase = await system.codebaseStore.get(nextTask.codebaseIds![0]);
-    }
-    if (!preferredCodebase) {
-      preferredCodebase = await system.codebaseStore.getDefault(nextTask.workspaceId);
-    }
+    const worktreeTruth = await resolveTaskWorktreeTruth(nextTask, system, {
+      preferredRepoPath: body.repoPath,
+    });
+    const preferredCodebase = worktreeTruth?.codebase;
 
     // Auto-create worktree when entering dev column (if no worktree yet and codebase exists)
     if (enteringDev && preferredCodebase && !nextTask.worktreeId) {

--- a/src/core/kanban/agent-trigger.ts
+++ b/src/core/kanban/agent-trigger.ts
@@ -259,6 +259,8 @@ export function buildTaskPrompt(
               "",
               `Pending handoff ${index + 1}: ${formatHandoffRequestType(handoff.requestType)}`,
               handoff.request,
+              ...(handoff.worktreeId ? [`Task worktreeId: ${handoff.worktreeId}`] : []),
+              ...(handoff.cwd ? [`Task cwd: ${handoff.cwd}`] : []),
               `Respond with \`submit_lane_handoff\` using handoffId: "${handoff.id}".`,
             ]))
           : []),

--- a/src/core/kanban/task-delivery-readiness.ts
+++ b/src/core/kanban/task-delivery-readiness.ts
@@ -8,6 +8,7 @@ import type { KanbanDeliveryRules } from "@/core/models/kanban";
 import type { Codebase } from "@/core/models/codebase";
 import type { Task } from "@/core/models/task";
 import type { Worktree } from "@/core/models/worktree";
+import { resolveTaskWorktreeTruth } from "./task-worktree-truth";
 
 interface DeliverySystemLike {
   codebaseStore: {
@@ -48,31 +49,16 @@ async function resolveTaskRepoContext(
   task: Task,
   system: DeliverySystemLike,
 ): Promise<TaskRepoContext | null> {
-  if (task.worktreeId) {
-    const worktree = await system.worktreeStore.get(task.worktreeId);
-    if (worktree?.worktreePath) {
-      const codebase = await system.codebaseStore.get(worktree.codebaseId);
-      return {
-        repoPath: worktree.worktreePath,
-        baseBranch: worktree.baseBranch || codebase?.branch,
-        codebase,
-      };
-    }
-  }
-
-  const primaryCodebaseId = task.codebaseIds[0];
-  const codebase = primaryCodebaseId
-    ? await system.codebaseStore.get(primaryCodebaseId)
-    : await system.codebaseStore.getDefault(task.workspaceId);
-  if (!codebase?.repoPath) {
+  const truth = await resolveTaskWorktreeTruth(task, system);
+  if (!truth) {
     return null;
   }
 
   return {
-    repoPath: codebase.repoPath,
-    baseBranch: codebase.branch,
-    codebase,
-    requiresWorktree: true,
+    repoPath: truth.repoPath,
+    baseBranch: truth.baseBranch,
+    codebase: truth.codebase,
+    requiresWorktree: truth.source !== "task.worktreeId",
   };
 }
 

--- a/src/core/kanban/task-lane-history.ts
+++ b/src/core/kanban/task-lane-history.ts
@@ -43,6 +43,7 @@ export function upsertTaskLaneSession(
   const created: TaskLaneSession = {
     sessionId: session.sessionId,
     routaAgentId: session.routaAgentId,
+    worktreeId: session.worktreeId,
     cwd: session.cwd,
     columnId: session.columnId,
     columnName: session.columnName,
@@ -181,6 +182,8 @@ export function createTaskLaneHandoff(params: {
   toSessionId: string;
   fromColumnId?: string;
   toColumnId?: string;
+  worktreeId?: string;
+  cwd?: string;
   requestType: TaskLaneHandoffRequestType;
   request: string;
   status?: TaskLaneHandoffStatus;
@@ -191,6 +194,8 @@ export function createTaskLaneHandoff(params: {
     toSessionId: params.toSessionId,
     fromColumnId: params.fromColumnId,
     toColumnId: params.toColumnId,
+    worktreeId: params.worktreeId,
+    cwd: params.cwd,
     requestType: params.requestType,
     request: params.request,
     status: params.status ?? "requested",

--- a/src/core/kanban/task-worktree-truth.ts
+++ b/src/core/kanban/task-worktree-truth.ts
@@ -1,0 +1,92 @@
+import type { Codebase } from "../models/codebase";
+import type { Task } from "../models/task";
+import type { Worktree } from "../models/worktree";
+
+interface TaskWorktreeTruthSystem {
+  codebaseStore: {
+    get(codebaseId: string): Promise<Codebase | undefined>;
+    getDefault(workspaceId: string): Promise<Codebase | undefined>;
+    findByRepoPath?(workspaceId: string, repoPath: string): Promise<Codebase | undefined>;
+  };
+  worktreeStore: {
+    get(worktreeId: string): Promise<Worktree | undefined>;
+  };
+}
+
+export interface TaskWorktreeTruth {
+  source: "task.worktreeId" | "repoPath" | "task.codebaseIds" | "defaultCodebase";
+  worktreeId?: string;
+  worktree?: Worktree;
+  codebase?: Codebase;
+  repoPath: string;
+  cwd: string;
+  branch?: string;
+  baseBranch?: string;
+}
+
+export async function resolveTaskWorktreeTruth(
+  task: Pick<Task, "workspaceId" | "codebaseIds" | "worktreeId">,
+  system: TaskWorktreeTruthSystem,
+  options?: { preferredRepoPath?: string },
+): Promise<TaskWorktreeTruth | null> {
+  if (task.worktreeId) {
+    const worktree = await system.worktreeStore.get(task.worktreeId);
+    if (worktree?.worktreePath) {
+      const codebase = await system.codebaseStore.get(worktree.codebaseId);
+      return {
+        source: "task.worktreeId",
+        worktreeId: task.worktreeId,
+        worktree,
+        codebase,
+        repoPath: worktree.worktreePath,
+        cwd: worktree.worktreePath,
+        branch: worktree.branch,
+        baseBranch: worktree.baseBranch || codebase?.branch,
+      };
+    }
+  }
+
+  const preferredRepoPath = options?.preferredRepoPath?.trim();
+  if (preferredRepoPath && system.codebaseStore.findByRepoPath) {
+    const codebase = await system.codebaseStore.findByRepoPath(task.workspaceId, preferredRepoPath);
+    if (codebase?.repoPath) {
+      return {
+        source: "repoPath",
+        codebase,
+        repoPath: codebase.repoPath,
+        cwd: codebase.repoPath,
+        branch: codebase.branch,
+        baseBranch: codebase.branch,
+      };
+    }
+  }
+
+  const primaryCodebaseId = task.codebaseIds[0];
+  if (primaryCodebaseId) {
+    const codebase = await system.codebaseStore.get(primaryCodebaseId);
+    if (codebase?.repoPath) {
+      return {
+        source: "task.codebaseIds",
+        codebase,
+        repoPath: codebase.repoPath,
+        cwd: codebase.repoPath,
+        branch: codebase.branch,
+        baseBranch: codebase.branch,
+      };
+    }
+  }
+
+  const defaultCodebase = await system.codebaseStore.getDefault(task.workspaceId);
+  if (!defaultCodebase?.repoPath) {
+    return null;
+  }
+
+  return {
+    source: "defaultCodebase",
+    codebase: defaultCodebase,
+    repoPath: defaultCodebase.repoPath,
+    cwd: defaultCodebase.repoPath,
+    branch: defaultCodebase.branch,
+    baseBranch: defaultCodebase.branch,
+  };
+}

--- a/src/core/kanban/workflow-orchestrator-singleton.ts
+++ b/src/core/kanban/workflow-orchestrator-singleton.ts
@@ -33,6 +33,7 @@ import { getKanbanSessionConcurrencyLimit as getBoardSessionConcurrencyLimit } f
 import { getKanbanDevSessionSupervision } from "./board-session-supervision";
 import { getKanbanAutoProvider } from "./board-auto-provider";
 import { upsertTaskLaneSession } from "./task-lane-history";
+import { resolveTaskWorktreeTruth } from "./task-worktree-truth";
 import { getHttpSessionStore } from "../acp/http-session-store";
 import { getSpecialistById } from "../orchestration/specialist-prompts";
 import { dispatchSessionPrompt } from "@/core/acp/session-prompt";
@@ -161,15 +162,10 @@ async function startKanbanTaskSession(
   const workspace = await system.workspaceStore.get(nextTask.workspaceId);
   const autoProviderId = getKanbanAutoProvider(workspace?.metadata, nextTask.boardId!);
 
-  let preferredCodebase = (nextTask.codebaseIds?.length ?? 0) > 0
-    ? await system.codebaseStore.get(nextTask.codebaseIds[0])
-    : undefined;
-  if (!preferredCodebase) {
-    preferredCodebase = await system.codebaseStore.getDefault(nextTask.workspaceId);
-  }
-
-  let worktreeCwd = preferredCodebase?.repoPath ?? process.cwd();
-  let worktreeBranch = preferredCodebase?.branch;
+  const initialWorktreeTruth = await resolveTaskWorktreeTruth(nextTask, system);
+  const preferredCodebase = initialWorktreeTruth?.codebase;
+  let worktreeCwd = initialWorktreeTruth?.cwd ?? process.cwd();
+  let worktreeBranch = initialWorktreeTruth?.branch;
   if (params.expectedColumnId === "dev" && preferredCodebase && !nextTask.worktreeId) {
     try {
       const worktreeService = new GitWorktreeService(
@@ -187,8 +183,6 @@ async function startKanbanTaskSession(
         worktreeRoot,
       });
       nextTask.worktreeId = worktree.id;
-      worktreeCwd = worktree.worktreePath;
-      worktreeBranch = worktree.branch;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       nextTask.status = TaskStatus.BLOCKED;
@@ -197,13 +191,10 @@ async function startKanbanTaskSession(
       await system.taskStore.save(nextTask);
       return { error: nextTask.lastSyncError };
     }
-  } else if (nextTask.worktreeId) {
-    const existingWorktree = await system.worktreeStore.get(nextTask.worktreeId);
-    if (existingWorktree?.worktreePath) {
-      worktreeCwd = existingWorktree.worktreePath;
-      worktreeBranch = existingWorktree.branch ?? worktreeBranch;
-    }
   }
+  const resolvedWorktreeTruth = await resolveTaskWorktreeTruth(nextTask, system);
+  worktreeCwd = resolvedWorktreeTruth?.cwd ?? worktreeCwd;
+  worktreeBranch = resolvedWorktreeTruth?.branch ?? worktreeBranch;
 
   const effectiveAutomation = resolveEffectiveTaskAutomation(
     nextTask,
@@ -256,6 +247,7 @@ async function startKanbanTaskSession(
     const currentColumn = board?.columns.find((column) => column.id === nextTask.columnId);
     upsertTaskLaneSession(nextTask, {
       sessionId: triggerResult.sessionId,
+      worktreeId: nextTask.worktreeId,
       cwd: worktreeCwd,
       columnId: nextTask.columnId,
       columnName: currentColumn?.name,

--- a/src/core/models/task.ts
+++ b/src/core/models/task.ts
@@ -121,6 +121,7 @@ export type TaskLaneHandoffStatus =
 export interface TaskLaneSession {
   sessionId: string;
   routaAgentId?: string;
+  worktreeId?: string;
   cwd?: string;
   columnId?: string;
   columnName?: string;
@@ -155,6 +156,8 @@ export interface TaskLaneHandoff {
   toSessionId: string;
   fromColumnId?: string;
   toColumnId?: string;
+  worktreeId?: string;
+  cwd?: string;
   requestType: TaskLaneHandoffRequestType;
   request: string;
   status: TaskLaneHandoffStatus;

--- a/src/core/tools/__tests__/kanban-tools.test.ts
+++ b/src/core/tools/__tests__/kanban-tools.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createKanbanBoard } from "../../models/kanban";
-import { createTask } from "../../models/task";
+import { EventBus, AgentEventType } from "../../events/event-bus";
+import { createTask, VerificationVerdict } from "../../models/task";
 import { createInMemorySystem } from "../../routa-system";
 import { resetWorkflowOrchestrator } from "../../kanban/workflow-orchestrator-singleton";
 import { InMemoryKanbanBoardStore } from "../../store/kanban-board-store";
@@ -269,6 +270,102 @@ describe("KanbanTools", () => {
       requestType: "environment_preparation",
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns review to dev on a not-approved handoff and persists worktree context", async () => {
+    const boardStore = new InMemoryKanbanBoardStore();
+    const taskStore = new InMemoryTaskStore();
+    const tools = new KanbanTools(boardStore, taskStore);
+    const eventBus = new EventBus();
+    tools.setEventBus(eventBus);
+
+    const transitionEvents: Array<{ fromColumnId: string; toColumnId: string }> = [];
+    eventBus.on("test-review-return", (event) => {
+      if (event.type === AgentEventType.COLUMN_TRANSITION) {
+        transitionEvents.push(event.data as { fromColumnId: string; toColumnId: string });
+      }
+    });
+
+    const board = createKanbanBoard({
+      id: "board-1",
+      workspaceId: "default",
+      name: "Default Board",
+      isDefault: true,
+      columns: [
+        { id: "backlog", name: "Backlog", position: 0, stage: "backlog" },
+        { id: "dev", name: "Dev", position: 1, stage: "dev" },
+        { id: "review", name: "Review", position: 2, stage: "review" },
+      ],
+    });
+    await boardStore.save(board);
+
+    const task = createTask({
+      id: "task-review-return",
+      title: "Review returns to dev",
+      objective: "Keep the original worktree on re-entry",
+      workspaceId: "default",
+      boardId: board.id,
+      columnId: "review",
+      worktreeId: "wt-1",
+    });
+    task.verificationVerdict = VerificationVerdict.NOT_APPROVED;
+    task.triggerSessionId = "session-review-1";
+    task.laneSessions = [
+      {
+        sessionId: "session-dev-1",
+        worktreeId: "wt-1",
+        cwd: "/tmp/worktrees/task-review-return",
+        columnId: "dev",
+        columnName: "Dev",
+        provider: "opencode",
+        role: "DEVELOPER",
+        status: "completed",
+        startedAt: "2026-03-17T00:00:00.000Z",
+      },
+      {
+        sessionId: "session-review-1",
+        columnId: "review",
+        columnName: "Review",
+        provider: "opencode",
+        role: "GATE",
+        status: "running",
+        startedAt: "2026-03-17T00:10:00.000Z",
+      },
+    ];
+    await taskStore.save(task);
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ result: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+    const result = await tools.requestPreviousLaneHandoff({
+      taskId: task.id,
+      requestType: "runtime_context",
+      request: "Reuse the existing app process and share the URL.",
+      sessionId: "session-review-1",
+    });
+
+    expect(result.success).toBe(true);
+    const savedTask = await taskStore.get(task.id);
+    expect(savedTask).toMatchObject({
+      columnId: "dev",
+      status: "IN_PROGRESS",
+      worktreeId: "wt-1",
+      triggerSessionId: undefined,
+    });
+    expect(savedTask?.laneHandoffs[0]).toMatchObject({
+      status: "delivered",
+      worktreeId: "wt-1",
+      cwd: "/tmp/worktrees/task-review-return",
+      toColumnId: "dev",
+    });
+    expect(transitionEvents).toEqual([
+      expect.objectContaining({
+        fromColumnId: "review",
+        toColumnId: "dev",
+      }),
+    ]);
   });
 
   it("submits a lane handoff response back to the requesting session", async () => {

--- a/src/core/tools/kanban-tools.ts
+++ b/src/core/tools/kanban-tools.ts
@@ -71,6 +71,7 @@ import {
   countContractGateFailures,
   resolveCurrentOrNextContractGate,
 } from "../kanban/task-contract-readiness";
+import { resolveTaskWorktreeTruth } from "../kanban/task-worktree-truth";
 
 const DESCRIPTION_FROZEN_STAGES = new Set<KanbanColumnStage>(["dev", "review", "blocked", "done"]);
 
@@ -249,7 +250,10 @@ export class KanbanTools {
 
     const fromColumnId = task.columnId ?? "backlog";
     const fromColumn = board.columns.find((c) => c.id === fromColumnId);
-    if (fromColumnId !== params.targetColumnId && task.triggerSessionId) {
+    const allowReviewFallbackToDev = fromColumnId === "review"
+      && params.targetColumnId === "dev"
+      && task.verificationVerdict === "NOT_APPROVED";
+    if (fromColumnId !== params.targetColumnId && task.triggerSessionId && !allowReviewFallbackToDev) {
       const laneAutomationState = resolveCurrentLaneAutomationState(task, board.columns, {
         currentSessionId: task.triggerSessionId,
       });
@@ -464,6 +468,10 @@ export class KanbanTools {
     if (!previousLaneSession?.sessionId) {
       return errorResult(`No previous lane session found for card ${params.taskId}`);
     }
+    const taskWorktreeTruth = this.automationSystem
+      ? await resolveTaskWorktreeTruth(task, this.automationSystem)
+      : null;
+    const targetCwd = previousLaneSession.cwd ?? taskWorktreeTruth?.cwd ?? currentLaneSession?.cwd;
 
     const handoff = createTaskLaneHandoff({
       id: uuidv4(),
@@ -471,11 +479,47 @@ export class KanbanTools {
       toSessionId: previousLaneSession.sessionId,
       fromColumnId: currentLaneSession?.columnId ?? task.columnId,
       toColumnId: previousLaneSession.columnId,
+      worktreeId: task.worktreeId,
+      cwd: targetCwd,
       requestType: params.requestType,
       request: params.request,
     });
     upsertTaskLaneHandoff(task, handoff);
+    const shouldReturnToPreviousLane = task.columnId === "review"
+      && task.verificationVerdict === "NOT_APPROVED"
+      && previousLaneSession.columnId
+      && previousLaneSession.columnId !== task.columnId;
+    const previousColumn = shouldReturnToPreviousLane
+      ? board.columns.find((column) => column.id === previousLaneSession.columnId)
+      : undefined;
+    if (shouldReturnToPreviousLane && previousLaneSession.columnId) {
+      if (task.triggerSessionId) {
+        if (!task.sessionIds.includes(task.triggerSessionId)) {
+          task.sessionIds.push(task.triggerSessionId);
+        }
+        markTaskLaneSessionStatus(task, task.triggerSessionId, "transitioned");
+        task.triggerSessionId = undefined;
+      }
+      task.columnId = previousLaneSession.columnId;
+      task.status = columnIdToTaskStatus(previousLaneSession.columnId);
+      task.updatedAt = new Date();
+    }
     await this.taskStore.save(task);
+    if (shouldReturnToPreviousLane && previousLaneSession.columnId) {
+      this.notifyWorkspaceChanged(task.workspaceId, "task", "moved", task.id);
+      if (this.eventBus) {
+        emitColumnTransition(this.eventBus, {
+          cardId: task.id,
+          cardTitle: task.title,
+          boardId: task.boardId,
+          workspaceId: task.workspaceId,
+          fromColumnId: "review",
+          toColumnId: previousLaneSession.columnId,
+          fromColumnName: board.columns.find((column) => column.id === "review")?.name,
+          toColumnName: previousColumn?.name,
+        });
+      }
+    }
 
     try {
       await this.promptSession(
@@ -488,6 +532,8 @@ export class KanbanTools {
           request: params.request,
           requestingColumnId: handoff.fromColumnId,
           requestingSessionId: params.sessionId,
+          worktreeId: handoff.worktreeId,
+          cwd: handoff.cwd,
         }),
       );
       handoff.status = "delivered";
@@ -863,6 +909,8 @@ export class KanbanTools {
     request: string;
     requestingColumnId?: string;
     requestingSessionId: string;
+    worktreeId?: string;
+    cwd?: string;
   }): string {
     return [
       `You have received a lane handoff request for card ${params.task.id}: ${params.task.title}.`,
@@ -870,6 +918,8 @@ export class KanbanTools {
       `Requesting lane: ${params.requestingColumnId ?? "unknown"}`,
       `Request type: ${this.formatHandoffRequestType(params.requestType)}`,
       `Request: ${params.request}`,
+      params.worktreeId ? `Task worktreeId: ${params.worktreeId}` : undefined,
+      params.cwd ? `Task cwd: ${params.cwd}` : undefined,
       "",
       "Complete only the requested support work for this card.",
       "If runtime setup or environment preparation is needed, perform it in this session.",
@@ -889,6 +939,8 @@ export class KanbanTools {
       `Request type: ${this.formatHandoffRequestType(handoff.requestType)}`,
       `Status: ${handoff.status}`,
       `Original request: ${handoff.request}`,
+      handoff.worktreeId ? `Task worktreeId: ${handoff.worktreeId}` : undefined,
+      handoff.cwd ? `Task cwd: ${handoff.cwd}` : undefined,
       handoff.responseSummary ? `Response: ${handoff.responseSummary}` : "Response: no summary provided",
       "",
       "Continue your current lane work using this updated runtime context.",


### PR DESCRIPTION
## Summary
- make `task.worktreeId` the canonical worktree source when resolving lane cwd and delivery repo paths
- reuse the same worktree across dev retries and review-to-dev returns
- carry worktree context through previous-lane handoffs so review feedback can reopen dev without stale lane-state guards blocking the move

## Why
During Litrader trial runs, cards that were returned from `Review` to `Dev` could lose their real worktree truth or get blocked by stale in-lane session state. That made delivery-readiness and re-entry behavior diverge from the actual code workspace.

## Changes
- add `task-worktree-truth` helpers to resolve canonical worktree/cwd truth
- update task route and workflow orchestration to preserve worktree assignment across lane re-entry
- update kanban handoff handling so `NOT_APPROVED` review feedback can return to `Dev` with the original worktree context intact
- add regression tests for review return and task route behavior

## Verification
- `pnpm exec vitest run 'src/app/api/tasks/[taskId]/__tests__/route.test.ts' src/core/tools/__tests__/kanban-tools.test.ts`

## Notes
- commit includes `Co-authored-by: Codex Agent (GPT 5.4) <codex-agent@openai.com>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed task retry logic to properly reuse existing worktrees instead of creating duplicates.
  * Improved handling of rejected review tasks to return to development with preserved worktree context.

* **Tests**
  * Added comprehensive test coverage for task retry scenarios and review-to-dev transitions.
  * Enhanced verification verdict workflow testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->