### PR TITLE
fix(acp): restore provider fallback and inline MCP config

### DIFF
--- a/src/client/hooks/__tests__/use-acp.test.tsx
+++ b/src/client/hooks/__tests__/use-acp.test.tsx
@@ -5,6 +5,7 @@ import type { AcpProviderInfo } from "@/client/acp-client";
 const {
   initializeMock,
   listProvidersMock,
+  loadRegistryProvidersMock,
   onUpdateMock,
   onConnectionIssueMock,
   disconnectMock,
@@ -19,6 +20,7 @@ const {
     source?: "static" | "registry";
     unavailableReason?: string;
   }[]>>(async () => []),
+  loadRegistryProvidersMock: vi.fn(async () => []),
   onUpdateMock: vi.fn(),
   onConnectionIssueMock: vi.fn(),
   disconnectMock: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock("../../acp-client", () => ({
   BrowserAcpClient: class MockBrowserAcpClient {
     initialize = initializeMock;
     listProviders = listProvidersMock;
+    loadRegistryProviders = loadRegistryProvidersMock;
     onUpdate = onUpdateMock;
     onConnectionIssue = onConnectionIssueMock;
     disconnect = disconnectMock;
@@ -103,6 +106,28 @@ describe("useAcp selected provider persistence", () => {
       expect(result.current.connected).toBe(true);
       expect(result.current.selectedProvider).toBe("codex");
     });
+  });
+
+  it("falls back to the first available provider when the stored provider is unavailable", async () => {
+    window.localStorage.setItem("routa.acp.selectedProvider", "claude");
+    listProvidersMock.mockResolvedValue([
+      { id: "claude", name: "Claude", command: "claude", description: "Claude provider", status: "unavailable", source: "static" },
+      { id: "opencode", name: "OpenCode", command: "opencode", description: "OpenCode provider", status: "available", source: "static" },
+      { id: "codex", name: "Codex", command: "codex-acp", description: "Codex provider", status: "unavailable", source: "static" },
+    ]);
+
+    const { result } = renderHook(() => useAcp());
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+      expect(result.current.selectedProvider).toBe("opencode");
+    });
+
+    expect(window.localStorage.getItem("routa.acp.selectedProvider")).toBe("opencode");
   });
 
   it("ignores duplicate connect calls while the client is already connected", async () => {

--- a/src/client/hooks/use-acp.ts
+++ b/src/client/hooks/use-acp.ts
@@ -259,8 +259,7 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
     sessionId: null,
     updates: [],
     providers: getInitialProviderFallbacks(),
-    // SSR-safe default; useEffect hydrates from localStorage after mount
-    // Using lazy initializer to avoid reading localStorage during SSR (returns "opencode")
+    // Always use SSR-safe default; useEffect below hydrates from localStorage
     selectedProvider: "opencode",
     loading: false,
     error: null,
@@ -268,21 +267,12 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
     dockerConfigError: null,
   }));
 
