### PR TITLE
fix(tauri-bridge): await async spawn and preserve workspace in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ docs/issues/*-gh-*.md
 tools/ppt-template/output/
 tools/ppt-template/node_modules/
 .agents
+/people/

--- a/src/app/settings/harness/harness-console-page.tsx
+++ b/src/app/settings/harness/harness-console-page.tsx
@@ -33,6 +33,7 @@ import {
 import { useHarnessSettingsData } from "@/client/hooks/use-harness-settings-data";
 import { useCodebases, useWorkspaces } from "@/client/hooks/use-workspaces";
 import { loadRepoSelection, saveRepoSelection } from "@/client/utils/repo-selection-storage";
+import { normalizeWorkspaceQueryId, resolveWorkspaceSelection } from "@/client/utils/workspace-id";
 
 type SectionId =
   | "overview"
@@ -139,8 +140,12 @@ export default function HarnessConsolePage() {
   const sectionFromUrl = resolveSectionId(searchParams.get(HARNESS_SECTION_QUERY_KEY));
   const architectureSectionActive = sectionFromUrl === "architecture-quality";
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState("");
-  const urlWorkspaceId = searchParams.get("workspaceId") || "";
-  const workspaceId = selectedWorkspaceId || urlWorkspaceId || workspacesHook.workspaces[0]?.id || "";
+  const urlWorkspaceId = normalizeWorkspaceQueryId(searchParams.get("workspaceId"));
+  const workspaceId = resolveWorkspaceSelection(
+    selectedWorkspaceId,
+    urlWorkspaceId,
+    workspacesHook.workspaces,
+  );
   const { codebases } = useCodebases(workspaceId);
   const [selectedCodebaseId, setSelectedCodebaseId] = useState("");
   const [selectedRepoOverrideState, setSelectedRepoOverrideState] = useState<{

--- a/src/app/settings/harness/harness-console-page.tsx
+++ b/src/app/settings/harness/harness-console-page.tsx
@@ -139,7 +139,8 @@ export default function HarnessConsolePage() {
   const sectionFromUrl = resolveSectionId(searchParams.get(HARNESS_SECTION_QUERY_KEY));
   const architectureSectionActive = sectionFromUrl === "architecture-quality";
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState("");
-  const workspaceId = selectedWorkspaceId || workspacesHook.workspaces[0]?.id || "";
+  const urlWorkspaceId = searchParams.get("workspaceId") || "";
+  const workspaceId = selectedWorkspaceId || urlWorkspaceId || workspacesHook.workspaces[0]?.id || "";
   const { codebases } = useCodebases(workspaceId);
   const [selectedCodebaseId, setSelectedCodebaseId] = useState("");
   const [selectedRepoOverrideState, setSelectedRepoOverrideState] = useState<{

--- a/src/app/settings/settings-page-client.tsx
+++ b/src/app/settings/settings-page-client.tsx
@@ -8,6 +8,7 @@ import { SettingsPanel } from "@/client/components/settings-panel";
 import type { SettingsTab } from "@/client/components/settings-panel-shared";
 import { useTranslation } from "@/i18n";
 import { desktopAwareFetch } from "@/client/utils/diagnostics";
+import { normalizeWorkspaceQueryId } from "@/client/utils/workspace-id";
 import { Settings } from "lucide-react";
 
 
@@ -24,8 +25,7 @@ export function SettingsPageClient() {
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const requestedTab = searchParams.get("tab");
   const initialTab = isSettingsTab(requestedTab) ? requestedTab : undefined;
-  // Preserve workspace context so sidebar navigation stays within the same workspace.
-  const workspaceId = searchParams.get("workspaceId") || null;
+  const workspaceId = normalizeWorkspaceQueryId(searchParams.get("workspaceId"));
 
   useEffect(() => {
     const fetchProviders = async () => {

--- a/src/app/settings/settings-page-client.tsx
+++ b/src/app/settings/settings-page-client.tsx
@@ -24,6 +24,8 @@ export function SettingsPageClient() {
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const requestedTab = searchParams.get("tab");
   const initialTab = isSettingsTab(requestedTab) ? requestedTab : undefined;
+  // Preserve workspace context so sidebar navigation stays within the same workspace.
+  const workspaceId = searchParams.get("workspaceId") || null;
 
   useEffect(() => {
     const fetchProviders = async () => {
@@ -46,11 +48,12 @@ export function SettingsPageClient() {
       router.back();
       return;
     }
-    router.push("/");
+    router.push(workspaceId ? `/workspace/${workspaceId}/sessions` : "/");
   };
 
   return (
     <DesktopAppShell
+      workspaceId={workspaceId}
       workspaceSwitcher={(
         <div className="flex items-center gap-1.5 rounded-xl border border-desktop-border bg-desktop-bg-secondary px-2.5 py-1.5 text-[11px] text-desktop-text-primary">
           <Settings className="h-3 w-3 text-desktop-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}/>

--- a/src/client/components/__tests__/desktop-sidebar.test.tsx
+++ b/src/client/components/__tests__/desktop-sidebar.test.tsx
@@ -29,7 +29,7 @@ describe("DesktopSidebar", () => {
     expect(screen.queryByRole("link", { name: "MCP Servers" })).toBeNull();
     expect(screen.getByRole("link", { name: "Harness" }).getAttribute("href")).toBe("/settings/harness?workspaceId=default");
     expect(screen.getByRole("link", { name: "Fluency" }).getAttribute("href")).toBe("/settings/fluency?workspaceId=default");
-    expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe("/settings");
+    expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe("/settings?workspaceId=default");
     expect(screen.queryByRole("button", { name: "Settings" })).toBeNull();
   });
 

--- a/src/client/components/desktop-sidebar.tsx
+++ b/src/client/components/desktop-sidebar.tsx
@@ -110,7 +110,9 @@ export function DesktopSidebar({
     {
       id: "settings",
       label: t.settings.title,
-      href: "/settings",
+      href: normalizedWorkspaceId
+        ? `/settings?workspaceId=${encodeURIComponent(normalizedWorkspaceId)}`
+        : "/settings",
       exactMatch: true,
       icon: <Settings className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.7}/>,
     },

--- a/src/client/utils/__tests__/workspace-id.test.ts
+++ b/src/client/utils/__tests__/workspace-id.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeWorkspaceQueryId, resolveWorkspaceSelection } from "../workspace-id";
+import type { WorkspaceData } from "@/client/hooks/use-workspaces";
+
+const workspaces: WorkspaceData[] = [
+  {
+    id: "default",
+    title: "Default",
+    status: "active",
+    metadata: {},
+    createdAt: "",
+    updatedAt: "",
+  },
+  {
+    id: "team_alpha",
+    title: "Team Alpha",
+    status: "active",
+    metadata: {},
+    createdAt: "",
+    updatedAt: "",
+  },
+];
+
+describe("workspace-id utilities", () => {
+  it("accepts only path-safe workspace ids from query params", () => {
+    expect(normalizeWorkspaceQueryId("default")).toBe("default");
+    expect(normalizeWorkspaceQueryId(" team_alpha ")).toBe("team_alpha");
+    expect(normalizeWorkspaceQueryId("../bad")).toBeNull();
+    expect(normalizeWorkspaceQueryId("bad/value")).toBeNull();
+    expect(normalizeWorkspaceQueryId("")).toBeNull();
+    expect(normalizeWorkspaceQueryId(null)).toBeNull();
+  });
+
+  it("prefers an explicit selection over the URL workspace", () => {
+    expect(resolveWorkspaceSelection("team_alpha", "default", workspaces)).toBe("team_alpha");
+  });
+
+  it("uses the URL workspace only when it exists in the loaded workspace list", () => {
+    expect(resolveWorkspaceSelection("", "team_alpha", workspaces)).toBe("team_alpha");
+    expect(resolveWorkspaceSelection("", "missing", workspaces)).toBe("default");
+  });
+});

--- a/src/client/utils/workspace-id.ts
+++ b/src/client/utils/workspace-id.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceData } from "@/client/hooks/use-workspaces";
+
+const WORKSPACE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function normalizeWorkspaceQueryId(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (!normalized || !WORKSPACE_ID_PATTERN.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function resolveWorkspaceSelection(
+  selectedWorkspaceId: string,
+  urlWorkspaceId: string | null,
+  workspaces: WorkspaceData[],
+): string {
+  const normalizedSelectedWorkspaceId = normalizeWorkspaceQueryId(selectedWorkspaceId);
+  if (normalizedSelectedWorkspaceId) {
+    return normalizedSelectedWorkspaceId;
+  }
+
+  const normalizedUrlWorkspaceId = normalizeWorkspaceQueryId(urlWorkspaceId);
+  if (normalizedUrlWorkspaceId && workspaces.some((workspace) => workspace.id === normalizedUrlWorkspaceId)) {
+    return normalizedUrlWorkspaceId;
+  }
+
+  return workspaces[0]?.id ?? "";
+}

--- a/src/core/acp/__tests__/process-ready.test.ts
+++ b/src/core/acp/__tests__/process-ready.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { awaitProcessReady } from "../utils";
+import type { IProcessHandle } from "@/core/platform/interfaces";
+
+function createProcessHandle(ready?: Promise<void>): IProcessHandle {
+  return {
+    pid: 123,
+    stdin: null,
+    stdout: null,
+    stderr: null,
+    exitCode: null,
+    ready,
+    kill: () => {},
+    on: () => {},
+  };
+}
+
+describe("awaitProcessReady", () => {
+  it("returns immediately when the backend does not expose a ready promise", async () => {
+    await expect(awaitProcessReady(createProcessHandle())).resolves.toBeUndefined();
+  });
+
+  it("clears the timeout after the ready promise resolves", async () => {
+    vi.useFakeTimers();
+
+    const ready = Promise.resolve();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    const pending = awaitProcessReady(createProcessHandle(ready), 25);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -161,6 +161,22 @@ export class AcpProcess {
             shell: needsShell(command),
         });
 
+        // Await ready promise for async spawn backends (e.g. Tauri).
+        if (this.process.ready) {
+            const SPAWN_READY_TIMEOUT_MS = 30_000;
+            await Promise.race([
+                this.process.ready,
+                new Promise<never>((_, reject) =>
+                    setTimeout(
+                        () => reject(new Error(
+                            `Timed out waiting for process spawn after ${SPAWN_READY_TIMEOUT_MS / 1000}s`
+                        )),
+                        SPAWN_READY_TIMEOUT_MS,
+                    )
+                ),
+            ]);
+        }
+
         if (!this.process || !this.process.pid) {
             throw new Error(
                 `Failed to spawn ${displayName} - is "${command}" installed and in PATH?`

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -5,7 +5,7 @@ import {
     NotificationHandler,
     PendingRequest,
 } from "@/core/acp/processer";
-import {needsShell} from "@/core/acp/utils";
+import { awaitProcessReady, needsShell } from "@/core/acp/utils";
 import {getTerminalManager} from "@/core/acp/terminal-manager";
 import type {IProcessHandle} from "@/core/platform/interfaces";
 import {getServerBridge} from "@/core/platform";
@@ -161,28 +161,6 @@ export class AcpProcess {
             shell: needsShell(command),
         });
 
-        // Await ready promise for async spawn backends (e.g. Tauri).
-        if (this.process.ready) {
-            const SPAWN_READY_TIMEOUT_MS = 30_000;
-            await Promise.race([
-                this.process.ready,
-                new Promise<never>((_, reject) =>
-                    setTimeout(
-                        () => reject(new Error(
-                            `Timed out waiting for process spawn after ${SPAWN_READY_TIMEOUT_MS / 1000}s`
-                        )),
-                        SPAWN_READY_TIMEOUT_MS,
-                    )
-                ),
-            ]);
-        }
-
-        if (!this.process || !this.process.pid) {
-            throw new Error(
-                `Failed to spawn ${displayName} - is "${command}" installed and in PATH?`
-            );
-        }
-
         if (!this.process.stdin || !this.process.stdout) {
             throw new Error(
                 `${displayName} spawned without required stdio streams`
@@ -191,7 +169,6 @@ export class AcpProcess {
 
         this._alive = true;
 
-        // Parse stdout as NDJSON
         this.process.stdout.on("data", (chunk: Buffer) => {
             this.buffer += chunk.toString("utf-8");
             this.processBuffer();
@@ -236,6 +213,14 @@ export class AcpProcess {
             console.error(`[AcpProcess:${displayName}] Process error:`, err);
             this._alive = false;
         });
+
+        await awaitProcessReady(this.process);
+
+        if (!this.process.pid) {
+            throw new Error(
+                `Failed to spawn ${displayName} - is "${command}" installed and in PATH?`
+            );
+        }
 
         // Wait for process to stabilize
         await new Promise((resolve) => setTimeout(resolve, 500));

--- a/src/core/acp/claude-code-process.ts
+++ b/src/core/acp/claude-code-process.ts
@@ -1,6 +1,6 @@
 import { NotificationHandler, JsonRpcMessage } from "@/core/acp/processer";
 import { AcpAgentPreset, resolveCommand } from "@/core/acp/acp-presets";
-import { needsShell } from "@/core/acp/utils";
+import { awaitProcessReady, needsShell } from "@/core/acp/utils";
 import type { IProcessHandle } from "@/core/platform/interfaces";
 import { getServerBridge } from "@/core/platform";
 
@@ -262,41 +262,12 @@ export class ClaudeCodeProcess {
             shell: needsShell(cmd[0]),
         });
 
-        // Await ready promise for async spawn backends (e.g. Tauri) where
-        // cmd.spawn() resolves after the handle is returned.
-        // Guard with a 30s timeout to prevent indefinite hangs if the
-        // Tauri shell plugin fails to respond.
-        if (this.process.ready) {
-            const SPAWN_READY_TIMEOUT_MS = 30_000;
-            await Promise.race([
-                this.process.ready,
-                new Promise<never>((_, reject) =>
-                    setTimeout(
-                        () => reject(new Error(
-                            `Timed out waiting for process spawn after ${SPAWN_READY_TIMEOUT_MS / 1000}s`
-                        )),
-                        SPAWN_READY_TIMEOUT_MS,
-                    )
-                ),
-            ]);
-        }
-
-        if (!this.process || !this.process.pid) {
-            const pathSep = process.platform === "win32" ? ";" : ":";
-            const pathHint = process.env.PATH?.split(pathSep).slice(0, 5).join(pathSep) ?? "(empty)";
-            throw new Error(
-                `Failed to spawn Claude Code - is "${command}" installed and in PATH? ` +
-                `(cwd: ${cwd}, PATH starts with: ${pathHint})`
-            );
-        }
-
         if (!this.process.stdin || !this.process.stdout) {
             throw new Error(`Claude Code spawned without required stdio streams`);
         }
 
         this._alive = true;
 
-        // Parse stdout as NDJSON
         this.process.stdout.on("data", (chunk: Buffer) => {
             this.buffer += chunk.toString("utf-8");
             this.processBuffer();
@@ -323,6 +294,17 @@ export class ClaudeCodeProcess {
             console.error(`[ClaudeCode:${displayName}] Process error:`, err);
             this._alive = false;
         });
+
+        await awaitProcessReady(this.process);
+
+        if (!this.process.pid) {
+            const pathSep = process.platform === "win32" ? ";" : ":";
+            const pathHint = process.env.PATH?.split(pathSep).slice(0, 5).join(pathSep) ?? "(empty)";
+            throw new Error(
+                `Failed to spawn Claude Code - is "${command}" installed and in PATH? ` +
+                `(cwd: ${cwd}, PATH starts with: ${pathHint})`
+            );
+        }
 
         // Wait for process to stabilize
         await new Promise((resolve) => setTimeout(resolve, 500));

--- a/src/core/acp/claude-code-process.ts
+++ b/src/core/acp/claude-code-process.ts
@@ -262,8 +262,28 @@ export class ClaudeCodeProcess {
             shell: needsShell(cmd[0]),
         });
 
+        // Await ready promise for async spawn backends (e.g. Tauri) where
+        // cmd.spawn() resolves after the handle is returned.
+        // Guard with a 30s timeout to prevent indefinite hangs if the
+        // Tauri shell plugin fails to respond.
+        if (this.process.ready) {
+            const SPAWN_READY_TIMEOUT_MS = 30_000;
+            await Promise.race([
+                this.process.ready,
+                new Promise<never>((_, reject) =>
+                    setTimeout(
+                        () => reject(new Error(
+                            `Timed out waiting for process spawn after ${SPAWN_READY_TIMEOUT_MS / 1000}s`
+                        )),
+                        SPAWN_READY_TIMEOUT_MS,
+                    )
+                ),
+            ]);
+        }
+
         if (!this.process || !this.process.pid) {
-            const pathHint = process.env.PATH?.split(":").slice(0, 5).join(":") ?? "(empty)";
+            const pathSep = process.platform === "win32" ? ";" : ":";
+            const pathHint = process.env.PATH?.split(pathSep).slice(0, 5).join(pathSep) ?? "(empty)";
             throw new Error(
                 `Failed to spawn Claude Code - is "${command}" installed and in PATH? ` +
                 `(cwd: ${cwd}, PATH starts with: ${pathHint})`

--- a/src/core/acp/utils.ts
+++ b/src/core/acp/utils.ts
@@ -4,6 +4,7 @@
  * Uses the platform bridge for process execution and file system access.
  */
 
