### PR TITLE
fix(acp): resolve spawn race, Windows shell escaping, and settings workspace context

### DIFF
--- a/src/app/workspace/[workspaceId]/team/[sessionId]/team-run-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/team/[sessionId]/team-run-page-client.tsx
@@ -285,7 +285,11 @@ export function TeamRunPageClient() {
 
       return nextSelection;
     });
-  }, [codebases, repoSelection, session?.branch, session?.cwd]);
+  // NOTE: `repoSelection` is intentionally excluded from deps.
+  // This effect syncs repoSelection FROM session/codebases data on mount or
+  // when session metadata changes — it must NOT re-fire when the user switches
+  // branches locally, or it would overwrite the new branch with session.branch.
+  }, [codebases, session?.branch, session?.cwd]);
 
   const fetchSpecialists = useCallback(async () => {
     const response = await desktopAwareFetch("/api/specialists", { cache: "no-store" });

--- a/src/core/acp/__tests__/claude-code-process.test.ts
+++ b/src/core/acp/__tests__/claude-code-process.test.ts
@@ -166,6 +166,33 @@ describe("ClaudeCodeProcess", () => {
     vi.useRealTimers();
   });
 
+  it("rejects a second prompt while one is already in flight", async () => {
+    vi.useFakeTimers();
+    const fakeProcess = new FakeProcess();
+    spawnMock.mockReturnValue(fakeProcess);
+
+    const process = createProcess();
+    const startPromise = process.start();
+    await vi.advanceTimersByTimeAsync(500);
+    await startPromise;
+
+    const firstPrompt = process.prompt("session-1", "Continue");
+    const secondPrompt = process.prompt("session-1", "Interrupt");
+
+    await expect(secondPrompt).rejects.toThrow("Claude Code already has a prompt in flight");
+
+    fakeProcess.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({ type: "result", result: "done", stop_reason: "end_turn" })}\n`,
+        "utf-8",
+      ),
+    );
+
+    await expect(firstPrompt).resolves.toEqual({ stopReason: "end_turn" });
+    vi.useRealTimers();
+  });
+
   it("translates streaming thinking and tool parameter deltas into session updates", async () => {
     vi.useFakeTimers();
     const onNotification = vi.fn();

--- a/src/core/acp/__tests__/mcp-setup.test.ts
+++ b/src/core/acp/__tests__/mcp-setup.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/core/store/custom-mcp-server-store", () => ({
 }));
 
 describe("ensureMcpForProvider", () => {
-  it("keeps Claude MCP config inline so SDK parsing still works", async () => {
+  it("writes Claude MCP config to a temp file so SDK parsing still works", async () => {
     const result = await ensureMcpForProvider("claude", {
       routaServerUrl: "http://127.0.0.1:3000",
       workspaceId: "ws-test",
@@ -19,7 +19,8 @@ describe("ensureMcpForProvider", () => {
     });
 
     expect(result.mcpConfigs).toHaveLength(1);
-    expect(result.mcpConfigs[0]).toContain("\"mcpServers\"");
+    // After fix: config is a file path (contains "mcp-tmp"), not inline JSON
+    expect(result.mcpConfigs[0]).toContain("mcp-tmp");
 
     const parsed = parseMcpServersFromConfigs(result.mcpConfigs);
     expect(parsed?.["routa-coordination"]).toMatchObject({

--- a/src/core/acp/__tests__/mcp-setup.test.ts
+++ b/src/core/acp/__tests__/mcp-setup.test.ts
@@ -2,8 +2,11 @@
  * @vitest-environment node
  */
 
-import { describe, expect, it, vi } from "vitest";
-import { ensureMcpForProvider, parseMcpServersFromConfigs } from "../mcp-setup";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/core/store/custom-mcp-server-store", () => ({
   getCustomMcpServerStore: () => null,
@@ -11,7 +14,30 @@ vi.mock("@/core/store/custom-mcp-server-store", () => ({
 }));
 
 describe("ensureMcpForProvider", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await fsp.mkdtemp(path.join(os.tmpdir(), "mcp-setup-inline-home-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    vi.resetModules();
+    await fsp.rm(tmpHome, { recursive: true, force: true });
+  });
+
   it("writes Claude MCP config to a temp file so SDK parsing still works", async () => {
+    const { ensureMcpForProvider, parseMcpServersFromConfigs } = await import("../mcp-setup");
+
     const result = await ensureMcpForProvider("claude", {
       routaServerUrl: "http://127.0.0.1:3000",
       workspaceId: "ws-test",
@@ -26,6 +52,65 @@ describe("ensureMcpForProvider", () => {
     expect(parsed?.["routa-coordination"]).toMatchObject({
       type: "http",
       url: "http://127.0.0.1:3000/api/mcp",
+    });
+  });
+
+  it("falls back to inline JSON on non-Windows when Claude temp file writes fail", async () => {
+    const invalidHomePath = path.join(tmpHome, "home-file");
+    await fsp.writeFile(invalidHomePath, "not-a-directory", "utf-8");
+    process.env.HOME = invalidHomePath;
+    vi.resetModules();
+
+    const { ensureMcpForProvider, parseMcpServersFromConfigs } = await import("../mcp-setup");
+
+    const result = await ensureMcpForProvider("claude", {
+      routaServerUrl: "http://127.0.0.1:3000",
+      workspaceId: "ws-fallback",
+      includeCustomServers: false,
+    });
+
+    expect(result.mcpConfigs).toHaveLength(1);
+    expect(result.mcpConfigs[0]).toContain("\"mcpServers\"");
+    expect(result.summary).toContain("inline JSON fallback");
+
+    const parsed = parseMcpServersFromConfigs(result.mcpConfigs);
+    expect(parsed?.["routa-coordination"]).toMatchObject({
+      type: "http",
+      url: "http://127.0.0.1:3000/api/mcp",
+    });
+  });
+
+  it("ignores unreadable and invalid file configs while merging valid entries", async () => {
+    const { parseMcpServersFromConfigs } = await import("../mcp-setup");
+
+    const validConfigPath = path.join(tmpHome, "valid-mcp.json");
+    const invalidConfigPath = path.join(tmpHome, "invalid-mcp.json");
+
+    await fsp.writeFile(
+      validConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          alpha: { type: "http", url: "http://alpha.local" },
+        },
+      }),
+      "utf-8",
+    );
+    await fsp.writeFile(invalidConfigPath, "{not-json", "utf-8");
+
+    const parsed = parseMcpServersFromConfigs([
+      path.join(tmpHome, "missing.json"),
+      invalidConfigPath,
+      validConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          beta: { type: "http", url: "http://beta.local" },
+        },
+      }),
+    ]);
+
+    expect(parsed).toEqual({
+      alpha: { type: "http", url: "http://alpha.local" },
+      beta: { type: "http", url: "http://beta.local" },
     });
   });
 });

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -161,15 +161,10 @@ export class AcpProcess {
             shell: needsShell(command),
         });
 
-        if (!this.process.stdin || !this.process.stdout) {
-            throw new Error(
-                `${displayName} spawned without required stdio streams`
-            );
-        }
-
-        this._alive = true;
-
-        this.process.stdout.on("data", (chunk: Buffer) => {
+        // Wire up stdout/stderr/exit listeners BEFORE awaiting ready.
+        // Tauri's shell plugin forwards events immediately after cmd.spawn(),
+        // so binding after the await would miss early output frames.
+        this.process.stdout?.on("data", (chunk: Buffer) => {
             this.buffer += chunk.toString("utf-8");
             this.processBuffer();
         });
@@ -216,11 +211,20 @@ export class AcpProcess {
 
         await awaitProcessReady(this.process);
 
-        if (!this.process.pid) {
+        if (!this.process || !this.process.pid) {
             throw new Error(
                 `Failed to spawn ${displayName} - is "${command}" installed and in PATH?`
             );
         }
+
+        if (!this.process.stdin || !this.process.stdout) {
+            throw new Error(
+                `${displayName} spawned without required stdio streams`
+            );
+        }
+
+        this._alive = true;
+
 
         // Wait for process to stabilize
         await new Promise((resolve) => setTimeout(resolve, 500));

--- a/src/core/acp/claude-code-process.ts
+++ b/src/core/acp/claude-code-process.ts
@@ -357,9 +357,15 @@ export class ClaudeCodeProcess {
         const PROMPT_TIMEOUT_MS = 300_000; // 5 min — matches ACP process
 
         return new Promise<{ stopReason: string }>((resolve, reject) => {
+            if (this.promptResolve || this.promptReject) {
+                reject(new Error("Claude Code already has a prompt in flight"));
+                return;
+            }
+
             // Clear any previous timeout
             if (this.promptTimeout) {
                 clearTimeout(this.promptTimeout);
+                this.promptTimeout = null;
             }
 
             this.promptResolve = resolve;
@@ -378,6 +384,8 @@ export class ClaudeCodeProcess {
             if (!this.process?.stdin?.writable) {
                 if (this.promptTimeout) clearTimeout(this.promptTimeout);
                 this.promptTimeout = null;
+                this.promptResolve = null;
+                this.promptReject = null;
                 reject(new Error("Claude Code stdin not writable"));
                 return;
             }

--- a/src/core/acp/claude-code-process.ts
+++ b/src/core/acp/claude-code-process.ts
@@ -167,6 +167,7 @@ export class ClaudeCodeProcess {
     // Resolve/reject for the current prompt
     private promptResolve: ((value: { stopReason: string }) => void) | null = null;
     private promptReject: ((reason: Error) => void) | null = null;
+    private promptTimeout: ReturnType<typeof setTimeout> | null = null;
 
     constructor(config: ClaudeCodeProcessConfig, onNotification: NotificationHandler) {
         this._config = config;
@@ -262,13 +263,10 @@ export class ClaudeCodeProcess {
             shell: needsShell(cmd[0]),
         });
 
-        if (!this.process.stdin || !this.process.stdout) {
-            throw new Error(`Claude Code spawned without required stdio streams`);
-        }
-
-        this._alive = true;
-
-        this.process.stdout.on("data", (chunk: Buffer) => {
+        // Wire up stdout/stderr/exit listeners BEFORE awaiting ready.
+        // Tauri's shell plugin forwards events immediately after cmd.spawn(),
+        // so binding after the await would miss early output frames (init messages).
+        this.process.stdout?.on("data", (chunk: Buffer) => {
             this.buffer += chunk.toString("utf-8");
             this.processBuffer();
         });
@@ -283,6 +281,7 @@ export class ClaudeCodeProcess {
         this.process.on("exit", (code, signal) => {
             console.log(`[ClaudeCode:${displayName}] Process exited: code=${code}, signal=${signal}`);
             this._alive = false;
+            if (this.promptTimeout) { clearTimeout(this.promptTimeout); this.promptTimeout = null; }
             if (this.promptReject) {
                 this.promptReject(new Error(`Claude Code process exited (code=${code})`));
                 this.promptResolve = null;
@@ -297,7 +296,7 @@ export class ClaudeCodeProcess {
 
         await awaitProcessReady(this.process);
 
-        if (!this.process.pid) {
+        if (!this.process || !this.process.pid) {
             const pathSep = process.platform === "win32" ? ";" : ":";
             const pathHint = process.env.PATH?.split(pathSep).slice(0, 5).join(pathSep) ?? "(empty)";
             throw new Error(
@@ -305,6 +304,13 @@ export class ClaudeCodeProcess {
                 `(cwd: ${cwd}, PATH starts with: ${pathHint})`
             );
         }
+
+        if (!this.process.stdin || !this.process.stdout) {
+            throw new Error(`Claude Code spawned without required stdio streams`);
+        }
+
+        this._alive = true;
+
 
         // Wait for process to stabilize
         await new Promise((resolve) => setTimeout(resolve, 500));
@@ -349,12 +355,30 @@ export class ClaudeCodeProcess {
             session_id: this._sessionId ?? undefined,
         });
 
+        const PROMPT_TIMEOUT_MS = 300_000; // 5 min — matches ACP process
+
         return new Promise<{ stopReason: string }>((resolve, reject) => {
+            // Clear any previous timeout
+            if (this.promptTimeout) {
+                clearTimeout(this.promptTimeout);
+            }
+
             this.promptResolve = resolve;
             this.promptReject = reject;
 
+            // Timeout guard: prevents the POST handler from blocking forever
+            // when Claude Code runs a long task or the process hangs.
+            this.promptTimeout = setTimeout(() => {
+                this.promptResolve = null;
+                this.promptReject = null;
+                this.promptTimeout = null;
+                reject(new Error(`Timeout waiting for session/prompt (${PROMPT_TIMEOUT_MS / 1000}s)`));
+            }, PROMPT_TIMEOUT_MS);
+
             // Write to stdin
             if (!this.process?.stdin?.writable) {
+                if (this.promptTimeout) clearTimeout(this.promptTimeout);
+                this.promptTimeout = null;
                 reject(new Error("Claude Code stdin not writable"));
                 return;
             }
@@ -580,6 +604,7 @@ export class ClaudeCodeProcess {
 
                 // Resolve the prompt promise
                 if (this.promptResolve) {
+                    if (this.promptTimeout) { clearTimeout(this.promptTimeout); this.promptTimeout = null; }
                     this.promptResolve({ stopReason });
                     this.promptResolve = null;
                     this.promptReject = null;

--- a/src/core/acp/claude-code-process.ts
+++ b/src/core/acp/claude-code-process.ts
@@ -311,7 +311,6 @@ export class ClaudeCodeProcess {
 
         this._alive = true;
 
-
         // Wait for process to stabilize
         await new Promise((resolve) => setTimeout(resolve, 500));
 

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -33,6 +33,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { createHash } from "crypto";
 import TOML from "smol-toml";
 import type { McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
 import {
@@ -266,7 +267,12 @@ async function ensureMcpForAuggie(
 
 // ─── Claude Code ───────────────────────────────────────────────────────
 //
-// Claude Code accepts inline JSON via --mcp-config <json>
+// Claude Code accepts --mcp-config <json|file-path>.
+// We write a temporary JSON file and pass the file path to avoid shell
+// escaping issues on Windows (cmd.exe mangles {}, :, & in inline JSON
+// when shell:true is used for .cmd/.bat binaries).
+
+const CLAUDE_MCP_CONFIG_DIR = path.join(os.homedir(), ".claude", "mcp-tmp");
 
 function ensureMcpForClaude(
   mcpEndpoint: string,
@@ -280,13 +286,46 @@ function ensureMcpForClaude(
       env: { ROUTA_WORKSPACE_ID: workspaceId || "" },
     },
   };
-  const json = JSON.stringify({
+  const mcpConfigObj = {
     mcpServers: mergeCustomMcpServers(builtIn, customServers),
-  });
+  };
+  const json = JSON.stringify(mcpConfigObj);
+
+  // Write to a temp file so shell:true on Windows doesn't mangle the JSON.
+  // Use a stable filename keyed by workspaceId + mcpEndpoint hash so that
+  // sessions with different mcpProfile (e.g. kanban-planning vs coordination)
+  // get separate config files instead of overwriting each other.
+  const hash = workspaceId
+    ? Buffer.from(workspaceId).toString("base64url").slice(0, 16)
+    : "default";
+  // Include a short hash of the mcpEndpoint so different profiles (which have
+  // different query params like mcpProfile=kanban-planning) produce different
+  // files. This prevents a later session without mcpProfile from overwriting
+  // an earlier kanban-planning session's config file.
+  // SHA-256 digest ensures uniform distribution even when URLs share a long
+  // common prefix (e.g. http://localhost:3000/api/mcp?wsId=...).
+  const endpointDigest = createHash("sha256")
+    .update(mcpEndpoint)
+    .digest("base64url")
+    .slice(0, 12);
+  const configPath = path.join(CLAUDE_MCP_CONFIG_DIR, `routa-mcp-${hash}-${endpointDigest}.json`);
+
+  try {
+    fs.mkdirSync(CLAUDE_MCP_CONFIG_DIR, { recursive: true });
+    fs.writeFileSync(configPath, json, "utf-8");
+  } catch (err) {
+    // Fallback to inline JSON if file write fails (non-Windows usually fine)
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[MCP:Claude] Failed to write config file: ${msg}, falling back to inline JSON`);
+    return {
+      mcpConfigs: [json],
+      summary: `claude: inline JSON fallback (${json.length} bytes)`,
+    };
+  }
 
   return {
-    mcpConfigs: [json],
-    summary: `claude: inline JSON (${json.length} bytes)`,
+    mcpConfigs: [configPath],
+    summary: `claude: config file ${configPath}`,
   };
 }
 
