### PR TITLE
fix(theme): keep system selection mutually exclusive

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,24 @@ export const metadata: Metadata = {
   },
 };
 
+// Inline script to prevent flash of wrong theme
+const themeInitScript = `
+  (function() {
+    try {
+      var theme = localStorage.getItem('routa.theme');
+      if (!theme || theme === 'system') {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = prefersDark ? 'dark' : 'light';
+      }
+      document.documentElement.classList.add(theme);
+      document.documentElement.dataset.themePreference = localStorage.getItem('routa.theme') || 'system';
+      document.documentElement.style.colorScheme = theme;
+    } catch (e) {
+      console.warn('Theme initialization failed:', e);
+    }
+  })();
+`;
+
 export default function RootLayout({
   children,
 }: {
@@ -20,7 +38,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head />
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="antialiased">
         <ThemeInitializer />
         <I18nProvider>{children}</I18nProvider>

--- a/src/client/components/__tests__/theme-switcher.test.tsx
+++ b/src/client/components/__tests__/theme-switcher.test.tsx
@@ -10,7 +10,7 @@ const {
 } = vi.hoisted(() => ({
   getStoredThemePreference: vi.fn(() => "light"),
   resolveThemePreference: vi.fn(() => "light"),
-  setThemePreference: vi.fn((theme: "light" | "dark") => theme),
+  setThemePreference: vi.fn((theme: "light" | "dark" | "system") => theme),
   subscribeToThemePreference: vi.fn(() => () => {}),
 }));
 
@@ -43,6 +43,7 @@ describe("ThemeSwitcher", () => {
     expect(screen.getByText("Theme")).not.toBeNull();
     expect(screen.getByRole("button", { name: "Light" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Dark" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "System" })).not.toBeNull();
   });
 
   it("keeps server markup deterministic and syncs the mounted title afterward", async () => {
@@ -64,5 +65,18 @@ describe("ThemeSwitcher", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dark" }));
 
     expect(setThemePreference).toHaveBeenCalledWith("dark");
+  });
+
+  it("marks only the system button as active when the system preference is selected", async () => {
+    getStoredThemePreference.mockReturnValue("system");
+    resolveThemePreference.mockReturnValue("dark");
+
+    render(<ThemeSwitcher compact />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "System" }).getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByRole("button", { name: "Dark" }).getAttribute("aria-pressed")).toBe("false");
+      expect(screen.getByRole("button", { name: "Light" }).getAttribute("aria-pressed")).toBe("false");
+    });
   });
 });