+import type { IProcessHandle } from "@/core/platform/interfaces";
 import { getServerBridge } from "@/core/platform";
 
 const WINDOWS_SPAWNABLE_EXTENSIONS = [".cmd", ".bat", ".exe", ".com"];
@@ -68,6 +69,38 @@ export function quoteShellCommandPath(command: string): string {
 
   // Quote all shell wrapper paths to handle all special characters
   return `"${command}"`;
+}
+
+/**
+ * Await async process backends (for example Tauri) until pid/stdio are wired.
+ *
+ * The timeout is explicitly cleared so successful spawns do not leave a
+ * dangling timer behind for the full timeout duration.
+ */
+export async function awaitProcessReady(
+  processHandle: IProcessHandle,
+  timeoutMs = 30_000,
+): Promise<void> {
+  if (!processHandle.ready) {
+    return;
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      processHandle.ready,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Timed out waiting for process spawn after ${timeoutMs / 1000}s`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 function preferSpawnableWindowsPath(candidates: string[]): string | null {

--- a/src/core/platform/interfaces.ts
+++ b/src/core/platform/interfaces.ts
@@ -35,6 +35,8 @@ export interface IProcessHandle {
   stdout: ReadableStreamLike | null;
   stderr: ReadableStreamLike | null;
   exitCode: number | null;
+  /** Resolves when the process has been spawned and pid is available (Tauri async spawn). */
+  ready?: Promise<void>;
   kill(signal?: string): void;
   on(event: "exit", handler: (code: number | null, signal: string | null) => void): void;
   on(event: "error", handler: (err: Error) => void): void;

--- a/src/core/platform/tauri-bridge.ts
+++ b/src/core/platform/tauri-bridge.ts
@@ -106,6 +106,7 @@ class TauriProcessHandle implements IProcessHandle {
   private _writeFn: ((data: string) => void) | null = null;
 
   constructor() {
+    this.ready.catch(() => {});
     this.stdout = {
       on: (_event: string, handler: (chunk: Buffer) => void) => {
         this._stdoutHandlers.push(handler);

--- a/src/core/platform/tauri-bridge.ts
+++ b/src/core/platform/tauri-bridge.ts
@@ -90,6 +90,14 @@ class TauriProcessHandle implements IProcessHandle {
   stderr: ReadableStreamLike | null = null;
   exitCode: number | null = null;
 
+  /** Resolves when the child process has been spawned and pid is available. */
+  private _readyResolve!: () => void;
+  private _readyReject!: (err: Error) => void;
+  readonly ready = new Promise<void>((resolve, reject) => {
+    this._readyResolve = resolve;
+    this._readyReject = reject;
+  });
+
   private _exitHandlers: Array<(code: number | null, signal: string | null) => void> = [];
   private _errorHandlers: Array<(err: Error) => void> = [];
   private _stdoutHandlers: Array<(chunk: Buffer) => void> = [];
@@ -129,6 +137,7 @@ class TauriProcessHandle implements IProcessHandle {
     this.pid = child.pid;
     this._killFn = () => child.kill();
     this._writeFn = (data: string) => child.write(data);
+    this._readyResolve();
   }
 
   /** @internal Forward stdout data from Tauri child */
@@ -208,7 +217,9 @@ class TauriProcess implements IPlatformProcess {
           kill: () => child.kill(),
         });
       } catch (err) {
-        handle._emitError(err instanceof Error ? err : new Error(String(err)));
+        const error = err instanceof Error ? err : new Error(String(err));
+        handle._emitError(error);
+        handle._readyReject(error);
       }
     })();
 


### PR DESCRIPTION
## Summary

Two related fixes for the Tauri desktop app:

1. **ACP spawn race condition (#455)**: `TauriProcess.spawn()` runs `cmd.spawn()` inside an async IIFE, but `ClaudeCodeProcess.start()` checks `pid` synchronously before the IIFE resolves — `pid` is always `undefined`. Fix by adding a `ready` Promise to `TauriProcessHandle` that resolves after `_wireChild()`, and awaiting it (with 30s timeout) before the pid check in both `ClaudeCodeProcess` and `AcpProcess`. Also fixes Windows PATH separator (`":"` → platform-aware `";"` on win32).

2. **Settings workspace context loss (#454)**: `DesktopSidebar` falls back to `"default"` workspace when `workspaceId` is `undefined`. Fix by passing `workspaceId` as a URL search param from the sidebar's Settings link and reading it in `SettingsPageClient`. Also applies the same fix to `HarnessConsolePage`.

Fixes #454
Fixes #455

## Root Cause

- **#455**: Tauri's `Command.spawn()` is async but `TauriProcess.spawn()` returns the handle immediately. The pid check in `claude-code-process.ts:265` runs before the async IIFE completes.
- **#454**: `SettingsPageClient` renders `<DesktopAppShell>` without passing `workspaceId`, causing all sidebar navigation links to use `/workspace/default/...`.

## Changes

| File | Change |
|------|--------|
| `src/core/platform/interfaces.ts` | Add optional `ready?: Promise<void>` to `IProcessHandle` |
| `src/core/platform/tauri-bridge.ts` | Add `ready` Promise to `TauriProcessHandle` (resolve in `_wireChild`, reject in catch) |
| `src/core/acp/claude-code-process.ts` | Await `process.ready` with 30s timeout; fix Windows PATH separator |
| `src/core/acp/acp-process.ts` | Await `process.ready` with 30s timeout (consistency fix) |
| `src/client/components/desktop-sidebar.tsx` | Settings link includes `?workspaceId=` when available |
| `src/app/settings/settings-page-client.tsx` | Read `workspaceId` from URL and pass to `DesktopAppShell` |
| `src/app/settings/harness/harness-console-page.tsx` | Read `workspaceId` from URL for workspace selection |
| `src/client/components/__tests__/desktop-sidebar.test.tsx` | Update test expectation for new Settings href |

## Test Plan

- [x] `npx vitest run src/client/components/__tests__/desktop-sidebar.test.tsx` — 4/4 passed
- [x] `eslint` on all changed files — passed
- [x] TypeScript typecheck — passed
- [ ] Manual: navigate from workspace A → Settings → Team sidebar link — should stay on workspace A
- [ ] Manual (Windows Tauri): create ACP session — should not freeze on `loading: true`

## Notes

Three pre-existing test failures unrelated to this change (present on `upstream/main`):
- `skill-loader.test.ts` — mock filesystem issue
- `kanban-task-changes-tab.test.tsx` — shadow DOM waitFor timeout
- `harness-monitor` Rust tests — assertion mismatch

Co-Authored-By: Claude Code (Claude Sonnet 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace selection can be provided via workspaceId in the URL and is preserved when navigating to settings and related pages.

* **Bug Fixes**
  * Process startup now waits for a readiness signal before proceeding, reducing startup races.
  * Platform-specific PATH parsing improved on Windows.

* **Tests**
  * Added tests for workspace-id handling and process readiness.

* **Chores**
  * Updated ignore patterns to exclude internal directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->