### PR TITLE
fix(docker): harden Windows detector fallback

### DIFF
--- a/src/client/components/docker-status-indicator.tsx
+++ b/src/client/components/docker-status-indicator.tsx
@@ -52,7 +52,7 @@ export function DockerStatusIndicator({ compact = false, className = "" }: Docke
   const label = isChecking
     ? t.dockerStatus.checking
     : available
-      ? t.dockerStatus.ready.replace("{{version}}", status?.version ?? "ready")
+      ? t.dockerStatus.ready.replace("{version}", status?.version ?? "ready")
       : loading
         ? t.dockerStatus.retrying
         : t.dockerStatus.unavailable;

--- a/src/core/acp/docker/__tests__/docker-detector.test.ts
+++ b/src/core/acp/docker/__tests__/docker-detector.test.ts
@@ -5,19 +5,48 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DockerDetector } from "../detector";
 
-const execMock = vi.fn();
+const {
+  execMock,
+  whichMock,
+  spawnMock,
+  statSyncMock,
+  osPlatformMock,
+} = vi.hoisted(() => ({
+  execMock: vi.fn(),
+  whichMock: vi.fn(),
+  spawnMock: vi.fn(),
+  statSyncMock: vi.fn(),
+  osPlatformMock: vi.fn(() => "linux"),
+}));
 
 vi.mock("@/core/platform", () => ({
   getServerBridge: () => ({
+    env: {
+      osPlatform: osPlatformMock,
+    },
+    fs: {
+      statSync: statSyncMock,
+    },
     process: {
       exec: execMock,
+      spawn: spawnMock,
     },
   }),
+}));
+
+vi.mock("@/core/acp/utils", () => ({
+  which: whichMock,
 }));
 
 describe("DockerDetector", () => {
   beforeEach(() => {
     execMock.mockReset();
+    whichMock.mockReset();
+    spawnMock.mockReset();
+    statSyncMock.mockReset();
+    osPlatformMock.mockReset();
+    osPlatformMock.mockReturnValue("linux");
+    whichMock.mockResolvedValue(null);
   });
 
   it("returns available status when docker info succeeds", async () => {
@@ -79,5 +108,51 @@ describe("DockerDetector", () => {
     expect(first.version).toBe("27.3.1");
     expect(second.version).toBe("27.4.0");
     expect(execMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("checks Windows install paths using platform fs flags", async () => {
+    osPlatformMock.mockReturnValue("win32");
+    statSyncMock.mockImplementation((path: string) => ({
+      isDirectory: false,
+      isFile: path === "C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe",
+    }));
+
+    spawnMock.mockImplementation(() => ({
+      stdout: {
+        on: (event: string, handler: (chunk: Buffer) => void) => {
+          if (event === "data") {
+            handler(Buffer.from(JSON.stringify({ ServerVersion: "27.5.1" })));
+          }
+        },
+      },
+      stderr: {
+        on: (_event: string, _handler: (chunk: Buffer) => void) => {},
+      },
+      on: (event: string, handler: (code?: number) => void) => {
+        if (event === "exit") {
+          setTimeout(() => handler(0), 0);
+        }
+      },
+      kill: vi.fn(),
+    }));
+
+    const detector = new DockerDetector();
+    const result = await detector.checkAvailability(true);
+
+    expect(result.available).toBe(true);
+    expect(result.version).toBe("27.5.1");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe",
+      ["info", "--format", "{{json .}}"],
+    );
+  });
+
+  it("preserves short ASCII docker errors when sanitizing", async () => {
+    execMock.mockRejectedValueOnce(new Error("dial tcp: EOF"));
+
+    const detector = new DockerDetector();
+    const result = await detector.checkAvailability(true);
+
+    expect(result.error).toBe("dial tcp: EOF");
   });
 });

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -1,8 +1,107 @@
 import { getServerBridge } from "@/core/platform";
+import { which } from "@/core/acp/utils";
 import type { DockerPullResult, DockerStatus } from "./types";
 
 const CACHE_TTL_MS = 30_000;
 const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Find docker executable on Windows by checking standard installation paths,
+ * since Docker Desktop typically installs outside the system PATH.
+ */
+async function findDockerOnWindows(bridge: ReturnType<typeof getServerBridge>): Promise<string | null> {
+  if (bridge.env.osPlatform() !== "win32") return null;
+
+  // Common Windows Docker Desktop installation paths
+  const programFilesDirs = [
+    process.env["ProgramFiles"] ?? "C:\\Program Files",
+    process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+  ];
+
+  const candidates = [
+    "\\Docker\\Docker\\resources\\bin\\docker.exe",
+    "\\Docker\\Docker\\resources\\bin\\docker-compose.exe",
+  ];
+
+  for (const base of programFilesDirs) {
+    for (const suffix of candidates) {
+      const fullPath = base + suffix;
+      try {
+        const stat = bridge.fs.statSync(fullPath);
+        if (stat.isFile) return fullPath;
+      } catch {
+        // Not found at this path, continue
+      }
+    }
+  }
+
+  return null;
+}
+
+function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: string | null): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const isWindows = bridge.env.osPlatform() === "win32";
+
+    if (dockerPath) {
+      // Use resolved absolute path — no shell needed for .exe files
+      const args = ["info", "--format", "{{json .}}"];
+      const handle = bridge.process.spawn(dockerPath, args, { timeout: DEFAULT_TIMEOUT_MS });
+      let stdout = "";
+      let stderr = "";
+
+      const timer = setTimeout(() => {
+        handle.kill();
+        reject(new Error("docker info timed out"));
+      }, DEFAULT_TIMEOUT_MS);
+
+      handle.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf-8");
+      });
+      handle.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf-8");
+      });
+      handle.on("exit", (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve(stdout);
+        else reject(new Error(stderr || `docker exited with code ${code}`));
+      });
+      handle.on("error", reject);
+    } else if (isWindows) {
+      // On Windows with no resolved path, use shell so cmd.exe searches PATH
+      const handle = bridge.process.spawn("docker", ["info", "--format", "{{json .}}"], {
+        shell: true,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+      let stdout = "";
+      let stderr = "";
+
+      const timer = setTimeout(() => {
+        handle.kill();
+        reject(new Error("docker info timed out"));
+      }, DEFAULT_TIMEOUT_MS);
+
+      handle.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf-8");
+      });
+      handle.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf-8");
+      });
+      handle.on("exit", (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve(stdout);
+        else reject(new Error(stderr || `docker exited with code ${code}`));
+      });
+      handle.on("error", reject);
+    } else {
+      // Unix: PATH should be inherited correctly
+      bridge.process.exec("docker info --format '{{json .}}'", { timeout: DEFAULT_TIMEOUT_MS })
+        .then(({ stdout: out }) => resolve(out))
+        .catch(reject);
+    }
+  });
+}
 
 export class DockerDetector {
   private static instance: DockerDetector | null = null;
@@ -25,11 +124,14 @@ export class DockerDetector {
     const bridge = getServerBridge();
     const checkedAt = new Date().toISOString();
 
-    try {
-      const { stdout } = await bridge.process.exec("docker info --format '{{json .}}'", {
-        timeout: DEFAULT_TIMEOUT_MS,
-      });
+    // Try to resolve docker path — first via PATH lookup, then standard Windows install dirs
+    let dockerPath = await which("docker");
+    if (!dockerPath) {
+      dockerPath = await findDockerOnWindows(bridge);
+    }
 
+    try {
+      const stdout = await execDockerInfo(bridge, dockerPath);
       const parsed = this.parseDockerInfo(stdout);
       const status: DockerStatus = {
         available: true,
@@ -43,10 +145,13 @@ export class DockerDetector {
       this.cachedAt = now;
       return status;
     } catch (err) {
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      // Strip platform-specific noise from error messages to avoid garbling
+      const sanitized = this.sanitizeErrorMessage(rawMessage);
       const status: DockerStatus = {
         available: false,
         daemonRunning: false,
-        error: err instanceof Error ? err.message : "Docker unavailable",
+        error: sanitized,
         checkedAt,
       };
 
@@ -60,10 +165,24 @@ export class DockerDetector {
     const bridge = getServerBridge();
 
     try {
-      const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
-        timeout: DEFAULT_TIMEOUT_MS,
-      });
-      return stdout.trim().length > 0;
+      let dockerPath = await which("docker");
+      if (!dockerPath) dockerPath = await findDockerOnWindows(bridge);
+      const args = ["images", "-q", image];
+
+      if (dockerPath) {
+        const handle = bridge.process.spawn(dockerPath, args, {});
+        let stdout = "";
+        return new Promise((resolve) => {
+          handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+          handle.on("exit", (code) => { resolve(code === 0 && stdout.trim().length > 0); });
+          handle.on("error", () => resolve(false));
+        });
+      } else {
+        const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
+          timeout: DEFAULT_TIMEOUT_MS,
+        });
+        return stdout.trim().length > 0;
+      }
     } catch {
       return false;
     }
@@ -73,21 +192,35 @@ export class DockerDetector {
     const bridge = getServerBridge();
 
     try {
-      const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
-        timeout: 10 * 60_000,
-      });
+      const dockerPath = await which("docker");
+      const args = ["pull", image];
 
-      return {
-        ok: true,
-        image,
-        output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim(),
-      };
+      if (dockerPath) {
+        const handle = bridge.process.spawn(dockerPath, args, { timeout: 10 * 60_000 });
+        let stdout = "";
+        let stderr = "";
+        return new Promise((resolve) => {
+          handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
+          handle.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
+          handle.on("exit", (code) => {
+            if (code === 0) {
+              resolve({ ok: true, image, output: stdout.trim() });
+            } else {
+              resolve({ ok: false, image, error: stderr || `docker exited with code ${code}` });
+            }
+          });
+          handle.on("error", (err: Error) => {
+            resolve({ ok: false, image, error: err.message });
+          });
+        });
+      } else {
+        const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
+          timeout: 10 * 60_000,
+        });
+        return { ok: true, image, output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim() };
+      }
     } catch (err) {
-      return {
-        ok: false,
-        image,
-        error: err instanceof Error ? err.message : "Failed to pull image",
-      };
+      return { ok: false, image, error: err instanceof Error ? err.message : "Failed to pull image" };
     }
   }
 
