### PR TITLE
fix(docker): Windows Docker detection and version display improvements

### DIFF
--- a/src/client/components/docker-status-indicator.tsx
+++ b/src/client/components/docker-status-indicator.tsx
@@ -52,7 +52,7 @@ export function DockerStatusIndicator({ compact = false, className = "" }: Docke
   const label = isChecking
     ? t.dockerStatus.checking
     : available
-      ? t.dockerStatus.ready.replace("{{version}}", status?.version ?? "ready")
+      ? t.dockerStatus.ready.replace("{version}", status?.version ?? "ready")
       : loading
         ? t.dockerStatus.retrying
         : t.dockerStatus.unavailable;

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -1,8 +1,107 @@
 import { getServerBridge } from "@/core/platform";
+import { which } from "@/core/acp/utils";
 import type { DockerPullResult, DockerStatus } from "./types";
 
 const CACHE_TTL_MS = 30_000;
 const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Find docker executable on Windows by checking standard installation paths,
+ * since Docker Desktop typically installs outside the system PATH.
+ */
+async function findDockerOnWindows(bridge: ReturnType<typeof getServerBridge>): Promise<string | null> {
+  if (bridge.env.osPlatform() !== "win32") return null;
+
+  // Common Windows Docker Desktop installation paths
+  const programFilesDirs = [
+    process.env["ProgramFiles"] ?? "C:\\Program Files",
+    process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+  ];
+
+  const candidates = [
+    "\\Docker\\Docker\\resources\\bin\\docker.exe",
+    "\\Docker\\Docker\\resources\\bin\\docker-compose.exe",
+  ];
+
+  for (const base of programFilesDirs) {
+    for (const suffix of candidates) {
+      const fullPath = base + suffix;
+      try {
+        const stat = bridge.fs.statSync(fullPath);
+        if (stat.isFile) return fullPath;
+      } catch {
+        // Not found at this path, continue
+      }
+    }
+  }
+
+  return null;
+}
+
+function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: string | null): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const isWindows = bridge.env.osPlatform() === "win32";
+
+    if (dockerPath) {
+      // Use resolved absolute path — no shell needed for .exe files
+      const args = ["info", "--format", "{{json .}}"];
+      const handle = bridge.process.spawn(dockerPath, args, { timeout: DEFAULT_TIMEOUT_MS });
+      let stdout = "";
+      let stderr = "";
+
+      const timer = setTimeout(() => {
+        handle.kill();
+        reject(new Error("docker info timed out"));
+      }, DEFAULT_TIMEOUT_MS);
+
+      handle.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf-8");
+      });
+      handle.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf-8");
+      });
+      handle.on("exit", (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve(stdout);
+        else reject(new Error(stderr || `docker exited with code ${code}`));
+      });
+      handle.on("error", reject);
+    } else if (isWindows) {
+      // On Windows with no resolved path, use shell so cmd.exe searches PATH
+      const handle = bridge.process.spawn("docker", ["info", "--format", "{{json .}}"], {
+        shell: true,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+      let stdout = "";
+      let stderr = "";
+
+      const timer = setTimeout(() => {
+        handle.kill();
+        reject(new Error("docker info timed out"));
+      }, DEFAULT_TIMEOUT_MS);
+
+      handle.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf-8");
+      });
+      handle.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf-8");
+      });
+      handle.on("exit", (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve(stdout);
+        else reject(new Error(stderr || `docker exited with code ${code}`));
+      });
+      handle.on("error", reject);
+    } else {
+      // Unix: PATH should be inherited correctly
+      bridge.process.exec("docker info --format '{{json .}}'", { timeout: DEFAULT_TIMEOUT_MS })
+        .then(({ stdout: out }) => resolve(out))
+        .catch(reject);
+    }
+  });
+}
 
 export class DockerDetector {
   private static instance: DockerDetector | null = null;
@@ -25,11 +124,14 @@ export class DockerDetector {
     const bridge = getServerBridge();
     const checkedAt = new Date().toISOString();
 
-    try {
-      const { stdout } = await bridge.process.exec("docker info --format '{{json .}}'", {
-        timeout: DEFAULT_TIMEOUT_MS,
-      });
+    // Try to resolve docker path — first via PATH lookup, then standard Windows install dirs
+    let dockerPath = await which("docker");
+    if (!dockerPath) {
+      dockerPath = await findDockerOnWindows(bridge);
+    }
 
+    try {
+      const stdout = await execDockerInfo(bridge, dockerPath);
       const parsed = this.parseDockerInfo(stdout);
       const status: DockerStatus = {
         available: true,
@@ -43,10 +145,13 @@ export class DockerDetector {
       this.cachedAt = now;
       return status;
     } catch (err) {
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      // Strip platform-specific noise from error messages to avoid garbling
+      const sanitized = this.sanitizeErrorMessage(rawMessage);
       const status: DockerStatus = {
         available: false,
         daemonRunning: false,
-        error: err instanceof Error ? err.message : "Docker unavailable",
+        error: sanitized,
         checkedAt,
       };
 
@@ -60,10 +165,24 @@ export class DockerDetector {
     const bridge = getServerBridge();
 
     try {
-      const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
-        timeout: DEFAULT_TIMEOUT_MS,
-      });
-      return stdout.trim().length > 0;
+      let dockerPath = await which("docker");
+      if (!dockerPath) dockerPath = await findDockerOnWindows(bridge);
+      const args = ["images", "-q", image];
+
+      if (dockerPath) {
+        const handle = bridge.process.spawn(dockerPath, args, {});
+        let stdout = "";
+        return new Promise((resolve) => {
+          handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+          handle.on("exit", (code) => { resolve(code === 0 && stdout.trim().length > 0); });
+          handle.on("error", () => resolve(false));
+        });
+      } else {
+        const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
+          timeout: DEFAULT_TIMEOUT_MS,
+        });
+        return stdout.trim().length > 0;
+      }
     } catch {
       return false;
     }
@@ -73,21 +192,35 @@ export class DockerDetector {
     const bridge = getServerBridge();
 
     try {
-      const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
-        timeout: 10 * 60_000,
-      });
+      const dockerPath = await which("docker");
+      const args = ["pull", image];
 
-      return {
-        ok: true,
-        image,
-        output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim(),
-      };
+      if (dockerPath) {
+        const handle = bridge.process.spawn(dockerPath, args, { timeout: 10 * 60_000 });
+        let stdout = "";
+        let stderr = "";
+        return new Promise((resolve) => {
+          handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+          handle.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
+          handle.on("exit", (code) => {
+            if (code === 0) {
+              resolve({ ok: true, image, output: stdout.trim() });
+            } else {
+              resolve({ ok: false, image, error: stderr || `docker exited with code ${code}` });
+            }
+          });
+          handle.on("error", (err: Error) => {
+            resolve({ ok: false, image, error: err.message });
+          });
+        });
+      } else {
+        const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
+          timeout: 10 * 60_000,
+        });
+        return { ok: true, image, output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim() };
+      }
     } catch (err) {
-      return {
-        ok: false,
-        image,
-        error: err instanceof Error ? err.message : "Failed to pull image",
-      };
+      return { ok: false, image, error: err instanceof Error ? err.message : "Failed to pull image" };
     }
   }
 