-  // Hydrate selectedProvider from localStorage after mount
-  // This ensures SSR (server="opencode") matches client initial render
+  // Hydrate selectedProvider from localStorage after mount to avoid SSR mismatch
   useEffect(() => {
     const persisted = loadSelectedAcpProvider();
-    setState((s) => {
-      // If persisted provider is unavailable, auto-select first available
-      const persistedProvider = s.providers.find((p) => p.id === persisted);
-      if (persistedProvider?.status === "unavailable") {
-        const firstAvailable = s.providers.find((p) => p.status === "available");
-        const nextProvider = firstAvailable?.id ?? "opencode";
-        saveSelectedAcpProvider(nextProvider);
-        return { ...s, selectedProvider: nextProvider };
-      }
-      return { ...s, selectedProvider: persisted };
-    });
+    if (persisted !== "opencode") {
+      setState((s) => ({ ...s, selectedProvider: persisted }));
+    }
   }, []);
   // Clean up on unmount
   useEffect(() => {

--- a/src/client/hooks/use-acp.ts
+++ b/src/client/hooks/use-acp.ts
@@ -254,18 +254,36 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
   // Track if user manually cancelled the session (to suppress "process exited" errors)
   const userCancelledRef = useRef(false);
 
-  const [state, setState] = useState<UseAcpState>({
+  const [state, setState] = useState<UseAcpState>(() => ({
     connected: false,
     sessionId: null,
     updates: [],
     providers: getInitialProviderFallbacks(),
-    selectedProvider: loadSelectedAcpProvider(),
+    // SSR-safe default; useEffect hydrates from localStorage after mount
+    // Using lazy initializer to avoid reading localStorage during SSR (returns "opencode")
+    selectedProvider: "opencode",
     loading: false,
     error: null,
     authError: null,
     dockerConfigError: null,
-  });
+  }));
 
+  // Hydrate selectedProvider from localStorage after mount
+  // This ensures SSR (server="opencode") matches client initial render
+  useEffect(() => {
+    const persisted = loadSelectedAcpProvider();
+    setState((s) => {
+      // If persisted provider is unavailable, auto-select first available
+      const persistedProvider = s.providers.find((p) => p.id === persisted);
+      if (persistedProvider?.status === "unavailable") {
+        const firstAvailable = s.providers.find((p) => p.status === "available");
+        const nextProvider = firstAvailable?.id ?? "opencode";
+        saveSelectedAcpProvider(nextProvider);
+        return { ...s, selectedProvider: nextProvider };
+      }
+      return { ...s, selectedProvider: persisted };
+    });
+  }, []);
   // Clean up on unmount
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -353,25 +371,11 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
 
       clientRef.current = client;
 
-      // Auto-select first available provider (claude-code-sdk in serverless, or first available)
-      const firstAvailable = allLocalProviders.find((p) => p.status === "available");
-
       setState((s) => ({
-        ...(function () {
-          const persistedProvider = loadSelectedAcpProvider();
-          const preferredProvider = allLocalProviders.find((provider) =>
-            provider.id === persistedProvider && provider.status !== "unavailable"
-          )?.id;
-          const nextSelectedProvider = preferredProvider ?? firstAvailable?.id ?? s.selectedProvider;
-          saveSelectedAcpProvider(nextSelectedProvider);
-          return {
-            ...s,
-            connected: true,
-            providers: allLocalProviders,
-            selectedProvider: nextSelectedProvider,
-            loading: false,
-          };
-        })(),
+        ...s,
+        connected: true,
+        providers: allLocalProviders,
+        loading: false,
       }));
 
       // Background task 1: Check local provider status

--- a/src/client/hooks/use-acp.ts
+++ b/src/client/hooks/use-acp.ts
@@ -361,11 +361,23 @@ export function useAcp(baseUrl: string = ""): UseAcpState & UseAcpActions {
 
       clientRef.current = client;
 
+      const firstAvailable = allLocalProviders.find((p) => p.status === "available");
       setState((s) => ({
-        ...s,
-        connected: true,
-        providers: allLocalProviders,
-        loading: false,
+        ...(function () {
+          const persistedProvider = loadSelectedAcpProvider();
+          const preferredProvider = allLocalProviders.find((provider) =>
+            provider.id === persistedProvider && provider.status !== "unavailable"
+          )?.id;
+          const nextSelectedProvider = preferredProvider ?? firstAvailable?.id ?? s.selectedProvider;
+          saveSelectedAcpProvider(nextSelectedProvider);
+          return {
+            ...s,
+            connected: true,
+            providers: allLocalProviders,
+            selectedProvider: nextSelectedProvider,
+            loading: false,
+          };
+        })(),
       }));
 
       // Background task 1: Check local provider status

--- a/src/core/acp/__tests__/mcp-setup.test.ts
+++ b/src/core/acp/__tests__/mcp-setup.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ensureMcpForProvider, parseMcpServersFromConfigs } from "../mcp-setup";
+
+vi.mock("@/core/store/custom-mcp-server-store", () => ({
+  getCustomMcpServerStore: () => null,
+  mergeCustomMcpServers: (builtIn: Record<string, unknown>) => builtIn,
+}));
+
+describe("ensureMcpForProvider", () => {
+  it("keeps Claude MCP config inline so SDK parsing still works", async () => {
+    const result = await ensureMcpForProvider("claude", {
+      routaServerUrl: "http://127.0.0.1:3000",
+      workspaceId: "ws-test",
+      includeCustomServers: false,
+    });
+
+    expect(result.mcpConfigs).toHaveLength(1);
+    expect(result.mcpConfigs[0]).toContain("\"mcpServers\"");
+
+    const parsed = parseMcpServersFromConfigs(result.mcpConfigs);
+    expect(parsed?.["routa-coordination"]).toMatchObject({
+      type: "http",
+      url: "http://127.0.0.1:3000/api/mcp",
+    });
+  });
+});

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -151,6 +151,7 @@ export class AcpProcess {
             stdio: ["pipe", "pipe", "pipe"],
             cwd,
             env: {
+                ...process.env,
                 ...env,
                 NODE_NO_READLINE: "1",
             },

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -385,7 +385,9 @@ export class AcpProcess {
             let defaultTimeout: number;
             if (isInitRequest) {
                 // npx/uvx may need to download packages on first run
-                defaultTimeout = isNpxOrUvx ? 120000 : 15000; // 2 min for npx/uvx, 15s for others
+                // OpenCode may need longer on Windows due to shell initialization overhead
+                const isOpencode = this._config.displayName?.toLowerCase().includes("opencode");
+                defaultTimeout = isNpxOrUvx ? 120000 : (isOpencode ? 30000 : 15000); // 30s for opencode, 15s for others
             } else if (isPromptRequest) {
                 // session/prompt can take a long time for complex tasks
                 // Match Rust implementation: 5 minutes for prompt requests

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -128,7 +128,7 @@ export async function ensureMcpForProvider(
     case "auggie":
       return await ensureMcpForAuggie(mcpEndpoint, cfg.workspaceId, customServers);
     case "claude":
-      return ensureMcpForClaude(mcpEndpoint, cfg.workspaceId, customServers);
+      return await ensureMcpForClaude(mcpEndpoint, cfg.workspaceId, customServers);
     case "codex":
       return await ensureMcpForCodex(mcpEndpoint, customServers);
     case "gemini":
@@ -267,12 +267,13 @@ async function ensureMcpForAuggie(
 // ─── Claude Code ───────────────────────────────────────────────────────
 //
 // Claude Code accepts inline JSON via --mcp-config <json>
+// On Windows, we write to a temp file to avoid shell quoting issues with backslashes in JSON
 
-function ensureMcpForClaude(
+async function ensureMcpForClaude(
   mcpEndpoint: string,
   workspaceId?: string,
   customServers: CustomMcpServerConfig[] = [],
-): McpSetupResult {
+): Promise<McpSetupResult> {
   const builtIn: Record<string, unknown> = {
     "routa-coordination": {
       url: mcpEndpoint,
@@ -284,6 +285,26 @@ function ensureMcpForClaude(
     mcpServers: mergeCustomMcpServers(builtIn, customServers),
   });
 
+  // On Windows, write to a temp file to avoid shell quoting issues
+  // The JSON contains backslashes (e.g., in URLs like http://localhost:3000)
+  // which get misinterpreted in shell mode
+  if (process.platform === "win32") {
+    const tempDir = os.tmpdir();
+    const tempFile = path.join(tempDir, `claude-mcp-${Date.now()}.json`);
+
+    try {
+      await fs.promises.writeFile(tempFile, json, "utf-8");
+      return {
+        mcpConfigs: [tempFile],
+        summary: `claude: temp file ${tempFile} (${json.length} bytes)`,
+      };
+    } catch (err) {
+      console.error(`[MCP:Claude] Failed to write temp file: ${err}`);
+      // Fall through to inline JSON as fallback
+    }
+  }
+
+  // On non-Windows or if temp file write fails, use inline JSON
   return {
     mcpConfigs: [json],
     summary: `claude: inline JSON (${json.length} bytes)`,

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -267,13 +267,12 @@ async function ensureMcpForAuggie(
 // ─── Claude Code ───────────────────────────────────────────────────────
 //
 // Claude Code accepts inline JSON via --mcp-config <json>
-// On Windows, we write to a temp file to avoid shell quoting issues with backslashes in JSON
 
-async function ensureMcpForClaude(
+function ensureMcpForClaude(
   mcpEndpoint: string,
   workspaceId?: string,
   customServers: CustomMcpServerConfig[] = [],
-): Promise<McpSetupResult> {
+): McpSetupResult {
   const builtIn: Record<string, unknown> = {
     "routa-coordination": {
       url: mcpEndpoint,
@@ -285,26 +284,6 @@ async function ensureMcpForClaude(
     mcpServers: mergeCustomMcpServers(builtIn, customServers),
   });
 
-  // On Windows, write to a temp file to avoid shell quoting issues
-  // The JSON contains backslashes (e.g., in URLs like http://localhost:3000)
-  // which get misinterpreted in shell mode
-  if (process.platform === "win32") {
-    const tempDir = os.tmpdir();
-    const tempFile = path.join(tempDir, `claude-mcp-${Date.now()}.json`);
-
-    try {
-      await fs.promises.writeFile(tempFile, json, "utf-8");
-      return {
-        mcpConfigs: [tempFile],
-        summary: `claude: temp file ${tempFile} (${json.length} bytes)`,
-      };
-    } catch (err) {
-      console.error(`[MCP:Claude] Failed to write temp file: ${err}`);
-      // Fall through to inline JSON as fallback
-    }
-  }
-
-  // On non-Windows or if temp file write fails, use inline JSON
   return {
     mcpConfigs: [json],
     summary: `claude: inline JSON (${json.length} bytes)`,

--- a/src/core/acp/terminal-manager.ts
+++ b/src/core/acp/terminal-manager.ts
@@ -183,7 +183,7 @@ export class TerminalManager {
       : bridge.process.spawn(command, args, {
           stdio: ["pipe", "pipe", "pipe"],
           cwd,
-          env: mergedEnv,
+          env: { ...process.env, ...mergedEnv },
           shell: true,
         });
     const backend: ManagedTerminal["backend"] = nodePty ? "node-pty" : "spawn";

--- a/src/core/acp/utils.ts
+++ b/src/core/acp/utils.ts
@@ -24,7 +24,23 @@ function getCandidateDirectory(candidate: string): string {
  */
 export function needsShell(command: string): boolean {
   const lower = command.toLowerCase();
-  return lower.endsWith(".cmd") || lower.endsWith(".bat");
+
+  // Explicit .cmd/.bat extension
+  if (lower.endsWith(".cmd") || lower.endsWith(".bat")) {
+    return true;
+  }
+
+  // On Windows, npm-installed CLI tools without extensions might be .cmd files
+  // We need shell to properly resolve and execute them
+  if (process.platform === "win32") {
+    const hasExtension = /\.[a-zA-Z0-9]+$/.test(command);
+    const isPath = command.includes("/") || command.includes("\\");
+    if (!hasExtension && !isPath) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Supersedes the unpushable maintainer follow-up for #449.

Why this exists:
- #449 comes from `sxyseo/routa`, and I do not have push permission to that forked branch.
- This PR carries the maintainer-side fixes needed before merging the ACP Windows changes.

Included changes:
- restore provider selection fallback during `useAcp.connect()`
- keep Claude MCP config as inline JSON so existing SDK/CLI parsing keeps working
- add regression coverage for unavailable persisted providers
- add MCP setup coverage proving Claude config remains parseable inline JSON

Local verification:
- `npx vitest run src/client/hooks/__tests__/use-acp.test.tsx src/core/acp/__tests__/mcp-setup.test.ts`
- existing local dev server on `http://127.0.0.1:3000`
- `curl -si http://127.0.0.1:3000/`
- `curl -si http://127.0.0.1:3000/api/test-mcp`

Note:
- original fork branch is not writable from maintainer side, so this PR is the mergeable handoff for the same review fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSR compatibility for provider selection initialization.
  * Enhanced Windows command resolution for npm-installed CLI tools.
  * Fixed async process handling in MCP setup.

* **Tests**
  * Added test coverage for provider fallback behavior when unavailable.
  * Added MCP setup verification tests.

* **Chores**
  * Improved process environment variable inheritance.
  * Adjusted timeout handling for provider-specific operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->