### PR TITLE
fix: advance review lane after QA writes its verdict

### DIFF
--- a/src/core/tools/__tests__/agent-tools.test.ts
+++ b/src/core/tools/__tests__/agent-tools.test.ts
@@ -4,10 +4,11 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { AgentTools } from "../agent-tools";
-import { EventBus } from "../../events/event-bus";
+import { AgentEventType, EventBus } from "../../events/event-bus";
 import { InMemoryAgentStore } from "../../store/agent-store";
 import { InMemoryConversationStore } from "../../store/conversation-store";
 import { InMemoryTaskStore } from "../../store/task-store";
+import { createTask } from "../../models/task";
 
 describe("AgentTools.createTask", () => {
   let tools: AgentTools;
@@ -36,5 +37,112 @@ describe("AgentTools.createTask", () => {
     const taskId = (result.data as { taskId: string }).taskId;
     const task = await taskStore.get(taskId);
     expect(task?.creationSource).toBe("session");
+  });
+});
+
+describe("AgentTools.updateTask synthetic completion", () => {
+  let tools: AgentTools;
+  let taskStore: InMemoryTaskStore;
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    eventBus = new EventBus();
+    tools = new AgentTools(
+      new InMemoryAgentStore(),
+      new InMemoryConversationStore(),
+      taskStore,
+      eventBus,
+    );
+  });
+
+  it("emits AGENT_COMPLETED when a running review gate writes verdict and report", async () => {
+    const task = createTask({
+      id: "task-review",
+      title: "Review task",
+      objective: "Allow review guard to continue",
+      workspaceId: "workspace-1",
+      columnId: "review",
+    });
+    task.laneSessions = [{
+      sessionId: "session-review-1",
+      columnId: "review",
+      columnName: "Review",
+      provider: "codex",
+      role: "GATE",
+      status: "running",
+      stepId: "qa-frontend",
+      stepIndex: 0,
+      stepName: "QA Frontend",
+      startedAt: new Date().toISOString(),
+    }];
+    await taskStore.save(task);
+
+    const events: AgentEventType[] = [];
+    let completionPayload: Record<string, unknown> | undefined;
+    eventBus.on("capture", (event) => {
+      events.push(event.type);
+      if (event.type === AgentEventType.AGENT_COMPLETED) {
+        completionPayload = event.data;
+      }
+    });
+
+    const result = await tools.updateTask({
+      taskId: task.id,
+      updates: {
+        verificationVerdict: "APPROVED",
+        verificationReport: "QA passed with screenshot and test results.",
+      },
+      agentId: "session-review-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(events).toContain(AgentEventType.AGENT_COMPLETED);
+    expect(completionPayload).toMatchObject({
+      sessionId: "session-review-1",
+      success: true,
+      synthesizedBy: "updateTask",
+      trigger: "verification_report",
+      taskId: task.id,
+    });
+  });
+
+  it("does not emit AGENT_COMPLETED when a non-review running session only writes a verdict", async () => {
+    const task = createTask({
+      id: "task-dev",
+      title: "Dev task",
+      objective: "Do not synthesize unrelated completion",
+      workspaceId: "workspace-1",
+      columnId: "dev",
+    });
+    task.laneSessions = [{
+      sessionId: "session-dev-1",
+      columnId: "dev",
+      columnName: "Dev",
+      provider: "codex",
+      role: "CRAFTER",
+      status: "running",
+      stepId: "dev-executor",
+      stepIndex: 0,
+      stepName: "Dev Crafter",
+      startedAt: new Date().toISOString(),
+    }];
+    await taskStore.save(task);
+
+    const events: AgentEventType[] = [];
+    eventBus.on("capture", (event) => {
+      events.push(event.type);
+    });
+
+    const result = await tools.updateTask({
+      taskId: task.id,
+      updates: {
+        verificationVerdict: "APPROVED",
+      },
+      agentId: "session-dev-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(events).not.toContain(AgentEventType.AGENT_COMPLETED);
   });
 });

--- a/src/core/tools/agent-tools.ts
+++ b/src/core/tools/agent-tools.ts
@@ -51,6 +51,7 @@ import {
   PermissionRequestOptions,
   PermissionUrgency,
 } from './permission-store';
+import { getTaskLaneSession } from "../kanban/task-lane-history";
 
 function extractSandboxId(options?: PermissionRequestOptions): string | undefined {
   const sandboxId = options?.sandboxId;
@@ -94,6 +95,50 @@ function notifyKanbanArtifactChanged(workspaceId: string, taskId: string): void 
     resourceId: taskId,
     source: "agent",
   });
+}
+
+function shouldEmitSyntheticCompletion(params: {
+  task: Task;
+  agentId: string;
+  updates: {
+    completionSummary?: string;
+    verificationVerdict?: string;
+    verificationReport?: string;
+  };
+}): boolean {
+  const { task, agentId, updates } = params;
+  const laneSession = getTaskLaneSession(task, agentId);
+  if (!laneSession || laneSession.status !== "running") {
+    return false;
+  }
+  if (laneSession.columnId !== task.columnId) {
+    return false;
+  }
+
+  if (
+    laneSession.completionRequirement === "completion_summary"
+    && updates.completionSummary?.trim()
+  ) {
+    return true;
+  }
+
+  if (
+    laneSession.completionRequirement === "verification_report"
+    && updates.verificationReport?.trim()
+  ) {
+    return true;
+  }
+
+  if (
+    laneSession.columnId === "review"
+    && laneSession.role === "GATE"
+    && updates.verificationVerdict
+    && updates.verificationReport?.trim()
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 export class AgentTools {
@@ -808,6 +853,22 @@ export class AgentTools {
     task.updatedAt = new Date();
 
     await this.taskStore.save(task);
+
+    if (shouldEmitSyntheticCompletion({ task, agentId, updates })) {
+      this.eventBus.emit({
+        type: AgentEventType.AGENT_COMPLETED,
+        agentId,
+        workspaceId: task.workspaceId,
+        data: {
+          sessionId: agentId,
+          success: true,
+          synthesizedBy: "updateTask",
+          trigger: updates.verificationReport !== undefined ? "verification_report" : "completion_summary",
+          taskId,
+        },
+        timestamp: new Date(),
+      });
+    }
 
     // Emit events if status changed
     if (updates.status && oldStatus !== task.status) {


### PR DESCRIPTION
## Summary
- synthesize a completion event when a running review gate session writes both `verificationVerdict` and `verificationReport`
- allow the next review lane step to start instead of leaving `QA Frontend` stuck in `running`
- add regression coverage for the new completion behavior

## Why
During live Litrader trials, review cards could remain stuck in `Review` even after `QA Frontend` had already written its verdict and report. The root cause was that `updateTask` persisted the review result but did not emit a completion signal for the current lane step, so `Review Guard` never took over.

## Changes
- detect when `updateTask` satisfies the current lane session's completion requirement
- emit a synthetic `AGENT_COMPLETED` event for that running review gate session
- add regression tests covering the review case and a non-review negative case

## Verification
- `pnpm exec vitest run src/core/tools/__tests__/agent-tools.test.ts src/core/tools/__tests__/kanban-tools.test.ts`

## Notes
- verified on the main working copy before branch split because the isolated worktree does not inherit the full `vitest` toolchain wiring
- commit includes `Co-authored-by: Codex Agent (GPT 5.4) <codex-agent@openai.com>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now automatically emit completion events when review gates are updated with both verification verdicts and reports.

* **Tests**
  * Added test coverage for synthetic completion event emission behavior during task updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->