### PR TITLE
fix: keep ACP sessions recoverable after prompt timeouts

### DIFF
--- a/src/core/acp/__tests__/http-session-store-acp-status.test.ts
+++ b/src/core/acp/__tests__/http-session-store-acp-status.test.ts
@@ -227,6 +227,31 @@ describe("HttpSessionStore — ACP status", () => {
     expect((statusNotification?.update as Record<string, unknown>)?.status).toBe("error");
   });
 
+  it("recovers a timeout-marked ACP session when later activity arrives", () => {
+    const store = getHttpSessionStore();
+    store.upsertSession({
+      sessionId: "test-timeout-recovery",
+      cwd: "/tmp",
+      workspaceId: "ws-1",
+      provider: "codex",
+      acpStatus: "error",
+      acpError: "Timeout waiting for session/prompt (id=3)",
+      createdAt: new Date().toISOString(),
+    });
+
+    store.pushNotification({
+      sessionId: "test-timeout-recovery",
+      update: {
+        sessionUpdate: "agent_message",
+        content: { type: "text", text: "still working" },
+      },
+    });
+
+    const session = store.getSession("test-timeout-recovery");
+    expect(session?.acpStatus).toBe("ready");
+    expect(session?.acpError).toBeUndefined();
+  });
+
   it("appends pushed notifications to the local event log", async () => {
     const store = getHttpSessionStore();
     const projectPath = path.join(process.env.HOME!, "project");

--- a/src/core/acp/__tests__/session-prompt.test.ts
+++ b/src/core/acp/__tests__/session-prompt.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { isSessionPromptTimeoutError } from "../session-prompt";
+
+describe("isSessionPromptTimeoutError", () => {
+  it("detects session/prompt timeout errors", () => {
+    expect(isSessionPromptTimeoutError(new Error("Timeout waiting for session/prompt (id=3)"))).toBe(true);
+  });
+
+  it("ignores non-timeout prompt errors", () => {
+    expect(isSessionPromptTimeoutError(new Error("Permission denied"))).toBe(false);
+    expect(isSessionPromptTimeoutError("Timeout waiting for session/prompt (id=3)")).toBe(false);
+  });
+});

--- a/src/core/acp/http-session-store.ts
+++ b/src/core/acp/http-session-store.ts
@@ -82,6 +82,21 @@ export interface RoutaSessionActivity {
   terminalAt?: string;
 }
 
+function isRecoverablePromptTimeoutStatus(
+  session: RoutaSessionRecord | undefined,
+): boolean {
+  return session?.acpStatus === "error"
+    && typeof session.acpError === "string"
+    && session.acpError.includes("Timeout waiting for session/prompt");
+}
+
+function isExplicitErrorNotification(notification: SessionUpdateNotification): boolean {
+  const update = notification.update as Record<string, unknown> | undefined;
+  return update?.sessionUpdate === "error"
+    || update?.sessionUpdate === "acp_status"
+    || (notification as Record<string, unknown>).type === "error";
+}
+
 /**
  * Consolidates consecutive agent_message_chunk notifications into a single message.
  * This reduces storage overhead from hundreds of small chunks to a single entry.
@@ -461,6 +476,11 @@ class HttpSessionStore {
     const enriched = ensureNotificationEventId(notification);
     const sessionId = enriched.sessionId;
     this.updateAccessTime(sessionId);
+
+    const currentSession = this.sessions.get(sessionId);
+    if (isRecoverablePromptTimeoutStatus(currentSession) && !isExplicitErrorNotification(enriched)) {
+      this.updateSessionAcpStatus(sessionId, "ready");
+    }
 
     // Child agent notifications (with childAgentId) are forwarded to the parent
     // session's SSE for real-time CRAFTER progress but should NOT be stored in

--- a/src/core/acp/session-prompt.ts
+++ b/src/core/acp/session-prompt.ts
@@ -130,6 +130,13 @@ function markSessionPromptError(
   return message;
 }
 
+export function isSessionPromptTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.includes("Timeout waiting for session/prompt");
+}
+
 function getPromptErrorData(error: unknown): Record<string, unknown> | undefined {
   if (isAcpErrorLike(error)) {
     return {
@@ -667,6 +674,17 @@ export async function handleSessionPrompt({
           await persistSessionHistorySnapshot(sessionId, store);
           controller.close();
         } catch (err) {
+          if (isSessionPromptTimeoutError(err)) {
+            console.warn(
+              `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+              err,
+            );
+            store.flushAgentBuffer(sessionId);
+            store.exitStreamingMode(sessionId);
+            await persistSessionHistorySnapshot(sessionId, store);
+            controller.close();
+            return;
+          }
           const message = markSessionPromptError(store, sessionId, err, "OpenCode SDK prompt failed");
           store.flushAgentBuffer(sessionId);
           store.exitStreamingMode(sessionId);
@@ -720,6 +738,17 @@ export async function handleSessionPrompt({
           await persistSessionHistorySnapshot(sessionId, store);
           controller.close();
         } catch (err) {
+          if (isSessionPromptTimeoutError(err)) {
+            console.warn(
+              `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+              err,
+            );
+            store.flushAgentBuffer(sessionId);
+            store.exitStreamingMode(sessionId);
+            await persistSessionHistorySnapshot(sessionId, store);
+            controller.close();
+            return;
+          }
           const message = markSessionPromptError(store, sessionId, err, "Docker OpenCode prompt failed");
           store.flushAgentBuffer(sessionId);
           store.exitStreamingMode(sessionId);
@@ -772,6 +801,17 @@ export async function handleSessionPrompt({
           await persistSessionHistorySnapshot(sessionId, store);
           controller.close();
         } catch (err) {
+          if (isSessionPromptTimeoutError(err)) {
+            console.warn(
+              `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+              err,
+            );
+            store.flushAgentBuffer(sessionId);
+            store.exitStreamingMode(sessionId);
+            await persistSessionHistorySnapshot(sessionId, store);
+            controller.close();
+            return;
+          }
           const message = markSessionPromptError(store, sessionId, err, "Claude Code SDK prompt failed");
           store.flushAgentBuffer(sessionId);
           store.exitStreamingMode(sessionId);
@@ -859,6 +899,15 @@ export async function handleSessionPrompt({
         void persistSessionHistorySnapshot(sessionId, store);
         return jsonrpcResponse(id ?? null, result);
       } catch (err) {
+        if (isSessionPromptTimeoutError(err)) {
+          console.warn(
+            `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+            err,
+          );
+          store.flushAgentBuffer(sessionId);
+          void persistSessionHistorySnapshot(sessionId, store);
+          return jsonrpcResponse(id ?? null, { sessionId, pending: true });
+        }
         const message = markSessionPromptError(store, sessionId, err, "Claude Code prompt failed after restart");
         store.flushAgentBuffer(sessionId);
         void persistSessionHistorySnapshot(sessionId, store);
@@ -876,6 +925,15 @@ export async function handleSessionPrompt({
       void persistSessionHistorySnapshot(sessionId, store);
       return jsonrpcResponse(id ?? null, result);
     } catch (err) {
+      if (isSessionPromptTimeoutError(err)) {
+        console.warn(
+          `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+          err,
+        );
+        store.flushAgentBuffer(sessionId);
+        void persistSessionHistorySnapshot(sessionId, store);
+        return jsonrpcResponse(id ?? null, { sessionId, pending: true });
+      }
       const message = markSessionPromptError(store, sessionId, err, "Claude Code prompt failed");
       store.flushAgentBuffer(sessionId);
       void persistSessionHistorySnapshot(sessionId, store);
@@ -911,6 +969,15 @@ export async function handleSessionPrompt({
     void persistSessionHistorySnapshot(sessionId, store);
     return jsonrpcResponse(id ?? null, result);
   } catch (err) {
+    if (isSessionPromptTimeoutError(err)) {
+      console.warn(
+        `[ACP Route] session/prompt timed out while waiting for ${sessionId}; keeping ACP session alive for continued lifecycle updates.`,
+        err,
+      );
+      store.flushAgentBuffer(sessionId);
+      void persistSessionHistorySnapshot(sessionId, store);
+      return jsonrpcResponse(id ?? null, { sessionId, pending: true });
+    }
     const message = markSessionPromptError(store, sessionId, err, "Prompt failed");
     store.flushAgentBuffer(sessionId);
     void persistSessionHistorySnapshot(sessionId, store);


### PR DESCRIPTION
## Summary
- stop turning prompt timeout responses into terminal ACP session failures
- restore timeout-marked sessions to `ready` if later non-error activity arrives
- add regression coverage for timeout detection and ACP status recovery

## Why
During live runs, `session/prompt` could time out while the underlying agent session was still alive and continued sending activity. Routa recorded those cases as permanent ACP errors, which polluted run status and made healthy sessions look dead.

## Changes
- add `isSessionPromptTimeoutError` helper
- treat prompt timeout as a non-terminal condition in `session-prompt`
- recover an ACP session from timeout-marked error state when later activity arrives in `http-session-store`
- add regression tests for timeout detection and ACP status recovery

## Verification
- `pnpm exec vitest run src/core/acp/__tests__/http-session-store-acp-status.test.ts src/core/acp/__tests__/session-prompt.test.ts`

## Notes
- commit includes `Co-authored-by: Codex Agent (GPT 5.4) <codex-agent@openai.com>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery from timeout errors. Sessions experiencing prompt timeouts can now automatically transition back to a ready state when new activity is detected, enhancing reliability and reducing manual reconnection needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->