### PR TITLE
fix: critical SQLite worktables and review lane convergence bugs

### DIFF
--- a/src/app/api/acp/route.ts
+++ b/src/app/api/acp/route.ts
@@ -1015,6 +1015,8 @@ interface JsonRpcError {
   data?: Record<string, unknown>;
   authMethods?: Array<{ id: string; name: string; description: string }>;
   agentInfo?: { name: string; version: string };
+  /** Optional flag indicating the session may continue processing despite this error */
+  sessionMayContinue?: boolean;
 }
 
 function createSessionUpdateForwarder(

--- a/src/app/api/tasks/[taskId]/__tests__/route-verdict-convergence.test.ts
+++ b/src/app/api/tasks/[taskId]/__tests__/route-verdict-convergence.test.ts
@@ -1,0 +1,176 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTask, TaskStatus, VerificationVerdict, type Task } from "@/core/models/task";
+import type { TaskDeliveryReadiness } from "@/core/kanban/task-delivery-readiness";
+
+const notify = vi.fn();
+const removeCardJob = vi.fn();
+const enqueueKanbanTaskSession = vi.fn();
+const processKanbanColumnTransition = vi.fn();
+const archiveActiveTaskSession = vi.fn<(task: Task) => void>();
+const prepareTaskForColumnChange = vi.fn<(fromColumnId?: string, task?: Task) => boolean>(() => false);
+const buildTaskDeliveryReadiness = vi.fn<
+  (task: Task, currentSystem: typeof system) => Promise<TaskDeliveryReadiness>
+>();
+const buildTaskDeliveryTransitionErrorFromRules = vi.fn<
+  (readiness: TaskDeliveryReadiness, targetColumnName: string, deliveryRules: Record<string, unknown> | undefined) => string | null
+>(() => null);
+
+const taskStore = {
+  get: vi.fn<(_: string) => Promise<Task | null>>(),
+  save: vi.fn<(task: Task) => Promise<void>>(),
+};
+
+const system = {
+  taskStore,
+  kanbanBoardStore: { get: vi.fn() },
+  workspaceStore: { get: vi.fn() },
+  worktreeStore: { assignSession: vi.fn(), get: vi.fn() },
+  codebaseStore: { findByRepoPath: vi.fn(), get: vi.fn(), getDefault: vi.fn() },
+  eventBus: {},
+  artifactStore: undefined,
+};
+
+vi.mock("@/core/routa-system", () => ({
+  getRoutaSystem: () => system,
+}));
+
+vi.mock("@/core/kanban/kanban-event-broadcaster", () => ({
+  getKanbanEventBroadcaster: () => ({ notify }),
+}));
+
+vi.mock("@/core/kanban/task-board-context", () => ({
+  ensureTaskBoardContext: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/core/kanban/github-issues", () => ({
+  updateGitHubIssue: vi.fn(),
+}));
+
+vi.mock("@/core/git/git-worktree-service", () => ({
+  GitWorktreeService: vi.fn(class {}),
+}));
+
+vi.mock("@/core/models/workspace", () => ({
+  getDefaultWorkspaceWorktreeRoot: vi.fn(),
+  getEffectiveWorkspaceMetadata: vi.fn(),
+}));
+
+vi.mock("@/core/kanban/column-transition", () => ({
+  emitColumnTransition: vi.fn(),
+}));
+
+vi.mock("@/core/kanban/task-session-transition", () => ({
+  archiveActiveTaskSession: (task: Task) => archiveActiveTaskSession(task),
+  prepareTaskForColumnChange: (fromColumnId?: string, task?: Task) =>
+    prepareTaskForColumnChange(fromColumnId, task),
+}));
+
+vi.mock("@/core/kanban/task-delivery-readiness", () => ({
+  buildTaskDeliveryReadiness: (task: Task, currentSystem: typeof system) =>
+    buildTaskDeliveryReadiness(task, currentSystem),
+  buildTaskDeliveryTransitionErrorFromRules: (
+    readiness: TaskDeliveryReadiness,
+    targetColumnName: string,
+    deliveryRules: Record<string, unknown> | undefined,
+  ) => buildTaskDeliveryTransitionErrorFromRules(readiness, targetColumnName, deliveryRules),
+}));
+
+vi.mock("@/core/kanban/workflow-orchestrator-singleton", () => ({
+  enqueueKanbanTaskSession: (currentSystem: typeof system, params: { task: Task }) =>
+    enqueueKanbanTaskSession(currentSystem, params),
+  getKanbanSessionQueue: () => ({ removeCardJob }),
+  processKanbanColumnTransition: (...args: unknown[]) => processKanbanColumnTransition(...args),
+}));
+
+import { PATCH } from "../route";
+
+describe("/api/tasks/[taskId] verdict convergence gates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskStore.save.mockResolvedValue();
+    taskStore.get.mockResolvedValue(createTask({
+      id: "task-1",
+      title: "Finalize review verdict",
+      objective: "Leave review only when done checks pass",
+      workspaceId: "workspace-1",
+      boardId: "board-1",
+      columnId: "review",
+      status: TaskStatus.REVIEW_REQUIRED,
+    }));
+    system.kanbanBoardStore.get = vi.fn().mockResolvedValue({
+      id: "board-1",
+      columns: [
+        {
+          id: "review",
+          name: "Review",
+          position: 0,
+          stage: "review",
+          automation: {
+            enabled: true,
+            steps: [
+              {
+                id: "review-guard",
+                role: "GATE",
+                specialistId: "kanban-review-guard",
+                specialistName: "Review Guard",
+              },
+            ],
+          },
+        },
+        {
+          id: "done",
+          name: "Done",
+          position: 1,
+          stage: "done",
+          automation: {
+            deliveryRules: {
+              requirePullRequestReady: true,
+            },
+          },
+        },
+      ],
+    });
+    buildTaskDeliveryReadiness.mockResolvedValue({
+      checked: true,
+      branch: "main",
+      baseBranch: "main",
+      baseRef: "origin/main",
+      modified: 0,
+      untracked: 0,
+      ahead: 1,
+      behind: 0,
+      commitsSinceBase: 1,
+      hasCommitsSinceBase: true,
+      hasUncommittedChanges: false,
+      isGitHubRepo: true,
+      canCreatePullRequest: false,
+    });
+    buildTaskDeliveryTransitionErrorFromRules.mockReturnValue(
+      'Cannot move task to "Done": GitHub repo is not PR-ready yet. Use a feature branch instead of "main" so this task can open a pull request cleanly.',
+    );
+  });
+
+  it("re-validates the converged lane before saving", async () => {
+    const response = await PATCH(new NextRequest("http://localhost/api/tasks/task-1", {
+      method: "PATCH",
+      body: JSON.stringify({
+        columnId: "review",
+        verificationVerdict: VerificationVerdict.APPROVED,
+      }),
+      headers: { "Content-Type": "application/json" },
+    }), {
+      params: Promise.resolve({ taskId: "task-1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('Cannot move task to "Done"');
+    expect(data.deliveryReadiness).toMatchObject({
+      checked: true,
+      branch: "main",
+      canCreatePullRequest: false,
+    });
+    expect(taskStore.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -271,134 +271,6 @@ export async function PATCH(
     }
   }
 
-  // Check required artifacts before allowing column transition
-  if (body.columnId !== undefined && body.columnId !== existing.columnId) {
-    const incomingVerificationVerdict = body.verificationVerdict ?? nextTask.verificationVerdict;
-    const allowReviewFallbackToDev = existing.columnId === "review"
-      && body.columnId === "dev"
-      && incomingVerificationVerdict === VerificationVerdict.NOT_APPROVED;
-    if (boardId && board) {
-        if (existing.triggerSessionId && !allowReviewFallbackToDev) {
-          const laneAutomationState = resolveCurrentLaneAutomationState(existing, board.columns, {
-            currentSessionId: existing.triggerSessionId,
-          });
-          const moveBlockedMessage = buildRemainingLaneStepsMessage(existing.title, laneAutomationState);
-          if (moveBlockedMessage) {
-            return NextResponse.json({ error: moveBlockedMessage }, { status: 400 });
-          }
-        }
-
-        const targetColumn = board.columns.find((c) => c.id === body.columnId);
-        const requiredArtifacts = targetColumn?.automation?.requiredArtifacts;
-        if (requiredArtifacts && requiredArtifacts.length > 0 && system.artifactStore) {
-          const missingArtifacts: string[] = [];
-          for (const artifactType of requiredArtifacts) {
-            const artifacts = await system.artifactStore.listByTaskAndType(
-              taskId,
-              artifactType as ArtifactType
-            );
-            if (artifacts.length === 0) {
-              missingArtifacts.push(artifactType);
-            }
-          }
-          if (missingArtifacts.length > 0) {
-            return NextResponse.json(
-              {
-                error: `Cannot move task to "${targetColumn?.name ?? body.columnId}": missing required artifacts: ${missingArtifacts.join(", ")}. Please provide these artifacts before moving the task.`,
-                missingArtifacts,
-              },
-              { status: 400 }
-            );
-          }
-        }
-
-        const requiredTaskFields = resolveTargetRequiredTaskFields(board.columns, targetColumn?.id);
-        if (requiredTaskFields.length > 0) {
-          const readiness = validateTaskReadiness(nextTask, requiredTaskFields);
-          if (!readiness.ready) {
-            const missingTaskFields = readiness.missing.map(formatRequiredTaskFieldLabel);
-            return NextResponse.json(
-              {
-                error: `Cannot move task to "${targetColumn?.name ?? body.columnId}": missing required task fields: ${missingTaskFields.join(", ")}. Please complete this story definition before moving the task.`,
-                missingTaskFields,
-                storyReadiness: readiness,
-              },
-              { status: 400 },
-            );
-          }
-        }
-
-        const contractReadiness = buildTaskContractReadiness(nextTask, targetColumn?.automation?.contractRules);
-        const contractError = buildTaskContractTransitionErrorFromRules(
-          contractReadiness,
-          targetColumn?.name ?? body.columnId,
-          targetColumn?.automation?.contractRules,
-        );
-        if (contractError) {
-          await recordTaskContractGateFailure(existing, system, {
-            message: contractError,
-            targetColumnName: targetColumn?.name ?? body.columnId,
-            threshold: contractReadiness.loopBreakerThreshold,
-            sessionId: existing.triggerSessionId,
-          });
-          return NextResponse.json(
-            {
-              error: contractError,
-              contractReadiness,
-            },
-            { status: 400 },
-          );
-        }
-
-        if (targetColumn?.automation?.deliveryRules) {
-          const deliveryReadiness = await buildTaskDeliveryReadiness(nextTask, system);
-          transitionDeliveryReadiness = deliveryReadiness;
-          const deliveryError = buildTaskDeliveryTransitionErrorFromRules(
-            deliveryReadiness,
-            targetColumn.name ?? body.columnId,
-            targetColumn.automation.deliveryRules,
-          );
-          if (deliveryError) {
-            return NextResponse.json(
-              {
-                error: deliveryError,
-                deliveryReadiness,
-              },
-              { status: 400 },
-            );
-          }
-        }
-    }
-  }
-
-  if (
-    body.columnId !== undefined
-    && body.columnId !== existing.columnId
-    && shouldCaptureTaskDeliverySnapshotForColumn(body.columnId)
-  ) {
-    transitionDeliveryReadiness ??= await buildTaskDeliveryReadiness(nextTask, system);
-    nextTask.deliverySnapshot = captureTaskDeliverySnapshot(nextTask, transitionDeliveryReadiness, {
-      source: body.columnId === "done" ? "done_transition" : "review_transition",
-    });
-  }
-
-  if (body.columnId !== undefined) nextTask.columnId = body.columnId;
-  if (body.position !== undefined) nextTask.position = body.position;
-  if (body.assignee !== undefined) nextTask.assignee = body.assignee;
-  if (body.assignedProvider !== undefined) nextTask.assignedProvider = body.assignedProvider;
-  if (body.assignedRole !== undefined) nextTask.assignedRole = body.assignedRole;
-  if (body.assignedSpecialistId !== undefined) nextTask.assignedSpecialistId = body.assignedSpecialistId;
-  if (body.assignedSpecialistName !== undefined) nextTask.assignedSpecialistName = body.assignedSpecialistName;
-  if (body.triggerSessionId !== undefined) nextTask.triggerSessionId = body.triggerSessionId;
-  if (body.githubId !== undefined) nextTask.githubId = body.githubId;
-  if (body.githubNumber !== undefined) nextTask.githubNumber = body.githubNumber;
-  if (body.githubUrl !== undefined) nextTask.githubUrl = body.githubUrl;
-  if (body.githubRepo !== undefined) nextTask.githubRepo = body.githubRepo;
-  if (body.githubState !== undefined) nextTask.githubState = body.githubState;
-  if (body.lastSyncError !== undefined) nextTask.lastSyncError = body.lastSyncError;
-  if (body.isPullRequest !== undefined) nextTask.isPullRequest = body.isPullRequest === true ? true : undefined;
-  if (body.dependencies !== undefined) nextTask.dependencies = body.dependencies;
-  if (body.parallelGroup !== undefined) nextTask.parallelGroup = body.parallelGroup;
   if (body.completionSummary !== undefined) nextTask.completionSummary = body.completionSummary;
   if (body.verificationVerdict !== undefined) nextTask.verificationVerdict = body.verificationVerdict;
   if (body.verificationReport !== undefined) nextTask.verificationReport = body.verificationReport;
@@ -422,14 +294,15 @@ export async function PATCH(
   if (body.status !== undefined && normalizedStatus === undefined) {
     return NextResponse.json({ error: `Invalid status: ${String(body.status)}` }, { status: 400 });
   }
-  if (body.status !== undefined) {
-    nextTask.status = normalizedStatus as TaskStatus;
+  const requestedStatus = body.status !== undefined ? normalizedStatus as TaskStatus : undefined;
+  if (requestedStatus !== undefined) {
+    nextTask.status = requestedStatus;
   }
 
-  if (body.columnId !== undefined && body.status !== undefined) {
+  if (body.columnId !== undefined && requestedStatus !== undefined) {
     const expectedStatus = columnIdToTaskStatus(body.columnId);
-    const expectedColumnId = taskStatusToColumnId(normalizedStatus);
-    if (expectedStatus !== normalizedStatus || expectedColumnId !== body.columnId) {
+    const expectedColumnId = taskStatusToColumnId(requestedStatus);
+    if (expectedStatus !== requestedStatus || expectedColumnId !== body.columnId) {
       return NextResponse.json(
         { error: "columnId and status must describe the same workflow state" },
         { status: 400 },
@@ -445,26 +318,154 @@ export async function PATCH(
     getKanbanSessionQueue(system).removeCardJob(taskId);
   }
 
-  if (body.columnId && !body.status) {
-    nextTask.status = columnIdToTaskStatus(body.columnId);
-  }
-  if (body.status && !body.columnId) {
-    nextTask.columnId = taskStatusToColumnId(body.status);
+  if (body.columnId !== undefined) {
+    nextTask.columnId = body.columnId;
+    if (requestedStatus === undefined) {
+      nextTask.status = columnIdToTaskStatus(body.columnId);
+    }
+  } else if (requestedStatus !== undefined) {
+    nextTask.columnId = taskStatusToColumnId(requestedStatus);
   }
 
-  // Always check review lane convergence when verification verdict is updated
-  // This ensures cards move out of review lane even when columnId/status is explicitly set
+  // Always check review lane convergence when verification verdict is updated.
+  // This must happen before transition gates so the final target lane is validated.
   if (body.verificationVerdict !== undefined || (body.columnId === undefined && body.status === undefined)) {
-    const boardId = nextTask.boardId ?? existing.boardId;
-    const board = boardId
-      ? await system.kanbanBoardStore.get(boardId)
-      : null;
     const convergenceColumnId = resolveReviewLaneConvergenceTarget(nextTask, board?.columns ?? []);
     if (convergenceColumnId && convergenceColumnId !== nextTask.columnId) {
       nextTask.columnId = convergenceColumnId;
       nextTask.status = columnIdToTaskStatus(convergenceColumnId);
     }
   }
+
+  const targetColumnId = nextTask.columnId;
+  const isColumnTransition = targetColumnId !== existing.columnId;
+
+  // Check required artifacts before allowing column transition
+  if (isColumnTransition && targetColumnId !== undefined) {
+    const incomingVerificationVerdict = nextTask.verificationVerdict;
+    const allowReviewFallbackToDev = existing.columnId === "review"
+      && targetColumnId === "dev"
+      && incomingVerificationVerdict === VerificationVerdict.NOT_APPROVED;
+    if (boardId && board) {
+        if (existing.triggerSessionId && !allowReviewFallbackToDev) {
+          const laneAutomationState = resolveCurrentLaneAutomationState(existing, board.columns, {
+            currentSessionId: existing.triggerSessionId,
+          });
+          const moveBlockedMessage = buildRemainingLaneStepsMessage(existing.title, laneAutomationState);
+          if (moveBlockedMessage) {
+            return NextResponse.json({ error: moveBlockedMessage }, { status: 400 });
+          }
+        }
+
+        const targetColumn = board.columns.find((c) => c.id === targetColumnId);
+        const requiredArtifacts = targetColumn?.automation?.requiredArtifacts;
+        if (requiredArtifacts && requiredArtifacts.length > 0 && system.artifactStore) {
+          const missingArtifacts: string[] = [];
+          for (const artifactType of requiredArtifacts) {
+            const artifacts = await system.artifactStore.listByTaskAndType(
+              taskId,
+              artifactType as ArtifactType
+            );
+            if (artifacts.length === 0) {
+              missingArtifacts.push(artifactType);
+            }
+          }
+          if (missingArtifacts.length > 0) {
+            return NextResponse.json(
+              {
+                error: `Cannot move task to "${targetColumn?.name ?? targetColumnId}": missing required artifacts: ${missingArtifacts.join(", ")}. Please provide these artifacts before moving the task.`,
+                missingArtifacts,
+              },
+              { status: 400 }
+            );
+          }
+        }
+
+        const requiredTaskFields = resolveTargetRequiredTaskFields(board.columns, targetColumn?.id);
+        if (requiredTaskFields.length > 0) {
+          const readiness = validateTaskReadiness(nextTask, requiredTaskFields);
+          if (!readiness.ready) {
+            const missingTaskFields = readiness.missing.map(formatRequiredTaskFieldLabel);
+            return NextResponse.json(
+              {
+                error: `Cannot move task to "${targetColumn?.name ?? targetColumnId}": missing required task fields: ${missingTaskFields.join(", ")}. Please complete this story definition before moving the task.`,
+                missingTaskFields,
+                storyReadiness: readiness,
+              },
+              { status: 400 },
+            );
+          }
+        }
+
+        const contractReadiness = buildTaskContractReadiness(nextTask, targetColumn?.automation?.contractRules);
+        const contractError = buildTaskContractTransitionErrorFromRules(
+          contractReadiness,
+          targetColumn?.name ?? targetColumnId,
+          targetColumn?.automation?.contractRules,
+        );
+        if (contractError) {
+          await recordTaskContractGateFailure(existing, system, {
+            message: contractError,
+            targetColumnName: targetColumn?.name ?? targetColumnId,
+            threshold: contractReadiness.loopBreakerThreshold,
+            sessionId: existing.triggerSessionId,
+          });
+          return NextResponse.json(
+            {
+              error: contractError,
+              contractReadiness,
+            },
+            { status: 400 },
+          );
+        }
+
+        if (targetColumn?.automation?.deliveryRules) {
+          const deliveryReadiness = await buildTaskDeliveryReadiness(nextTask, system);
+          transitionDeliveryReadiness = deliveryReadiness;
+          const deliveryError = buildTaskDeliveryTransitionErrorFromRules(
+            deliveryReadiness,
+            targetColumn.name ?? targetColumnId,
+            targetColumn.automation.deliveryRules,
+          );
+          if (deliveryError) {
+            return NextResponse.json(
+              {
+                error: deliveryError,
+                deliveryReadiness,
+              },
+              { status: 400 },
+            );
+          }
+        }
+    }
+  }
+
+  if (
+    isColumnTransition
+    && shouldCaptureTaskDeliverySnapshotForColumn(nextTask.columnId)
+  ) {
+    transitionDeliveryReadiness ??= await buildTaskDeliveryReadiness(nextTask, system);
+    nextTask.deliverySnapshot = captureTaskDeliverySnapshot(nextTask, transitionDeliveryReadiness, {
+      source: nextTask.columnId === "done" ? "done_transition" : "review_transition",
+    });
+  }
+
+  if (body.position !== undefined) nextTask.position = body.position;
+  if (body.assignee !== undefined) nextTask.assignee = body.assignee;
+  if (body.assignedProvider !== undefined) nextTask.assignedProvider = body.assignedProvider;
+  if (body.assignedRole !== undefined) nextTask.assignedRole = body.assignedRole;
+  if (body.assignedSpecialistId !== undefined) nextTask.assignedSpecialistId = body.assignedSpecialistId;
+  if (body.assignedSpecialistName !== undefined) nextTask.assignedSpecialistName = body.assignedSpecialistName;
+  if (body.triggerSessionId !== undefined) nextTask.triggerSessionId = body.triggerSessionId;
+  if (body.githubId !== undefined) nextTask.githubId = body.githubId;
+  if (body.githubNumber !== undefined) nextTask.githubNumber = body.githubNumber;
+  if (body.githubUrl !== undefined) nextTask.githubUrl = body.githubUrl;
+  if (body.githubRepo !== undefined) nextTask.githubRepo = body.githubRepo;
+  if (body.githubState !== undefined) nextTask.githubState = body.githubState;
+  if (body.lastSyncError !== undefined) nextTask.lastSyncError = body.lastSyncError;
+  if (body.isPullRequest !== undefined) nextTask.isPullRequest = body.isPullRequest === true ? true : undefined;
+  if (body.dependencies !== undefined) nextTask.dependencies = body.dependencies;
+  if (body.parallelGroup !== undefined) nextTask.parallelGroup = body.parallelGroup;
 
   Object.assign(nextTask, await ensureTaskBoardContext(system, nextTask));
 

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -452,7 +452,9 @@ export async function PATCH(
     nextTask.columnId = taskStatusToColumnId(body.status);
   }
 
-  if (body.columnId === undefined && body.status === undefined) {
+  // Always check review lane convergence when verification verdict is updated
+  // This ensures cards move out of review lane even when columnId/status is explicitly set
+  if (body.verificationVerdict !== undefined || (body.columnId === undefined && body.status === undefined)) {
     const boardId = nextTask.boardId ?? existing.boardId;
     const board = boardId
       ? await system.kanbanBoardStore.get(boardId)

--- a/src/client/__tests__/acp-client.test.ts
+++ b/src/client/__tests__/acp-client.test.ts
@@ -153,4 +153,50 @@ describe("BrowserAcpClient", () => {
       expect(MockEventSource.instances[0]?.url).toContain("sessionId=session-resume-1");
     });
   });
+
+  it("preserves sessionMayContinue on RPC errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32000,
+        message: "Session timed out but may continue",
+        sessionMayContinue: true,
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    const client = new BrowserAcpClient("");
+
+    await expect(client.initialize()).rejects.toMatchObject({
+      code: -32000,
+      message: "Session timed out but may continue",
+      sessionMayContinue: true,
+    });
+  });
+
+  it("preserves sessionMayContinue on prompt errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32010,
+        message: "Prompt timed out",
+        sessionMayContinue: true,
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    const client = new BrowserAcpClient("");
+
+    await expect(client.prompt("session-1", "continue")).rejects.toMatchObject({
+      code: -32010,
+      message: "Prompt timed out",
+      sessionMayContinue: true,
+    });
+  });
 });

--- a/src/client/__tests__/rpc-client.test.ts
+++ b/src/client/__tests__/rpc-client.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils/diagnostics", () => ({
+  isTauriRuntime: () => false,
+}));
+
+vi.mock("../config/backend", () => ({
+  resolveApiPath: () => "/api/rpc",
+}));
+
+import { RoutaRpcClient } from "../rpc-client";
+
+describe("RoutaRpcClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves sessionMayContinue on JSON-RPC errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32000,
+        message: "Session timed out",
+        sessionMayContinue: true,
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    const client = new RoutaRpcClient("");
+
+    await expect(client.call("agents.list")).rejects.toMatchObject({
+      code: -32000,
+      message: "Session timed out",
+      sessionMayContinue: true,
+    });
+  });
+});

--- a/src/client/acp-client.ts
+++ b/src/client/acp-client.ts
@@ -118,6 +118,7 @@ export class AcpClientError extends Error {
   authMethods?: AcpAuthMethod[];
   agentInfo?: { name: string; version: string };
   data?: unknown;
+  sessionMayContinue?: boolean;
 
   constructor(
     message: string,
@@ -125,6 +126,7 @@ export class AcpClientError extends Error {
     authMethods?: AcpAuthMethod[],
     agentInfo?: { name: string; version: string },
     data?: unknown,
+    sessionMayContinue?: boolean,
   ) {
     super(message);
     this.name = "AcpClientError";
@@ -132,6 +134,7 @@ export class AcpClientError extends Error {
     this.authMethods = authMethods;
     this.agentInfo = agentInfo;
     this.data = data;
+    this.sessionMayContinue = sessionMayContinue;
   }
 
   toJSON(): Record<string, unknown> {
@@ -142,6 +145,7 @@ export class AcpClientError extends Error {
       authMethods: this.authMethods,
       agentInfo: this.agentInfo,
       data: this.data,
+      sessionMayContinue: this.sessionMayContinue,
       stack: this.stack,
     };
   }
@@ -427,6 +431,7 @@ export class BrowserAcpClient {
         data.error.authMethods,
         data.error.agentInfo,
         data.error.data,
+        data.error.sessionMayContinue,
       );
     }
 
@@ -807,6 +812,7 @@ export class BrowserAcpClient {
         data.error.authMethods,
         data.error.agentInfo,
         data.error.data,
+        data.error.sessionMayContinue,
       );
     }
 

--- a/src/client/hooks/__tests__/use-acp.test.ts
+++ b/src/client/hooks/__tests__/use-acp.test.ts
@@ -16,12 +16,14 @@ describe("formatAcpErrorForLog", () => {
           optionId: "approved",
         },
       },
+      true,
     );
 
     expect(formatAcpErrorForLog(err)).toMatchObject({
       name: "AcpClientError",
       message: "Internal error",
       code: -32000,
+      sessionMayContinue: true,
       errorData: {
         details: "Permission denied",
         optionId: "approved",

--- a/src/client/hooks/use-acp.ts
+++ b/src/client/hooks/use-acp.ts
@@ -78,6 +78,7 @@ export function formatAcpErrorForLog(err: unknown): unknown {
       code: err.code,
       authMethods: err.authMethods,
       agentInfo: err.agentInfo,
+      sessionMayContinue: err.sessionMayContinue,
       data,
       errorData: nestedErrorData,
     };

--- a/src/client/rpc-client.ts
+++ b/src/client/rpc-client.ts
@@ -31,6 +31,7 @@ export interface JsonRpcError {
   code: number;
   message: string;
   data?: unknown;
+  sessionMayContinue?: boolean;
 }
 
 export interface JsonRpcResponse {
@@ -47,12 +48,14 @@ export interface JsonRpcResponse {
 export class RpcError extends Error {
   code: number;
   data?: unknown;
+  sessionMayContinue?: boolean;
 
-  constructor(code: number, message: string, data?: unknown) {
+  constructor(code: number, message: string, data?: unknown, sessionMayContinue?: boolean) {
     super(message);
     this.name = "RpcError";
     this.code = code;
     this.data = data;
+    this.sessionMayContinue = sessionMayContinue;
   }
 }
 
@@ -144,6 +147,7 @@ export class RoutaRpcClient {
         response.error.code,
         response.error.message,
         response.error.data,
+        response.error.sessionMayContinue,
       );
     }
 

--- a/src/core/db/__tests__/sqlite.test.ts
+++ b/src/core/db/__tests__/sqlite.test.ts
@@ -81,4 +81,33 @@ describe("ensureSqliteDefaultWorkspace", () => {
       if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
     }
   });
+
+  it("recreates the worktrees table when it is missing on reopen", () => {
+    const dbPath = path.join(os.tmpdir(), `routa-sqlite-repair-${Date.now()}.db`);
+    closeSqliteDatabase();
+
+    try {
+      getSqliteDatabase(dbPath);
+      closeSqliteDatabase();
+
+      const writable = new BetterSqlite3(dbPath);
+      writable.exec("DROP TABLE worktrees");
+      writable.close();
+
+      getSqliteDatabase(dbPath);
+
+      const readonly = new BetterSqlite3(dbPath, { readonly: true });
+      const row = readonly.prepare(`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'worktrees'
+      `).get() as { name: string } | undefined;
+      readonly.close();
+
+      expect(row).toEqual({ name: "worktrees" });
+    } finally {
+      closeSqliteDatabase();
+      if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    }
+  });
 });

--- a/src/core/db/sqlite.ts
+++ b/src/core/db/sqlite.ts
@@ -42,6 +42,49 @@ export function getSqliteDatabase(dbPath?: string): SqliteDatabase {
     // Run migrations / create tables on first use
     initializeSqliteTables(db);
 
+    // Ensure worktrees table exists (fix for #414)
+    // This is a defensive check to handle cases where the table wasn't created
+    // due to database initialization issues or version mismatches
+    try {
+      const tableCheck = sqlite.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='worktrees'"
+      ).get();
+      if (!tableCheck) {
+        console.warn("[SQLite] worktrees table missing, creating it now");
+        sqlite.run(`
+          CREATE TABLE worktrees (
+            id TEXT PRIMARY KEY,
+            codebase_id TEXT NOT NULL REFERENCES codebases(id) ON DELETE CASCADE,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            worktree_path TEXT NOT NULL,
+            branch TEXT NOT NULL,
+            base_branch TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'creating',
+            session_id TEXT,
+            label TEXT,
+            error_message TEXT,
+            created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
+          )
+        `);
+        sqlite.run(`
+          CREATE UNIQUE INDEX uq_worktrees_codebase_branch
+          ON worktrees (codebase_id, branch)
+        `);
+        sqlite.run(`
+          CREATE UNIQUE INDEX uq_worktrees_path
+          ON worktrees (worktree_path)
+        `);
+        sqlite.run(`
+          CREATE INDEX idx_worktrees_workspace_id
+          ON worktrees (workspace_id)
+        `);
+        console.log("[SQLite] worktrees table created successfully");
+      }
+    } catch (error) {
+      console.error("[SQLite] Failed to ensure worktrees table exists:", error);
+    }
+
     // Store both the drizzle wrapper and the raw connection
     g[GLOBAL_KEY] = db;
     g[GLOBAL_RAW_KEY] = sqlite;

--- a/src/core/db/sqlite.ts
+++ b/src/core/db/sqlite.ts
@@ -17,6 +17,55 @@ export type SqliteDatabase = BetterSQLite3Database<typeof schema>;
 
 const GLOBAL_KEY = "__routa_sqlite_db__";
 const GLOBAL_RAW_KEY = "__routa_sqlite_raw__";
+const WORKTREES_DDL_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS worktrees (
+    id TEXT PRIMARY KEY,
+    codebase_id TEXT NOT NULL REFERENCES codebases(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    worktree_path TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    base_branch TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'creating',
+    session_id TEXT,
+    label TEXT,
+    error_message TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_codebase_branch
+  ON worktrees (codebase_id, branch)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_path
+  ON worktrees (worktree_path)`,
+  `CREATE INDEX IF NOT EXISTS idx_worktrees_workspace_id
+  ON worktrees (workspace_id)`,
+] as const;
+
+function applyWorktreesTableDdl(execute: (statement: string) => void): void {
+  for (const statement of WORKTREES_DDL_STATEMENTS) {
+    execute(statement);
+  }
+}
+
+function hasSqliteTable(sqlite: BetterSqlite3.Database, tableName: string): boolean {
+  return Boolean(
+    sqlite.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name = ?"
+    ).get(tableName),
+  );
+}
+
+function ensureWorktreesTable(sqlite: BetterSqlite3.Database): void {
+  if (hasSqliteTable(sqlite, "worktrees")) {
+    return;
+  }
+
+  console.warn("[SQLite] worktrees table missing, creating it now");
+  applyWorktreesTableDdl((statement) => sqlite.exec(statement));
+
+  if (!hasSqliteTable(sqlite, "worktrees")) {
+    throw new Error("[SQLite] Failed to create missing worktrees table");
+  }
+}
 
 /**
  * Get or create a SQLite database instance.
@@ -42,47 +91,11 @@ export function getSqliteDatabase(dbPath?: string): SqliteDatabase {
     // Run migrations / create tables on first use
     initializeSqliteTables(db);
 
-    // Ensure worktrees table exists (fix for #414)
-    // This is a defensive check to handle cases where the table wasn't created
-    // due to database initialization issues or version mismatches
     try {
-      const tableCheck = sqlite.prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='worktrees'"
-      ).get();
-      if (!tableCheck) {
-        console.warn("[SQLite] worktrees table missing, creating it now");
-        sqlite.run(`
-          CREATE TABLE worktrees (
-            id TEXT PRIMARY KEY,
-            codebase_id TEXT NOT NULL REFERENCES codebases(id) ON DELETE CASCADE,
-            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-            worktree_path TEXT NOT NULL,
-            branch TEXT NOT NULL,
-            base_branch TEXT NOT NULL,
-            status TEXT NOT NULL DEFAULT 'creating',
-            session_id TEXT,
-            label TEXT,
-            error_message TEXT,
-            created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
-            updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
-          )
-        `);
-        sqlite.run(`
-          CREATE UNIQUE INDEX uq_worktrees_codebase_branch
-          ON worktrees (codebase_id, branch)
-        `);
-        sqlite.run(`
-          CREATE UNIQUE INDEX uq_worktrees_path
-          ON worktrees (worktree_path)
-        `);
-        sqlite.run(`
-          CREATE INDEX idx_worktrees_workspace_id
-          ON worktrees (workspace_id)
-        `);
-        console.log("[SQLite] worktrees table created successfully");
-      }
+      ensureWorktreesTable(sqlite);
     } catch (error) {
       console.error("[SQLite] Failed to ensure worktrees table exists:", error);
+      throw error;
     }
 
     // Store both the drizzle wrapper and the raw connection
@@ -392,34 +405,9 @@ function initializeSqliteTables(db: SqliteDatabase): void {
   try { db.run(sql`ALTER TABLE codebases ADD COLUMN source_type TEXT`); } catch { /* column already exists */ }
   try { db.run(sql`ALTER TABLE codebases ADD COLUMN source_url TEXT`); } catch { /* column already exists */ }
 
-  db.run(sql`
-    CREATE TABLE IF NOT EXISTS worktrees (
-      id TEXT PRIMARY KEY,
-      codebase_id TEXT NOT NULL REFERENCES codebases(id) ON DELETE CASCADE,
-      workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-      worktree_path TEXT NOT NULL,
-      branch TEXT NOT NULL,
-      base_branch TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'creating',
-      session_id TEXT,
-      label TEXT,
-      error_message TEXT,
-      created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
-      updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
-    )
-  `);
-  db.run(sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_codebase_branch
-    ON worktrees (codebase_id, branch)
-  `);
-  db.run(sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS uq_worktrees_path
-    ON worktrees (worktree_path)
-  `);
-  db.run(sql`
-    CREATE INDEX IF NOT EXISTS idx_worktrees_workspace_id
-    ON worktrees (workspace_id)
-  `);
+  applyWorktreesTableDdl((statement) => {
+    db.run(sql.raw(statement));
+  });
 
   db.run(sql`
     CREATE TABLE IF NOT EXISTS kanban_boards (

--- a/src/core/tools/agent-tools.ts
+++ b/src/core/tools/agent-tools.ts
@@ -892,7 +892,9 @@ export class AgentTools {
     if (updates.verificationCommands !== undefined) task.verificationCommands = updates.verificationCommands;
     if (updates.testCases !== undefined) task.testCases = updates.testCases;
 
-    if (updates.status === undefined) {
+    // Always check review lane convergence when verification verdict is updated
+    // This ensures cards move out of review lane even when status is explicitly set
+    if (updates.verificationVerdict !== undefined || updates.status === undefined) {
       const board = task.boardId && this.kanbanBoardStore
         ? await this.kanbanBoardStore.get(task.boardId)
         : undefined;


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs affecting database initialization and workflow reliability.

### ✅ Critical Fixes

**#414: SQLite initialization misses worktrees table** (CRITICAL - DATA LOSS)
- **Problem**: Moving tasks from Todo to Dev fails because worktrees table is missing from SQLite database
- **Root Cause**: Databases created with older schema versions don't have the worktrees table
- **Solution**: Added defensive check to ensure worktrees table is always created during initialization
- **Impact**: Fixes broken worktree creation, delivery snapshots, review handoff, and cleanup gates
- **Files**: `src/core/db/sqlite.ts`

**#417: Review lane may not converge cleanly after QA verdict** (WORKFLOW BUG)
- **Problem**: Cards remain stuck in review lane even after QA writes final verification verdict
- **Root Cause**: Convergence check was skipped when verificationVerdict was updated along with status/columnId
- **Solution**: Modified logic to always check convergence when verificationVerdict is updated
- **Impact**: Ensures review lane converges properly to done/dev/blocked based on final verdict
- **Files**: 
  - `src/core/tools/agent-tools.ts`
  - `src/app/api/tasks/[taskId]/route.ts`

**✅ Session Timeout Handling** (#416 - Partial)
- Added `sessionMayContinue` flag to `JsonRpcError` interface
- Allows clients to handle timeout scenarios gracefully without marking sessions as permanently failed
- **Note**: Full timeout handling logic needs re-implementation against latest codebase

### Technical Details

**Worktrees Table Fix (#414)**:
```typescript
// Defensive check after initialization
const tableCheck = sqlite.prepare(
  "SELECT name FROM sqlite_master WHERE type='table' AND name='worktrees'"
).get();

if (!tableCheck) {
  // Create table with all required indexes
  console.warn("[SQLite] worktrees table missing, creating it now");
  // ... CREATE TABLE statements
}
```

**Review Lane Convergence Fix (#417)**:
```typescript
// OLD: Only check when status not explicitly set
if (updates.status === undefined) {
  checkConvergence();
}

// NEW: Always check when verdict is updated
if (updates.verificationVerdict !== undefined || updates.status === undefined) {
  checkConvergence();
}
```

### Testing

- [x] Verified worktrees table is created when missing
- [x] Tested SQLite initialization from scratch
- [x] Verified review lane convergence triggers on verdict updates
- [x] Confirmed no errors during database setup

### Related

Fixes #414
Fixes #417
Partial fix for #416 (interface preparation only)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error responses now include an optional session-continuation flag surfaced to clients.

* **Bug Fixes**
  * Improved database initialization to ensure required tables are created and recovered.
  * Task update handling tightened: inputs are validated earlier, workflow/status consistency enforced, and review/verdict-driven lane convergence revalidated before persisting.

* **Tests**
  * Added tests covering verdict-driven convergence, error propagation of the session flag, RPC error handling, and DB recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->