@@ -100,13 +233,25 @@ export class DockerDetector {
         ? clientInfo.ApiVersion
         : (typeof json.APIVersion === "string" ? json.APIVersion : undefined);
 
-      return {
-        version: serverVersion,
-        apiVersion,
-      };
+      return { version: serverVersion, apiVersion };
     } catch {
       return {};
     }
+  }
+
+  /**
+   * Remove Windows cmd.exe noise from error messages so the UI never displays
+   * garbled characters. Only keep the last line if it looks like a meaningful
+   * Docker / system error.
+   */
+  private sanitizeErrorMessage(raw: string): string {
+    if (!raw) return "Docker unavailable";
+    const lastLine = raw.split("\n").map((l) => l.trim()).filter(Boolean).pop() ?? raw;
+    // If it looks like encoded Chinese/GBK noise (contains high-byte chars), use a clean fallback
+    if (lastLine.length > 0 && lastLine.length < 20 && /[^a-zA-Z0-9 .,!?'-]/.test(lastLine)) {
+      return "Docker unavailable";
+    }
+    return lastLine;
   }
 }
 

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -169,12 +169,23 @@ export class DockerDetector {
       const args = ["images", "-q", image];
 
       if (dockerPath) {
-        const handle = bridge.process.spawn(dockerPath, args, {});
+        const handle = bridge.process.spawn(dockerPath, args);
         let stdout = "";
         return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            handle.kill();
+            resolve(false);
+          }, DEFAULT_TIMEOUT_MS);
+
           handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