@@ -629,7 +668,8 @@ export function isMcpConfigured(mcpConfigs?: string[]): boolean {
 }
 
 /**
- * Parse Claude-style inline MCP config JSON into the SDK's `mcpServers` object.
+ * Parse MCP config into the SDK's `mcpServers` object.
+ * Supports both inline JSON strings and file paths (reads file content).
  * Ignores unreadable entries so callers can fall back safely.
  */
 export function parseMcpServersFromConfigs(mcpConfigs?: string[]): Record<string, McpServerConfig> | undefined {
@@ -640,13 +680,25 @@ export function parseMcpServersFromConfigs(mcpConfigs?: string[]): Record<string
   const merged: Record<string, McpServerConfig> = {};
 
   for (const rawConfig of mcpConfigs) {
+    let jsonStr = rawConfig;
+
+    // If it looks like a file path (not starting with '{'), try reading the file
+    if (!rawConfig.trimStart().startsWith("{")) {
+      try {
+        jsonStr = fs.readFileSync(rawConfig, "utf-8");
+      } catch {
+        // Not a readable file path — skip
+        continue;
+      }
+    }
+
     try {
-      const parsed = JSON.parse(rawConfig) as { mcpServers?: Record<string, McpServerConfig> } | null;
+      const parsed = JSON.parse(jsonStr) as { mcpServers?: Record<string, McpServerConfig> } | null;
       if (parsed?.mcpServers && typeof parsed.mcpServers === "object") {
         Object.assign(merged, parsed.mcpServers);
       }
     } catch {
-      // Ignore non-inline configs; Claude SDK path only relies on JSON strings.
+      // Ignore unparseable configs
     }
   }
 

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -272,7 +272,73 @@ async function ensureMcpForAuggie(
 // escaping issues on Windows (cmd.exe mangles {}, :, & in inline JSON
 // when shell:true is used for .cmd/.bat binaries).
 
-const CLAUDE_MCP_CONFIG_DIR = path.join(os.homedir(), ".claude", "mcp-tmp");
+const CLAUDE_MCP_CONFIG_PREFIX = "routa-mcp-";
+const CLAUDE_MCP_CONFIG_DIRNAME = path.join(".claude", "mcp-tmp");
+const CLAUDE_MCP_CONFIG_MAX_FILES = 64;
+const CLAUDE_MCP_CONFIG_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function getClaudeMcpConfigDir(): string {
+  return path.join(os.homedir(), CLAUDE_MCP_CONFIG_DIRNAME);
+}
+
+function pruneClaudeMcpConfigDir(configDir: string, currentConfigPath: string): void {
+  const now = Date.now();
+
+  type ClaudeConfigFile = {
+    path: string;
+    mtimeMs: number;
+  };
+
+  const files: ClaudeConfigFile[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(configDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (!entry.name.startsWith(CLAUDE_MCP_CONFIG_PREFIX) || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const filePath = path.join(configDir, entry.name);
+    try {
+      const stats = fs.statSync(filePath);
+      files.push({ path: filePath, mtimeMs: stats.mtimeMs });
+    } catch {
+      // Ignore files that disappear mid-prune.
+    }
+  }
+
+  files.sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  let keptStaleConfigs = 0;
+  for (const file of files) {
+    if (file.path === currentConfigPath) {
+      continue;
+    }
+
+    const ageMs = Math.max(0, now - file.mtimeMs);
+    const shouldKeep =
+      ageMs <= CLAUDE_MCP_CONFIG_MAX_AGE_MS &&
+      keptStaleConfigs < CLAUDE_MCP_CONFIG_MAX_FILES;
+
+    if (shouldKeep) {
+      keptStaleConfigs += 1;
+      continue;
+    }
+
+    try {
+      fs.unlinkSync(file.path);
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+}
 
 function ensureMcpForClaude(
   mcpEndpoint: string,
@@ -308,14 +374,22 @@ function ensureMcpForClaude(
     .update(mcpEndpoint)
     .digest("base64url")
     .slice(0, 12);
-  const configPath = path.join(CLAUDE_MCP_CONFIG_DIR, `routa-mcp-${hash}-${endpointDigest}.json`);
+  const configDir = getClaudeMcpConfigDir();
+  const configPath = path.join(configDir, `${CLAUDE_MCP_CONFIG_PREFIX}${hash}-${endpointDigest}.json`);
 
   try {
-    fs.mkdirSync(CLAUDE_MCP_CONFIG_DIR, { recursive: true });
-    fs.writeFileSync(configPath, json, "utf-8");
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(configPath, json, { encoding: "utf-8", mode: 0o600 });
+    pruneClaudeMcpConfigDir(configDir, configPath);
   } catch (err) {
-    // Fallback to inline JSON if file write fails (non-Windows usually fine)
     const msg = err instanceof Error ? err.message : String(err);
+    if (process.platform === "win32") {
+      throw new Error(`Failed to write Claude MCP config file: ${msg}`, {
+        cause: err,
+      });
+    }
+
+    // Fallback to inline JSON if file write fails on non-Windows.
     console.warn(`[MCP:Claude] Failed to write config file: ${msg}, falling back to inline JSON`);
     return {
       mcpConfigs: [json],

--- a/src/core/platform/tauri-bridge.ts
+++ b/src/core/platform/tauri-bridge.ts
@@ -106,7 +106,10 @@ class TauriProcessHandle implements IProcessHandle {
   private _writeFn: ((data: string) => void) | null = null;
 
   constructor() {
+    // Prevent unhandled rejection for callers (git clone, terminal, etc.)
+    // that don't await `ready`. Only ACP/Claude paths consume it.
     this.ready.catch(() => {});
+
     this.stdout = {
       on: (_event: string, handler: (chunk: Buffer) => void) => {
         this._stdoutHandlers.push(handler);

--- a/src/core/platform/web-bridge.ts
+++ b/src/core/platform/web-bridge.ts
@@ -51,10 +51,16 @@ class WebProcess implements IPlatformProcess {
       throw new Error("Process spawning is not available in serverless environments");
     }
     const { spawn } = require("child_process");
+    // Normalize backslashes to forward slashes on Windows.
+    // When shell:true, cmd.exe cannot handle backslash cwd paths and exits
+    // with ENOENT. Forward slashes work correctly in all Node.js APIs on Windows.
+    const cwd = options?.cwd
+      ? (process.platform === "win32" ? options.cwd.replace(/\\/g, "/") : options.cwd)
+      : undefined;
     // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
     return spawn(command, args, { // Platform abstraction layer intentionally exposes spawn with shell disabled by default.
       stdio: options?.stdio ?? ["pipe", "pipe", "pipe"],
-      cwd: options?.cwd,
+      cwd,
       env: options?.env ? { ...process.env, ...options.env } : process.env,
       shell: options?.shell ?? false,
       detached: options?.detached ?? false,


### PR DESCRIPTION
## Summary

- Wire stdout/stderr/exit listeners **before** `awaitProcessReady` in AcpProcess and ClaudeCodeProcess to prevent lost output frames on Tauri's async spawn path
- Write Claude MCP config to a temp file instead of passing inline JSON via `--mcp-config`, avoiding Windows cmd.exe shell escaping corruption
- Exclude `repoSelection` from session-sync useEffect deps so local branch switches aren't overwritten

Fixes #454
Fixes #455

## Root Cause

### #455 — ACP spawn race
Tauri's shell plugin emits events immediately after `cmd.spawn()`, but listeners were bound **after** `await ready`. Early init messages (including the `initialize` response) were silently dropped, causing agents to appear unresponsive on startup.

Additionally, inline JSON passed via `--mcp-config` was mangled by Windows `cmd.exe` when `shell: true` is used for `.cmd`/`.bat` binaries — `{`, `:`, `&` characters were interpreted as shell operators, producing broken MCP config that Claude Code silently ignored.

### #454 — Settings workspace context loss
The `repoSelection` state was included in the useEffect dependency array that syncs branch selection from session metadata. When a user switched branches locally, the effect re-fired and overwrote the new selection with `session.branch`.

## Changes

- **`acp-process.ts`** — Move listener registration before `awaitProcessReady`; add `?.` on stdout (TS2531 fix)
- **`claude-code-process.ts`** — Same listener reorder; add `promptTimeout` guard to prevent unbounded hangs; TS2531 fix
- **`tauri-bridge.ts`** — Swallow unhandled rejection on `ready` promise for non-ACP callers (git clone, terminal)
- **`mcp-setup.ts`** — Write Claude MCP config to `~/.claude/mcp-tmp/` temp file; update `parseMcpServersFromConfigs` to handle file paths
- **`web-bridge.ts`** — Normalize backslashes to forward slashes in `cwd` on Windows
- **`team-run-page-client.tsx`** — Remove `repoSelection` from session-sync effect deps
- **`mcp-setup.test.ts`** — Update test assertions for file-path based config

## Test Plan

- [ ] On Windows (Tauri): start an ACP agent and verify init messages appear in the session
- [ ] On Windows (web): verify Claude Code spawns with correct MCP config (check `~/.claude/mcp-tmp/`)
- [ ] Switch branches in a team session and verify the selection is preserved
- [ ] `npx tsc --noEmit` passes with no TS2531 errors

Co-authored-by: 叶璃笙 (Claude) <yelisheng@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration can now be provided via per-workspace temp files with a robust fallback to inline configs.

* **Bug Fixes**
  * Added a 5-minute prompt timeout and rejection for concurrent prompts.
  * Improved Windows working-directory handling and process startup/lifecycle stability.
  * Safer handling of process I/O wiring to avoid early failures.

* **Tests**
  * Updated and added tests to cover temp-file config handling and concurrent-prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->