### PR TITLE
fix: initialize sqlite worktrees and tolerate missing-table reads

### DIFF
--- a/src/app/api/tasks/__tests__/route.test.ts
+++ b/src/app/api/tasks/__tests__/route.test.ts
@@ -181,6 +181,22 @@ describe("/api/tasks GET", () => {
     });
   });
 
+  it("degrades gracefully when the sqlite worktrees table is missing", async () => {
+    system.worktreeStore.listByWorkspace.mockRejectedValueOnce(
+      new Error("SqliteError: no such table: worktrees"),
+    );
+
+    const response = await GET(new NextRequest("http://localhost/api/tasks?workspaceId=workspace-1"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.tasks).toHaveLength(1);
+    expect(data.tasks[0]).toMatchObject({
+      id: "task-1",
+      title: "Artifact summary",
+    });
+  });
+
   it("rejects task listing without workspaceId", async () => {
     const response = await GET(new NextRequest("http://localhost/api/tasks"));
     const data = await response.json();

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -63,6 +63,24 @@ function cachePromise<K, V>(cache: Map<K, Promise<V>>, key: K, load: () => Promi
   return promise;
 }
 
+function isMissingSqliteWorktreesTable(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("no such table: worktrees");
+}
+
+async function listWorktreesSafely(
+  system: RoutaSystem,
+  workspaceId: string,
+): Promise<Awaited<ReturnType<WorktreeStore["listByWorkspace"]>>> {
+  try {
+    return await system.worktreeStore.listByWorkspace(workspaceId);
+  } catch (error) {
+    if (isMissingSqliteWorktreesTable(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 async function createTaskSerializationSystem(
   system: RoutaSystem,
   workspaceId: string,
@@ -70,7 +88,7 @@ async function createTaskSerializationSystem(
 ): Promise<TaskSerializationSystem> {
   const [codebases, worktrees, artifacts] = await Promise.all([
     system.codebaseStore.listByWorkspace(workspaceId),
-    system.worktreeStore.listByWorkspace(workspaceId),
+    listWorktreesSafely(system, workspaceId),
     typeof system.artifactStore.listByWorkspace === "function"
       ? system.artifactStore.listByWorkspace(workspaceId)
       : Promise.resolve([]),

--- a/src/core/db/__tests__/sqlite.test.ts
+++ b/src/core/db/__tests__/sqlite.test.ts
@@ -1,6 +1,9 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
 import BetterSqlite3 from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ensureSqliteDefaultWorkspace } from "../sqlite";
+import { ensureSqliteDefaultWorkspace, getSqliteDatabase } from "../sqlite";
 
 describe("ensureSqliteDefaultWorkspace", () => {
   let sqlite: BetterSqlite3.Database;
@@ -56,5 +59,29 @@ describe("ensureSqliteDefaultWorkspace", () => {
 
     expect(row.title).toBe("Existing Default");
     expect(JSON.parse(row.metadata)).toEqual({ keep: true });
+  });
+
+  it("initializes the worktrees table for local sqlite databases", () => {
+    const dbPath = path.join(os.tmpdir(), `routa-sqlite-init-${Date.now()}.db`);
+    const g = globalThis as Record<string, unknown>;
+    delete g.__routa_sqlite_db__;
+    delete g.__routa_sqlite_raw__;
+
+    try {
+      getSqliteDatabase(dbPath);
+      const raw = new BetterSqlite3(dbPath, { readonly: true });
+      const row = raw.prepare(`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'worktrees'
+      `).get() as { name: string } | undefined;
+      raw.close();
+
+      expect(row).toEqual({ name: "worktrees" });
+    } finally {
+      delete g.__routa_sqlite_db__;
+      delete g.__routa_sqlite_raw__;
+      if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    }
   });
 });

--- a/src/core/db/sqlite.ts
+++ b/src/core/db/sqlite.ts
@@ -350,6 +350,31 @@ function initializeSqliteTables(db: SqliteDatabase): void {
   try { db.run(sql`ALTER TABLE codebases ADD COLUMN source_url TEXT`); } catch { /* column already exists */ }
 
   db.run(sql`
+    CREATE TABLE IF NOT EXISTS worktrees (
+      id TEXT PRIMARY KEY,
+      codebase_id TEXT NOT NULL REFERENCES codebases(id) ON DELETE CASCADE,
+      workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+      worktree_path TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      base_branch TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'creating',
+      session_id TEXT,
+      label TEXT,
+      error_message TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
+    )
+  `);
+  db.run(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_codebase_branch
+    ON worktrees (codebase_id, branch)
+  `);
+  db.run(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_path
+    ON worktrees (worktree_path)
+  `);
+
+  db.run(sql`
     CREATE TABLE IF NOT EXISTS kanban_boards (
       id TEXT PRIMARY KEY,
       workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- create the `worktrees` table and indexes during local sqlite bootstrap
- let `/api/tasks` degrade gracefully when a legacy sqlite database still lacks the `worktrees` table
- add regression coverage for both bootstrap and route behavior

## Why
During local trial runs, a fresh or older sqlite database could miss the `worktrees` table. That broke Todo -> Dev worktree creation and could also make `/api/tasks` fail hard instead of continuing to serialize tasks.

## Changes
- add `worktrees` table creation to sqlite initialization
- add a safe `listWorktreesSafely` path for task serialization when the table is missing
- add regression tests for sqlite bootstrap and `/api/tasks` graceful degradation

## Verification
- `pnpm exec vitest run src/core/db/__tests__/sqlite.test.ts src/app/api/tasks/__tests__/route.test.ts`

## Notes
- commit includes `Co-authored-by: Codex Agent (GPT 5.4) <codex-agent@openai.com>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved system resilience: the application now gracefully handles missing database tables instead of failing, allowing task operations to proceed with fallback behavior

* **Tests**
  * Added test coverage for database table initialization
  * Added test coverage validating graceful error recovery when database tables are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->