### PR TITLE
fix: align scheduler tick origin and embedded run failure truth

### DIFF
--- a/src/app/api/tasks/[taskId]/runs/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/runs/__tests__/route.test.ts
@@ -131,6 +131,50 @@ describe("/api/tasks/[taskId]/runs", () => {
     ]);
   });
 
+  it("treats a running lane session as failed when the linked ACP session is already in error", async () => {
+    const task = createTask({
+      id: "task-2",
+      title: "Surface session error state",
+      objective: "Reflect ACP failure in the run ledger",
+      workspaceId: "workspace-1",
+    });
+    task.laneSessions = [
+      {
+        sessionId: "session-stuck-running",
+        columnId: "review",
+        transport: "acp",
+        status: "running",
+        startedAt: "2026-03-27T09:00:00.000Z",
+      },
+    ];
+
+    taskStore.get.mockResolvedValue(task);
+    getSession.mockReturnValue({
+      sessionId: "session-stuck-running",
+      cwd: "/tmp/repo",
+      workspaceId: "workspace-1",
+      provider: "codex",
+      createdAt: "2026-03-27T09:00:00.000Z",
+      executionMode: "embedded",
+      acpStatus: "error",
+      acpError: "Prompt failed",
+    });
+
+    const response = await GET(new NextRequest("http://localhost/api/tasks/task-2/runs"), {
+      params: Promise.resolve({ taskId: "task-2" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.runs).toEqual([
+      expect.objectContaining({
+        id: "session-stuck-running",
+        kind: "embedded_acp",
+        status: "failed",
+      }),
+    ]);
+  });
+
   it("returns 404 when the task does not exist", async () => {
     taskStore.get.mockResolvedValue(null);
 

--- a/src/core/scheduling/__tests__/scheduler-service.test.ts
+++ b/src/core/scheduling/__tests__/scheduler-service.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveSchedulerTickUrl } from "../scheduler-service";
+
+const ORIGINAL_ENV = {
+  PORT: process.env.PORT,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  ROUTA_INTERNAL_API_ORIGIN: process.env.ROUTA_INTERNAL_API_ORIGIN,
+  ROUTA_BASE_URL: process.env.ROUTA_BASE_URL,
+  VERCEL_URL: process.env.VERCEL_URL,
+};
+
+describe("resolveSchedulerTickUrl", () => {
+  afterEach(() => {
+    process.env.PORT = ORIGINAL_ENV.PORT;
+    process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_ENV.NEXT_PUBLIC_APP_URL;
+    process.env.ROUTA_INTERNAL_API_ORIGIN = ORIGINAL_ENV.ROUTA_INTERNAL_API_ORIGIN;
+    process.env.ROUTA_BASE_URL = ORIGINAL_ENV.ROUTA_BASE_URL;
+    process.env.VERCEL_URL = ORIGINAL_ENV.VERCEL_URL;
+  });
+
+  it("uses the current local PORT when no explicit origin is configured", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.ROUTA_INTERNAL_API_ORIGIN;
+    delete process.env.ROUTA_BASE_URL;
+    delete process.env.VERCEL_URL;
+    process.env.PORT = "3500";
+
+    expect(resolveSchedulerTickUrl()).toBe("http://127.0.0.1:3500/api/schedules/tick");
+  });
+
+  it("prefers explicit internal origin when provided", () => {
+    process.env.ROUTA_INTERNAL_API_ORIGIN = "http://100.71.239.88:3500/";
+    process.env.PORT = "3000";
+
+    expect(resolveSchedulerTickUrl()).toBe("http://100.71.239.88:3500/api/schedules/tick");
+  });
+});

--- a/src/core/scheduling/scheduler-service.ts
+++ b/src/core/scheduling/scheduler-service.ts
@@ -15,10 +15,20 @@ import { runWithSpan } from "../telemetry/tracing";
 let schedulerTask: ScheduledTask | null = null;
 let isStarted = false;
 
-const TICK_URL =
-  process.env.NEXT_PUBLIC_APP_URL
-    ? `${process.env.NEXT_PUBLIC_APP_URL}/api/schedules/tick`
-    : "http://localhost:3000/api/schedules/tick";
+export function resolveSchedulerTickUrl(): string {
+  const configuredOrigin =
+    process.env.ROUTA_INTERNAL_API_ORIGIN
+    ?? process.env.ROUTA_BASE_URL
+    ?? process.env.NEXT_PUBLIC_APP_URL
+    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+
+  if (configuredOrigin) {
+    return `${configuredOrigin.replace(/\/$/, "")}/api/schedules/tick`;
+  }
+
+  const port = process.env.PORT ?? "3000";
+  return `http://127.0.0.1:${port}/api/schedules/tick`;
+}
 
 export function startSchedulerService(): void {
   if (isStarted) return;
@@ -32,17 +42,18 @@ export function startSchedulerService(): void {
   }
 
   console.log("[Scheduler] Starting in-process cron scheduler (every minute)");
+  const tickUrl = resolveSchedulerTickUrl();
 
   schedulerTask = nodeCron.schedule("* * * * *", () => {
     void runWithSpan(
       "routa.scheduler.tick_cycle",
       {
         attributes: {
-          "routa.scheduler.tick_url": TICK_URL,
+          "routa.scheduler.tick_url": tickUrl,
         },
       },
       async (span) => {
-        const resp = await fetch(TICK_URL, { method: "POST" });
+        const resp = await fetch(tickUrl, { method: "POST" });
         span.setAttribute("http.response.status_code", resp.status);
 
         if (!resp.ok) {

--- a/src/core/task-run-ledger.ts
+++ b/src/core/task-run-ledger.ts
@@ -51,6 +51,13 @@ function resolveStatus(
   laneSession: TaskLaneSession,
   session?: SessionLookup,
 ): TaskRunStatus {
+  if (
+    session?.acpStatus === "error"
+    && (!laneSession.status || laneSession.status === "running")
+  ) {
+    return "failed";
+  }
+
   if (laneSession.status) {
     return laneSession.status;
   }


### PR DESCRIPTION
## Summary
- derive the in-process scheduler tick URL from the actual local Routa origin instead of hardcoding `localhost:3000`
- surface ACP error sessions as failed embedded task runs even when the lane session record still says `running`
- add regression coverage for both behaviors

## Why
During local trial runs, the scheduler could tick the wrong origin when Routa was served on a non-default port, and task run history could keep showing `running` even after the linked ACP session was already in error. Both issues made runtime truth harder to trust.

## Changes
- add `resolveSchedulerTickUrl()` with support for `ROUTA_INTERNAL_API_ORIGIN`, `ROUTA_BASE_URL`, `NEXT_PUBLIC_APP_URL`, `VERCEL_URL`, or local `PORT`
- use the resolved URL in the in-process scheduler service
- update embedded task run status resolution to treat ACP `error` sessions as failed
- add regression tests for scheduler URL resolution and task run failure truth

## Verification
- `pnpm exec vitest run src/core/scheduling/__tests__/scheduler-service.test.ts 'src/app/api/tasks/[taskId]/runs/__tests__/route.test.ts'`

## Notes
- commit includes `Co-authored-by: Codex Agent (GPT 5.4) <codex-agent@openai.com>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task run status reporting to properly detect and normalize error states from upstream ACP sessions.

* **Tests**
  * Added test coverage for scheduler endpoint URL resolution across different environment configurations.
  * Added test coverage for error state handling in task run status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->