@@ -100,13 +233,25 @@ export class DockerDetector {
         ? clientInfo.ApiVersion
         : (typeof json.APIVersion === "string" ? json.APIVersion : undefined);
 
-      return {
-        version: serverVersion,
-        apiVersion,
-      };
+      return { version: serverVersion, apiVersion };
     } catch {
       return {};
     }
+  }
+
+  /**
+   * Remove Windows cmd.exe noise from error messages so the UI never displays
+   * garbled characters. Only keep the last line if it looks like a meaningful
+   * Docker / system error.
+   */
+  private sanitizeErrorMessage(raw: string): string {
+    if (!raw) return "Docker unavailable";
+    const lastLine = raw.split("\n").map((l) => l.trim()).filter(Boolean).pop() ?? raw;
+    // If it looks like encoded Chinese/GBK noise (contains high-byte chars), use a clean fallback
+    if (lastLine.length > 0 && lastLine.length < 20 && /[^a-zA-Z0-9 .,!?'-]/.test(lastLine)) {
+      return "Docker unavailable";
+    }
+    return lastLine;
   }
 }
 

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -22,7 +22,6 @@ async function findDockerOnWindows(bridge: ReturnType<typeof getServerBridge>): 
 
   const candidates = [
     "\\Docker\\Docker\\resources\\bin\\docker.exe",
-    "\\Docker\\Docker\\resources\\bin\\docker-compose.exe",
   ];
 
   for (const base of programFilesDirs) {
@@ -67,7 +66,10 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
         if (code === 0) resolve(stdout);
         else reject(new Error(stderr || `docker exited with code ${code}`));
       });