-          handle.on("exit", (code) => { resolve(code === 0 && stdout.trim().length > 0); });
-          handle.on("error", () => resolve(false));
+          handle.on("exit", (code) => {
+            clearTimeout(timer);
+            resolve(code === 0 && stdout.trim().length > 0);
+          });
+          handle.on("error", () => {
+            clearTimeout(timer);
+            resolve(false);
+          });
         });
       } else {
         const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
@@ -189,19 +200,27 @@ export class DockerDetector {
 
   async pullImage(image: string): Promise<DockerPullResult> {
     const bridge = getServerBridge();
+    const PULL_TIMEOUT_MS = 10 * 60_000; // 10 minutes for image pulls
 
     try {
-      const dockerPath = await which("docker");
+      let dockerPath = await which("docker");
+      if (!dockerPath) dockerPath = await findDockerOnWindows(bridge);
       const args = ["pull", image];
 
       if (dockerPath) {
-        const handle = bridge.process.spawn(dockerPath, args, { timeout: 10 * 60_000 });
+        const handle = bridge.process.spawn(dockerPath, args);
         let stdout = "";
         let stderr = "";
         return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            handle.kill();
+            resolve({ ok: false, image, error: "docker pull timed out" });
+          }, PULL_TIMEOUT_MS);
+
           handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
           handle.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
           handle.on("exit", (code) => {
+            clearTimeout(timer);
             if (code === 0) {
               resolve({ ok: true, image, output: stdout.trim() });
             } else {
@@ -209,12 +228,13 @@ export class DockerDetector {
             }
           });
           handle.on("error", (err: Error) => {
+            clearTimeout(timer);
             resolve({ ok: false, image, error: err.message });
           });
         });
       } else {
         const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
-          timeout: 10 * 60_000,
+          timeout: PULL_TIMEOUT_MS,
         });
         return { ok: true, image, output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim() };
       }

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -47,7 +47,7 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
     if (dockerPath) {
       // Use resolved absolute path — no shell needed for .exe files
       const args = ["info", "--format", "{{json .}}"];
-      const handle = bridge.process.spawn(dockerPath, args, { timeout: DEFAULT_TIMEOUT_MS });
+      const handle = bridge.process.spawn(dockerPath, args);
       let stdout = "";
       let stderr = "";
 
@@ -72,7 +72,6 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
       // On Windows with no resolved path, use shell so cmd.exe searches PATH
       const handle = bridge.process.spawn("docker", ["info", "--format", "{{json .}}"], {
         shell: true,
-        timeout: DEFAULT_TIMEOUT_MS,
       });
       let stdout = "";
       let stderr = "";


### PR DESCRIPTION
## 🐳 Docker Windows 兼容性修复

### 问题
在 Windows 系统上，Routa 的 Docker 检测和显示存在以下问题：
1. **Docker Desktop 无法被检测到** - Docker Desktop 安装在系统 PATH 之外的路径
2. **Docker 版本号无法正确显示** - 翻译键占位符不匹配导致版本号不显示

### 修复内容

#### 1. Windows PATH 上的 Docker 检测修复 (+171 行)
**文件**: `src/core/acp/docker/detector.ts`

**改进**:
- ✅ 使用 `which('docker')` 先通过系统 PATH 查找 Docker
- ✅ 在 Windows 上检查标准 Docker Desktop 安装目录：
  - `C:\Program Files\Docker\Docker\resources\bin\docker.exe`
  - `C:\Program Files (x86)\Docker\Docker\resources\bin\docker.exe`
- ✅ 使用 `spawn()` 和绝对路径，不依赖 shell PATH 解析
- ✅ 清理错误消息，避免 cmd.exe 乱码中文显示在 UI 中

#### 2. Docker 版本插值显示修复
**文件**: `src/client/components/docker-status-indicator.tsx`

**修复**:
- ✅ 修正翻译键占位符：`{{version}}` → `{version}`
- ✅ 版本号现在正确显示：`Docker 27.5.1` 而不是 `Docker {version}`

### 变更统计
- **2 个文件修改**
- **+172 行新增，-27 行删除**
- **主要改进**: Windows Docker 检测逻辑和 UI 显示

### 测试建议
1. ✅ 在 Windows 上测试 Docker Desktop 是否能正确检测
2. ✅ 验证 Docker 版本是否正确显示在状态标签中
3. ✅ 检查错误消息是否清晰无乱码
4. ✅ 确保 Unix/Linux 系统不受影响

### 相关问题
Windows 用户报告 Docker 状态指示器始终显示"不可用"，即使 Docker Desktop 正在运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker detection on Windows by searching common installation locations when PATH lookup fails.
  * Enhanced Docker command execution to prefer resolved executables and reliably fall back across platforms.
  * Added timeout and stronger handling for image checks and pulls to avoid hanging operations.
  * Sanitized and clarified diagnostic messages when Docker is unavailable.
  * Fixed version placeholder substitution in the Docker status label so the version token renders correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->