### PR TITLE
fix: revive review cards after stale lane sessions

### DIFF
--- a/src/app/api/kanban/boards/__tests__/route.test.ts
+++ b/src/app/api/kanban/boards/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTask, TaskStatus, type Task } from "@/core/models/task";
+import { createTask, TaskStatus, VerificationVerdict, type Task } from "@/core/models/task";
 
 const notify = vi.fn();
 const ensureDefaultBoard = vi.fn();
@@ -9,6 +9,7 @@ const getBoardSnapshot = vi.fn();
 
 const taskStore = {
   listByWorkspace: vi.fn<(_: string) => Promise<Task[]>>(),
+  save: vi.fn<(task: Task) => Promise<void>>(),
 };
 
 const boardStore = {
@@ -26,8 +27,25 @@ const system = {
   workspaceStore,
 };
 
+const sessionStore = {
+  hydrateFromDb: vi.fn<() => Promise<void>>(),
+  getSession: vi.fn(),
+};
+
+const processManager = {
+  hasActiveSession: vi.fn<(sessionId: string) => boolean>(),
+};
+
 vi.mock("@/core/routa-system", () => ({
   getRoutaSystem: () => system,
+}));
+
+vi.mock("@/core/acp/http-session-store", () => ({
+  getHttpSessionStore: () => sessionStore,
+}));
+
+vi.mock("@/core/acp/processer", () => ({
+  getAcpProcessManager: () => processManager,
 }));
 
 vi.mock("@/core/kanban/boards", () => ({
@@ -49,6 +67,10 @@ describe("/api/kanban/boards GET", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ensureDefaultBoard.mockResolvedValue(undefined);
+    taskStore.save.mockResolvedValue(undefined);
+    sessionStore.hydrateFromDb.mockResolvedValue(undefined);
+    sessionStore.getSession.mockReturnValue(undefined);
+    processManager.hasActiveSession.mockReturnValue(false);
     workspaceStore.get.mockResolvedValue({
       metadata: {
         "kanbanAutoProvider:board-1": "codex",
@@ -132,6 +154,7 @@ describe("/api/kanban/boards GET", () => {
   });
 
   it("does not re-enqueue tasks that already have lane history in the current column", async () => {
+    processManager.hasActiveSession.mockImplementation((sessionId) => sessionId === "session-1");
     taskStore.listByWorkspace.mockResolvedValue([
       {
         ...createTask({
@@ -154,6 +177,112 @@ describe("/api/kanban/boards GET", () => {
 
     const response = await GET(new NextRequest("http://localhost/api/kanban/boards?workspaceId=workspace-1"));
     expect(response.status).toBe(200);
+    expect(processKanbanColumnTransition).not.toHaveBeenCalled();
+  });
+
+  it("revives tasks after clearing stale trigger sessions in the current lane", async () => {
+    taskStore.listByWorkspace.mockResolvedValue([
+      {
+        ...createTask({
+          id: "task-1",
+          title: "Stale review story",
+          objective: "Review story",
+          workspaceId: "workspace-1",
+          boardId: "board-1",
+          columnId: "backlog",
+          status: TaskStatus.REVIEW_REQUIRED,
+        }),
+        triggerSessionId: "session-1",
+        verificationVerdict: undefined,
+        laneSessions: [{
+          sessionId: "session-1",
+          columnId: "backlog",
+          status: "running",
+          startedAt: "2025-01-01T00:00:00.000Z",
+        }],
+      },
+    ]);
+
+    const response = await GET(new NextRequest("http://localhost/api/kanban/boards?workspaceId=workspace-1"));
+
+    expect(response.status).toBe(200);
+    expect(taskStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: "task-1",
+      triggerSessionId: undefined,
+      laneSessions: [expect.objectContaining({
+        sessionId: "session-1",
+        status: "timed_out",
+      })],
+    }));
+    expect(processKanbanColumnTransition).toHaveBeenCalledWith(system, expect.objectContaining({
+      cardId: "task-1",
+      toColumnId: "backlog",
+      fromColumnId: "__revive__",
+    }));
+  });
+
+  it("marks stale review sessions with existing verdicts as transitioned before revive", async () => {
+    taskStore.listByWorkspace.mockResolvedValue([
+      {
+        ...createTask({
+          id: "task-1",
+          title: "Approved review story",
+          objective: "Review story",
+          workspaceId: "workspace-1",
+          boardId: "board-1",
+          columnId: "backlog",
+          status: TaskStatus.REVIEW_REQUIRED,
+        }),
+        triggerSessionId: "session-1",
+        verificationVerdict: VerificationVerdict.APPROVED,
+        verificationReport: "looks good",
+        laneSessions: [{
+          sessionId: "session-1",
+          columnId: "backlog",
+          status: "running",
+          startedAt: "2025-01-01T00:00:00.000Z",
+        }],
+      },
+    ]);
+
+    const response = await GET(new NextRequest("http://localhost/api/kanban/boards?workspaceId=workspace-1"));
+
+    expect(response.status).toBe(200);
+    expect(taskStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      laneSessions: [expect.objectContaining({
+        sessionId: "session-1",
+        status: "transitioned",
+      })],
+    }));
+    expect(processKanbanColumnTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not revive tasks when the trigger session is still active", async () => {
+    processManager.hasActiveSession.mockImplementation((sessionId) => sessionId === "session-1");
+    taskStore.listByWorkspace.mockResolvedValue([
+      {
+        ...createTask({
+          id: "task-1",
+          title: "Active backlog story",
+          objective: "Backlog story",
+          workspaceId: "workspace-1",
+          boardId: "board-1",
+          columnId: "backlog",
+          status: TaskStatus.PENDING,
+        }),
+        triggerSessionId: "session-1",
+        laneSessions: [{
+          sessionId: "session-1",
+          columnId: "backlog",
+          status: "running",
+          startedAt: "2025-01-01T00:00:00.000Z",
+        }],
+      },
+    ]);
+
+    const response = await GET(new NextRequest("http://localhost/api/kanban/boards?workspaceId=workspace-1"));
+    expect(response.status).toBe(200);
+    expect(taskStore.save).not.toHaveBeenCalled();
     expect(processKanbanColumnTransition).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/kanban/boards/route.ts
+++ b/src/app/api/kanban/boards/route.ts
@@ -9,6 +9,93 @@ import { getKanbanDevSessionSupervision } from "@/core/kanban/board-session-supe
 import { getKanbanEventBroadcaster } from "@/core/kanban/kanban-event-broadcaster";
 import { getKanbanSessionQueue } from "@/core/kanban/workflow-orchestrator-singleton";
 import { processKanbanColumnTransition } from "@/core/kanban/workflow-orchestrator-singleton";
+import { getHttpSessionStore } from "@/core/acp/http-session-store";
+import { getAcpProcessManager } from "@/core/acp/processer";
+import {
+  getTaskLaneSession,
+  markTaskLaneSessionStatus,
+} from "@/core/kanban/task-lane-history";
+import type { Task, TaskLaneSessionStatus } from "@/core/models/task";
+
+function isSessionActivelyRunning(
+  taskSessionId: string | undefined,
+  options: {
+    sessionStore: ReturnType<typeof getHttpSessionStore>;
+    processManager: ReturnType<typeof getAcpProcessManager>;
+  },
+): boolean {
+  if (!taskSessionId) return false;
+
+  if (options.processManager.hasActiveSession(taskSessionId)) {
+    return true;
+  }
+
+  const session = options.sessionStore.getSession(taskSessionId);
+  return session?.acpStatus === "ready" || session?.acpStatus === "connecting";
+}
+
+function resolveStaleLaneSessionTerminalStatus(task: Pick<Task, "verificationVerdict" | "verificationReport" | "completionSummary">): TaskLaneSessionStatus {
+  return task.verificationVerdict || task.verificationReport || task.completionSummary
+    ? "transitioned"
+    : "timed_out";
+}
+
+async function sanitizeStaleCurrentLaneAutomation(
+  system: ReturnType<typeof getRoutaSystem>,
+  task: Task,
+  options: {
+    sessionStore: ReturnType<typeof getHttpSessionStore>;
+    processManager: ReturnType<typeof getAcpProcessManager>;
+  },
+): Promise<Task> {
+  let mutated = false;
+  const nextTask: Task = {
+    ...task,
+    laneSessions: [...(task.laneSessions ?? [])],
+    laneHandoffs: [...(task.laneHandoffs ?? [])],
+    sessionIds: [...(task.sessionIds ?? [])],
+    comments: [...(task.comments ?? [])],
+    labels: [...(task.labels ?? [])],
+    dependencies: [...(task.dependencies ?? [])],
+    codebaseIds: [...(task.codebaseIds ?? [])],
+  };
+
+  if (nextTask.triggerSessionId && !isSessionActivelyRunning(nextTask.triggerSessionId, options)) {
+    const triggerLaneSession = getTaskLaneSession(nextTask, nextTask.triggerSessionId);
+    if (triggerLaneSession && triggerLaneSession.columnId === nextTask.columnId && triggerLaneSession.status === "running") {
+      markTaskLaneSessionStatus(
+        nextTask,
+        triggerLaneSession.sessionId,
+        resolveStaleLaneSessionTerminalStatus(nextTask),
+      );
+    }
+    nextTask.triggerSessionId = undefined;
+    mutated = true;
+  }
+
+  for (const entry of nextTask.laneSessions ?? []) {
+    if (
+      entry.columnId === nextTask.columnId
+      && entry.status === "running"
+      && !isSessionActivelyRunning(entry.sessionId, options)
+    ) {
+      markTaskLaneSessionStatus(
+        nextTask,
+        entry.sessionId,
+        resolveStaleLaneSessionTerminalStatus(nextTask),
+      );
+      mutated = true;
+    }
+  }
+
+  if (mutated) {
+    nextTask.updatedAt = new Date();
+    await system.taskStore.save(nextTask);
+    return nextTask;
+  }
+
+  return task;
+}
 
 async function reviveMissingEntryAutomations(
   system: ReturnType<typeof getRoutaSystem>,
@@ -18,16 +105,33 @@ async function reviveMissingEntryAutomations(
   const board = await system.kanbanBoardStore.get(boardId);
   if (!board) return;
 
+  const sessionStore = getHttpSessionStore();
+  const processManager = getAcpProcessManager();
+  await sessionStore.hydrateFromDb();
+
   const tasks = await system.taskStore.listByWorkspace(workspaceId);
-  for (const task of tasks) {
-    if (task.boardId !== boardId || task.triggerSessionId || !task.columnId) {
+  for (const originalTask of tasks) {
+    if (originalTask.boardId !== boardId || !originalTask.columnId) {
       continue;
     }
 
-    const column = board.columns.find((entry) => entry.id === task.columnId);
+    const task = await sanitizeStaleCurrentLaneAutomation(system, originalTask, {
+      sessionStore,
+      processManager,
+    });
+    if (task.triggerSessionId) continue;
+
+    const currentColumnId = task.columnId;
+    if (!currentColumnId) continue;
+    const column = board.columns.find((entry) => entry.id === currentColumnId);
+    if (!column) continue;
     const automation = column?.automation;
     const transitionType = automation?.transitionType ?? "entry";
-    const hasLaneSessionForCurrentColumn = (task.laneSessions ?? []).some((entry) => entry.columnId === task.columnId);
+    const hasLaneSessionForCurrentColumn = (task.laneSessions ?? []).some((entry) => (
+      entry.columnId === currentColumnId
+      && entry.status === "running"
+      && isSessionActivelyRunning(entry.sessionId, { sessionStore, processManager })
+    ));
     if (
       !automation?.enabled
       || (transitionType !== "entry" && transitionType !== "both")
@@ -43,9 +147,9 @@ async function reviveMissingEntryAutomations(
       boardId,
       workspaceId,
       fromColumnId: "__revive__",
-      toColumnId: task.columnId,
+      toColumnId: currentColumnId,
       fromColumnName: "Revive",
-      toColumnName: column?.name,
+      toColumnName: column.name,
     });
   }
 }


### PR DESCRIPTION
## Summary
- clear stale `triggerSessionId` ownership before board revive runs
- mark disconnected current-lane `running` sessions terminal instead of treating them as active forever
- re-enqueue entry automation only when no live ACP session still owns the lane
- add regression coverage for stale review recovery vs truly active sessions

## Problem
Review cards could stay stuck in `Review` with a persisted `qa-frontend/running` lane session and a restorable ACP session id even though the real worker process was gone. Because `reviveMissingEntryAutomations` treated any current-column lane history as proof that review was still active, approved, rejected, and pending cards could all remain stranded in Review.

## Testing
- `pnpm exec vitest run src/app/api/kanban/boards/__tests__/route.test.ts`

## Notes
- Verified on code/test level; live board behavior still requires restarting the production Next.js server that serves port 3500 so it picks up the new build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for stale session recovery in kanban board operations, including expired trigger sessions, verification verdicts, and active session scenarios.

* **Bug Fixes**
  * Improved handling of expired sessions in task state management with enhanced detection of inactive sessions and proper state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->