-      handle.on("error", reject);
+      handle.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
     } else if (isWindows) {
       // On Windows with no resolved path, use shell so cmd.exe searches PATH
       const handle = bridge.process.spawn("docker", ["info", "--format", "{{json .}}"], {
@@ -92,7 +94,10 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
         if (code === 0) resolve(stdout);
         else reject(new Error(stderr || `docker exited with code ${code}`));
       });
-      handle.on("error", reject);
+      handle.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
     } else {
       // Unix: PATH should be inherited correctly
       bridge.process.exec("docker info --format '{{json .}}'", { timeout: DEFAULT_TIMEOUT_MS })
@@ -266,8 +271,9 @@ export class DockerDetector {
   private sanitizeErrorMessage(raw: string): string {
     if (!raw) return "Docker unavailable";
     const lastLine = raw.split("\n").map((l) => l.trim()).filter(Boolean).pop() ?? raw;
-    // If it looks like encoded Chinese/GBK noise (contains high-byte chars), use a clean fallback
-    if (lastLine.length > 0 && lastLine.length < 20 && /[^a-zA-Z0-9 .,!?'-]/.test(lastLine)) {
+    // Preserve short, valid Docker errors like "dial tcp: EOF" and only
+    // collapse messages that contain non-ASCII / replacement characters.
+    if (/[^\u0020-\u007E]|�/u.test(lastLine)) {
       return "Docker unavailable";
     }
     return lastLine;

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -169,12 +169,23 @@ export class DockerDetector {
       const args = ["images", "-q", image];
 
       if (dockerPath) {
-        const handle = bridge.process.spawn(dockerPath, args, {});
+        const handle = bridge.process.spawn(dockerPath, args);
         let stdout = "";
         return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            handle.kill();
+            resolve(false);
+          }, DEFAULT_TIMEOUT_MS);
+
           handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
-          handle.on("exit", (code) => { resolve(code === 0 && stdout.trim().length > 0); });
-          handle.on("error", () => resolve(false));
+          handle.on("exit", (code) => {
+            clearTimeout(timer);
+            resolve(code === 0 && stdout.trim().length > 0);
+          });
+          handle.on("error", () => {
+            clearTimeout(timer);
+            resolve(false);
+          });
         });
       } else {
         const { stdout } = await bridge.process.exec(`docker images -q ${image}`, {
@@ -189,19 +200,27 @@ export class DockerDetector {
 
   async pullImage(image: string): Promise<DockerPullResult> {
     const bridge = getServerBridge();
+    const PULL_TIMEOUT_MS = 10 * 60_000; // 10 minutes for image pulls
 
     try {
-      const dockerPath = await which("docker");
+      let dockerPath = await which("docker");
+      if (!dockerPath) dockerPath = await findDockerOnWindows(bridge);
       const args = ["pull", image];
 
       if (dockerPath) {
-        const handle = bridge.process.spawn(dockerPath, args, { timeout: 10 * 60_000 });
+        const handle = bridge.process.spawn(dockerPath, args);
         let stdout = "";
         let stderr = "";
         return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            handle.kill();
+            resolve({ ok: false, image, error: "docker pull timed out" });
+          }, PULL_TIMEOUT_MS);
+
           handle.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf-8"); });
           handle.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf-8"); });
           handle.on("exit", (code) => {
+            clearTimeout(timer);
             if (code === 0) {
               resolve({ ok: true, image, output: stdout.trim() });
             } else {
@@ -209,12 +228,13 @@ export class DockerDetector {
             }
           });
           handle.on("error", (err: Error) => {
+            clearTimeout(timer);
             resolve({ ok: false, image, error: err.message });
           });
         });
       } else {
         const { stdout, stderr } = await bridge.process.exec(`docker pull ${image}`, {
-          timeout: 10 * 60_000,
+          timeout: PULL_TIMEOUT_MS,
         });
         return { ok: true, image, output: `${stdout}${stderr ? `\n${stderr}` : ""}`.trim() };
       }

--- a/src/core/acp/docker/detector.ts
+++ b/src/core/acp/docker/detector.ts
@@ -47,7 +47,7 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
     if (dockerPath) {
       // Use resolved absolute path — no shell needed for .exe files
       const args = ["info", "--format", "{{json .}}"];
-      const handle = bridge.process.spawn(dockerPath, args, { timeout: DEFAULT_TIMEOUT_MS });
+      const handle = bridge.process.spawn(dockerPath, args);
       let stdout = "";
       let stderr = "";
 
@@ -72,7 +72,6 @@ function execDockerInfo(bridge: ReturnType<typeof getServerBridge>, dockerPath: 
       // On Windows with no resolved path, use shell so cmd.exe searches PATH
       const handle = bridge.process.spawn("docker", ["info", "--format", "{{json .}}"], {
         shell: true,
-        timeout: DEFAULT_TIMEOUT_MS,
       });
       let stdout = "";
       let stderr = "";


### PR DESCRIPTION
Supersedes the unpushable maintainer follow-up for #448.

Why this exists:
- #448 comes from `sxyseo/routa`, and I do not have push permission to that forked branch.
- This PR carries the maintainer-side follow-up needed to safely merge the Docker Windows work.

Included changes:
- remove `docker-compose.exe` from Windows Docker fallback candidates
- preserve short actionable ASCII Docker errors instead of collapsing them
- clear spawn timeouts on early process errors
- extend `docker-detector` tests to cover Windows fallback path resolution and sanitizer behavior

Local verification:
- `npx vitest run src/core/acp/docker/__tests__/docker-detector.test.ts`
- `npm run dev`
- `curl -si http://127.0.0.1:3000/`
- `curl -si http://127.0.0.1:3000/api/acp/docker/status`

Known unrelated push-gate failures in current repo baseline:
- `ts_test_pass_full`: local `better-sqlite3` binary compiled for a different Node module version
- `clippy_pass`: existing workspace-wide `format!` lint failures unrelated to this diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows-specific Docker detection, including Docker Desktop installation directory scanning.

* **Bug Fixes**
  * Improved error message handling for Docker operations.
  * Fixed Docker version placeholder substitution in status displays.

* **Tests**
  * Added Windows platform compatibility test coverage.
  * Added Docker error scenario test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->