--- a/src/client/components/repo-picker.tsx
+++ b/src/client/components/repo-picker.tsx
@@ -157,6 +157,7 @@ export function RepoPicker({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const cloneInputRef = useRef<HTMLInputElement>(null);
+  const isMountedRef = useRef(true);
   const [dropdownPos, setDropdownPos] = useState<{
     left: number;
     width: number;
@@ -172,11 +173,15 @@ export function RepoPicker({
     try {
       const res = await desktopAwareFetch("/api/clone");
       const data = await res.json();
-      setRepos(data.repos || []);
+      if (isMountedRef.current) {
+        setRepos(data.repos || []);
+      }
     } catch {
       // ignore
     } finally {
-      setLoadingRepos(false);
+      if (isMountedRef.current) {
+        setLoadingRepos(false);
+      }
     }
   }, []);
 
@@ -185,6 +190,14 @@ export function RepoPicker({
       fetchRepos();
     }
   }, [fetchRepos, sourceMode]);
+
+  // Track component mount status for async operations
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   // ── Click outside to close ─────────────────────────────────────────
 
@@ -274,6 +287,8 @@ export function RepoPicker({
               try {
                 const event = JSON.parse(line.slice(6));
 
+                if (!isMountedRef.current) return;
+
                 if (event.phase === "done") {
                   // Clone successful
                   onChange({
@@ -303,12 +318,15 @@ export function RepoPicker({
           }
         }
       } catch (err) {
+        if (!isMountedRef.current) return;
         setCloneError(
           err instanceof Error ? err.message : "Clone failed"
         );
         setCloneProgress(null);
       } finally {
-        setCloning(false);
+        if (isMountedRef.current) {
+          setCloning(false);
+        }
       }
     },
     [onChange, fetchRepos]
@@ -350,6 +368,8 @@ export function RepoPicker({
           );
         }
 
+        if (!isMountedRef.current) return;
+
         onChange({
           name:
             typeof data?.name === "string"
@@ -362,11 +382,14 @@ export function RepoPicker({
         setSearchQuery("");
         setShowDropdown(false);
       } catch (err) {
+        if (!isMountedRef.current) return;
         setLocalRepoError(
           err instanceof Error ? err.message : "Failed to load local repository"
         );
       } finally {
-        setLoadingLocalRepo(false);
+        if (isMountedRef.current) {
+          setLoadingLocalRepo(false);
+        }
       }
     },
     [onChange]

--- a/src/client/components/theme-switcher.tsx
+++ b/src/client/components/theme-switcher.tsx
@@ -12,7 +12,7 @@ import {
   type ResolvedTheme,
   type ThemePreference,
 } from "../utils/theme";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, Monitor } from "lucide-react";
 
 
 interface ThemeSwitcherProps {
@@ -38,10 +38,14 @@ export function ThemeSwitcher({ showLabel = false, compact = false, className = 
     ? "rounded-md p-1.5 transition-colors"
     : "rounded-md px-2 py-1 text-[11px] font-medium transition-colors";
 
-  const renderButton = (nextTheme: Exclude<ThemePreference, "system">) => {
-    const active = resolvedTheme === nextTheme;
-    const label = nextTheme === "light" ? t.settings.light : t.settings.dark;
-    const title = themePreference === "system" ? `${label} · ${t.settings.system}` : label;
+  const renderButton = (nextTheme: ThemePreference) => {
+    const isActivePreference = themePreference === nextTheme;
+    // For system mode, check resolved theme; for explicit modes, check the mode itself
+    const active = nextTheme === "system"
+      ? isActivePreference
+      : resolvedTheme === nextTheme;
+    const label = nextTheme === "light" ? t.settings.light : nextTheme === "dark" ? t.settings.dark : t.settings.system;
+    const title = nextTheme === "system" ? label : (themePreference === "system" ? `${label} · ${t.settings.system}` : label);
 
     return (
       <button
@@ -62,8 +66,10 @@ export function ThemeSwitcher({ showLabel = false, compact = false, className = 
         <span className="flex items-center gap-1.5">
           {nextTheme === "light" ? (
             <Sun className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}/>
-          ) : (
+          ) : nextTheme === "dark" ? (
             <Moon className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}/>
+          ) : (
+            <Monitor className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}/>
           )}
           {!compact ? <span>{label}</span> : null}
         </span>
@@ -82,6 +88,7 @@ export function ThemeSwitcher({ showLabel = false, compact = false, className = 
       ) : null}
       {renderButton("light")}
       {renderButton("dark")}
+      {renderButton("system")}
     </div>
   );
 }

--- a/src/client/components/theme-switcher.tsx
+++ b/src/client/components/theme-switcher.tsx
@@ -32,18 +32,14 @@ export function ThemeSwitcher({ showLabel = false, compact = false, className = 
     },
     () => "system:light",
   );
-  const [themePreference, resolvedTheme] = themeSnapshot.split(":") as [ThemePreference, ResolvedTheme];
+  const [themePreference] = themeSnapshot.split(":") as [ThemePreference, ResolvedTheme];
 
   const buttonBaseClassName = compact
     ? "rounded-md p-1.5 transition-colors"
     : "rounded-md px-2 py-1 text-[11px] font-medium transition-colors";
 
   const renderButton = (nextTheme: ThemePreference) => {
-    const isActivePreference = themePreference === nextTheme;
-    // For system mode, check resolved theme; for explicit modes, check the mode itself
-    const active = nextTheme === "system"
-      ? isActivePreference
-      : resolvedTheme === nextTheme;
+    const active = themePreference === nextTheme;
     const label = nextTheme === "light" ? t.settings.light : nextTheme === "dark" ? t.settings.dark : t.settings.system;
     const title = nextTheme === "system" ? label : (themePreference === "system" ? `${label} · ${t.settings.system}` : label);
 


### PR DESCRIPTION
Maintainer-side follow-up for #450.

Why this exists:
- #450 comes from `sxyseo/routa`, and I do not have push permission to that forked branch.
- The original `RepoPicker` unmount-safety fix looks reasonable, but the PR also introduced a theme selection regression.

Included changes:
- keep the new `system` theme option
- make the theme switcher mutually exclusive again by keying the active state to the selected preference
- add regression coverage proving `System` is the only active option when system preference is selected

Local verification:
- `npx vitest run src/client/components/__tests__/theme-switcher.test.tsx src/client/components/__tests__/repo-picker.test.tsx`
- existing local dev server on `http://127.0.0.1:3000`
- `curl -si http://127.0.0.1:3000/`

Note:
- original fork branch is not writable from maintainer side, so this PR is the maintainer merge path for the final semantic fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system theme preference option alongside light and dark modes.
  * Theme preference now initializes before page renders, eliminating flash of incorrect theme.

* **Bug Fixes**
  * Fixed potential state update errors when repository picker component unmounts.

* **Tests**
  * Updated theme switcher tests to support system theme selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->