### PR TITLE
fix(desktop): hide windows console for background checks

### DIFF
--- a/crates/routa-core/src/acp/warmup.rs
+++ b/crates/routa-core/src/acp/warmup.rs
@@ -11,6 +11,8 @@
 //!   - uvx agent: `uvx <package>`      → pre-downloads Python + pack
 
 use std::collections::HashMap;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -25,6 +27,8 @@ use super::runtime_manager::{AcpRuntimeManager, RuntimeType};
 // ─── Constants ─────────────────────────────────────────────────────────────
 
 const PREWARM_TIMEOUT_SECS: u64 = 5 * 60; // 5 minutes
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -268,6 +272,9 @@ impl AcpWarmupService {
         cmd.args(&args)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null());
+
+        #[cfg(windows)]
+        cmd.as_std_mut().creation_flags(CREATE_NO_WINDOW);
 
         // Prepend runtime dir to PATH
         if let Ok(path_env) = std::env::var("PATH") {

--- a/crates/routa-core/src/acp/warmup.rs
+++ b/crates/routa-core/src/acp/warmup.rs
@@ -23,6 +23,8 @@ use tokio::sync::RwLock;
 use super::paths::AcpPaths;
 use super::registry_fetch::fetch_registry;
 use super::runtime_manager::{AcpRuntimeManager, RuntimeType};
+#[cfg(windows)]
+use super::CREATE_NO_WINDOW;
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 

--- a/crates/routa-core/src/codeowners.rs
+++ b/crates/routa-core/src/codeowners.rs
@@ -1,10 +1,13 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
-use std::process::Command;
 
+use crate::git::git_command;
 use glob::Pattern;
 use serde::Serialize;
 use serde_yaml::Value;
+
+#[cfg(test)]
+use std::process::Command;
 
 const CODEOWNERS_CANDIDATES: &[&str] = &[".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
 
@@ -517,7 +520,7 @@ fn build_codeowners_correlation_report(
 }
 
 fn collect_tracked_files(repo_root: &Path, warnings: &mut Vec<String>) -> Vec<String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["ls-files"])
         .current_dir(repo_root)
         .output();

--- a/crates/routa-core/src/git.rs
+++ b/crates/routa-core/src/git.rs
@@ -14,7 +14,7 @@ const GIT_LOG_SEARCH_SCAN_LIMIT: usize = 2000;
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-fn git_command() -> Command {
+pub fn git_command() -> Command {
     let mut command = Command::new("git");
     #[cfg(windows)]
     command.creation_flags(CREATE_NO_WINDOW);
@@ -160,7 +160,7 @@ pub fn get_branch_info(repo_path: &str) -> RepoBranchInfo {
 }
 
 pub fn checkout_branch(repo_path: &str, branch: &str) -> bool {
-    let ok = Command::new("git")
+    let ok = git_command()
         .args(["checkout", branch])
         .current_dir(repo_path)
         .output()
@@ -169,7 +169,7 @@ pub fn checkout_branch(repo_path: &str, branch: &str) -> bool {
     if ok {
         return true;
     }
-    Command::new("git")
+    git_command()
         .args(["checkout", "-b", branch])
         .current_dir(repo_path)
         .output()
@@ -190,7 +190,7 @@ pub fn delete_branch(repo_path: &str, branch: &str) -> Result<(), String> {
         return Err(format!("Branch '{branch}' not found"));
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(["branch", "-D", branch])
         .current_dir(repo_path)
         .output()
@@ -204,7 +204,7 @@ pub fn delete_branch(repo_path: &str, branch: &str) -> Result<(), String> {
 }
 
 pub fn fetch_remote(repo_path: &str) -> bool {
-    Command::new("git")
+    git_command()
         .args(["fetch", "--all", "--prune"])
         .current_dir(repo_path)
         .output()
@@ -213,7 +213,7 @@ pub fn fetch_remote(repo_path: &str) -> bool {
 }
 
 pub fn pull_branch(repo_path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["pull", "--ff-only"])
         .current_dir(repo_path)
         .output()
@@ -273,7 +273,7 @@ pub fn get_branch_status(repo_path: &str, branch: &str) -> BranchStatus {
 }
 
 pub fn reset_local_changes(repo_path: &str) -> Result<(), String> {
-    let reset_output = Command::new("git")
+    let reset_output = git_command()
         .args(["reset", "--hard", "HEAD"])
         .current_dir(repo_path)
         .output()
@@ -284,7 +284,7 @@ pub fn reset_local_changes(repo_path: &str) -> Result<(), String> {
             .to_string());
     }
 
-    let clean_output = Command::new("git")
+    let clean_output = git_command()
         .args(["clean", "-fd"])
         .current_dir(repo_path)
         .output()

--- a/crates/routa-core/src/git.rs
+++ b/crates/routa-core/src/git.rs
@@ -338,7 +338,7 @@ pub fn stage_files(repo_path: &str, files: &[String]) -> Result<(), String> {
     let mut args = vec!["add", "--"];
     args.extend(files.iter().map(|s| s.as_str()));
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -361,7 +361,7 @@ pub fn unstage_files(repo_path: &str, files: &[String]) -> Result<(), String> {
     let mut args = vec!["restore", "--staged", "--"];
     args.extend(files.iter().map(|s| s.as_str()));
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -386,7 +386,7 @@ pub fn discard_changes(repo_path: &str, files: &[String]) -> Result<(), String> 
     let mut untracked_files: Vec<&str> = Vec::new();
 
     for file in files {
-        let output = Command::new("git")
+        let output = git_command()
             .args(["ls-files", "--error-unmatch", "--", file.as_str()])
             .current_dir(repo_path)
             .output()
@@ -403,7 +403,7 @@ pub fn discard_changes(repo_path: &str, files: &[String]) -> Result<(), String> 
         let mut restore_args = vec!["restore", "--"];
         restore_args.extend(tracked_files);
 
-        let restore_output = Command::new("git")
+        let restore_output = git_command()
             .args(&restore_args)
             .current_dir(repo_path)
             .output()
@@ -420,7 +420,7 @@ pub fn discard_changes(repo_path: &str, files: &[String]) -> Result<(), String> 
         let mut clean_args = vec!["clean", "-f", "--"];
         clean_args.extend(untracked_files);
 
-        let clean_output = Command::new("git")
+        let clean_output = git_command()
             .args(&clean_args)
             .current_dir(repo_path)
             .output()
@@ -455,7 +455,7 @@ pub fn create_commit(
     }
 
     // Check if there are staged changes
-    let check_output = Command::new("git")
+    let check_output = git_command()
         .args(["diff", "--cached", "--name-only"])
         .current_dir(repo_path)
         .output()
@@ -466,7 +466,7 @@ pub fn create_commit(
     }
 
     // Create the commit
-    let commit_output = Command::new("git")
+    let commit_output = git_command()
         .args(["commit", "-m", message])
         .current_dir(repo_path)
         .output()
@@ -479,7 +479,7 @@ pub fn create_commit(
     }
 
     // Get the commit SHA
-    let sha_output = Command::new("git")
+    let sha_output = git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(repo_path)
         .output()
@@ -503,7 +503,7 @@ pub fn pull_commits(
         args.push(branch_name);
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -518,7 +518,7 @@ pub fn pull_commits(
 
 /// Rebase current branch onto target branch
 pub fn rebase_branch(repo_path: &str, onto: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["rebase", onto])
         .current_dir(repo_path)
         .output()
@@ -553,7 +553,7 @@ pub fn reset_branch(
         return Err("Hard reset requires explicit destructive confirmation".to_string());
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(["reset", reset_mode, to])
         .current_dir(repo_path)
         .output()
@@ -788,7 +788,7 @@ fn git_commit_file_status(code: &str) -> CommitFileChangeKind {
 pub fn list_git_refs(repo_path: &str) -> Result<GitRefsResult, String> {
     let current_branch = get_current_branch(repo_path);
 
-    let local_output = Command::new("git")
+    let local_output = git_command()
         .args([
             "for-each-ref",
             "--format=%(refname:short)%09%(objectname)",
@@ -834,7 +834,7 @@ pub fn list_git_refs(repo_path: &str) -> Result<GitRefsResult, String> {
             head_ref
         });
 
-    let remote_output = Command::new("git")
+    let remote_output = git_command()
         .args([
             "for-each-ref",
             "--format=%(refname:short)%09%(objectname)",
@@ -877,7 +877,7 @@ pub fn list_git_refs(repo_path: &str) -> Result<GitRefsResult, String> {
         Vec::new()
     };
 
-    let tag_output = Command::new("git")
+    let tag_output = git_command()
         .args([
             "for-each-ref",
             "--format=%(refname:short)%09%(*objectname)%09%(objectname)",
@@ -946,7 +946,7 @@ pub fn get_git_log_page(
     let has_branch_filters = !branch_filters.is_empty();
     let should_scan_for_search = !search.is_empty();
 
-    let mut command = Command::new("git");
+    let mut command = git_command();
     command.args([
         "--no-pager",
         "log",
@@ -1005,7 +1005,7 @@ pub fn get_git_log_page(
     }
 
     let total = {
-        let mut count_command = Command::new("git");
+        let mut count_command = git_command();
         count_command.args(["rev-list", "--count"]);
         if has_branch_filters {
             for branch in &branch_filters {
@@ -1040,7 +1040,7 @@ pub fn get_git_commit_detail(repo_path: &str, sha: &str) -> Result<GitCommitDeta
     let refs = list_git_refs(repo_path)?;
     let ref_map = git_refs_map(&refs);
 
-    let metadata_output = Command::new("git")
+    let metadata_output = git_command()
         .args([
             "--no-pager",
             "show",
@@ -1076,7 +1076,7 @@ pub fn get_git_commit_detail(repo_path: &str, sha: &str) -> Result<GitCommitDeta
         .map(str::to_string)
         .collect::<Vec<_>>();
 
-    let name_status_output = Command::new("git")
+    let name_status_output = git_command()
         .args(["show", "--format=", "--name-status", sha.as_str()])
         .current_dir(repo_path)
         .output()
@@ -1088,7 +1088,7 @@ pub fn get_git_commit_detail(repo_path: &str, sha: &str) -> Result<GitCommitDeta
             .to_string());
     }
 
-    let numstat_output = Command::new("git")
+    let numstat_output = git_command()
         .args(["show", "--format=", "--numstat", sha.as_str()])
         .current_dir(repo_path)
         .output()
@@ -1213,7 +1213,7 @@ pub fn get_commit_list(
         args.push(&since_str);
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -1665,7 +1665,7 @@ pub fn get_repo_commit_diff(repo_path: &str, sha: &str) -> RepoCommitDiff {
 }
 
 fn git_output_at_path(repo_root: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(args)
         .current_dir(repo_root)
         .output()
@@ -1783,7 +1783,7 @@ pub fn compute_historical_related_files(
 }
 
 fn file_exists_at_revision(repo_root: &Path, revision: &str, file_path: &str) -> bool {
-    Command::new("git")
+    git_command()
         .args(["cat-file", "-e", &format!("{revision}:{file_path}")])
         .current_dir(repo_root)
         .output()
@@ -2197,7 +2197,7 @@ pub fn branch_to_safe_dir_name(branch: &str) -> String {
 
 /// Prune stale worktree references.
 pub fn worktree_prune(repo_path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["worktree", "prune"])
         .current_dir(repo_path)
         .output()
@@ -2240,7 +2240,7 @@ pub fn worktree_add(
         ]
     };
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -2261,7 +2261,7 @@ pub fn worktree_remove(repo_path: &str, worktree_path: &str, force: bool) -> Res
     }
     args.push(worktree_path);
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(&args)
         .current_dir(repo_path)
         .output()
@@ -2284,7 +2284,7 @@ pub struct WorktreeListEntry {
 
 /// List all worktrees for a repository.
 pub fn worktree_list(repo_path: &str) -> Vec<WorktreeListEntry> {
-    let output = match Command::new("git")
+    let output = match git_command()
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_path)
         .output()
@@ -2331,7 +2331,7 @@ pub fn worktree_list(repo_path: &str) -> Vec<WorktreeListEntry> {
 
 /// Check if a local branch exists.
 pub fn branch_exists(repo_path: &str, branch: &str) -> bool {
-    Command::new("git")
+    git_command()
         .args(["branch", "--list", branch])
         .current_dir(repo_path)
         .output()

--- a/crates/routa-core/src/git.rs
+++ b/crates/routa-core/src/git.rs
@@ -5,10 +5,21 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap};
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 const GIT_LOG_SEARCH_SCAN_LIMIT: usize = 2000;
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+fn git_command() -> Command {
+    let mut command = Command::new("git");
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParsedGitHubUrl {
@@ -74,7 +85,7 @@ pub fn dir_name_to_repo(dir_name: &str) -> String {
 }
 
 pub fn is_git_repository(repo_path: &str) -> bool {
-    Command::new("git")
+    git_command()
         .args(["rev-parse", "--git-dir"])
         .current_dir(repo_path)
         .output()
@@ -83,7 +94,7 @@ pub fn is_git_repository(repo_path: &str) -> bool {
 }
 
 pub fn get_current_branch(repo_path: &str) -> Option<String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(repo_path)
         .output()
@@ -101,7 +112,7 @@ pub fn get_current_branch(repo_path: &str) -> Option<String> {
 }
 
 pub fn list_local_branches(repo_path: &str) -> Vec<String> {
-    Command::new("git")
+    git_command()
         .args(["branch", "--format=%(refname:short)"])
         .current_dir(repo_path)
         .output()
@@ -118,7 +129,7 @@ pub fn list_local_branches(repo_path: &str) -> Vec<String> {
 }
 
 pub fn list_remote_branches(repo_path: &str) -> Vec<String> {
-    Command::new("git")
+    git_command()
         .args(["branch", "-r", "--format=%(refname:short)"])
         .current_dir(repo_path)
         .output()
@@ -232,7 +243,7 @@ pub fn get_branch_status(repo_path: &str, branch: &str) -> BranchStatus {
     // Build the range string separately to ensure proper handling of branch names with slashes
     let range = format!("{branch}...origin/{branch}");
 
-    if let Ok(o) = Command::new("git")
+    if let Ok(o) = git_command()
         .args(["rev-list", "--left-right", "--count", &range])
         .current_dir(repo_path)
         .output()
@@ -248,7 +259,7 @@ pub fn get_branch_status(repo_path: &str, branch: &str) -> BranchStatus {
         // Silently ignore errors - upstream may not exist or branch may not be on remote
     }
 
-    if let Ok(o) = Command::new("git")
+    if let Ok(o) = git_command()
         .args(["status", "--porcelain", "-uall"])
         .current_dir(repo_path)
         .output()
@@ -1383,7 +1394,7 @@ pub fn get_repo_status(repo_path: &str) -> RepoStatus {
         untracked: 0,
     };
 
-    if let Ok(o) = Command::new("git")
+    if let Ok(o) = git_command()
         .args(["status", "--porcelain", "-uall"])
         .current_dir(repo_path)
         .output()
@@ -1397,7 +1408,7 @@ pub fn get_repo_status(repo_path: &str) -> RepoStatus {
         }
     }
 
-    if let Ok(o) = Command::new("git")
+    if let Ok(o) = git_command()
         .args(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
         .current_dir(repo_path)
         .output()
@@ -1487,7 +1498,7 @@ pub fn parse_git_status_porcelain(output: &str) -> Vec<GitFileChange> {
 pub fn get_repo_changes(repo_path: &str) -> RepoChanges {
     let branch = get_current_branch(repo_path).unwrap_or_else(|| "unknown".into());
     let status = get_repo_status(repo_path);
-    let files = Command::new("git")
+    let files = git_command()
         .args(["status", "--porcelain", "-uall"])
         .current_dir(repo_path)
         .output()
@@ -1504,7 +1515,7 @@ pub fn get_repo_changes(repo_path: &str) -> RepoChanges {
 }
 
 fn git_output_in_repo(repo_path: &str, args: &[&str]) -> Option<String> {
-    Command::new("git")
+    git_command()
         .args(args)
         .current_dir(repo_path)
         .output()

--- a/crates/routa-core/src/git.rs
+++ b/crates/routa-core/src/git.rs
@@ -15,10 +15,29 @@ const GIT_LOG_SEARCH_SCAN_LIMIT: usize = 2000;
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub fn git_command() -> Command {
-    let mut command = Command::new("git");
     #[cfg(windows)]
-    command.creation_flags(CREATE_NO_WINDOW);
-    command
+    {
+        let mut command = Command::new("git");
+        command.creation_flags(CREATE_NO_WINDOW);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        Command::new("git")
+    }
+}
+
+pub fn git_tokio_command() -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let mut command = tokio::process::Command::new("git");
+        command.creation_flags(CREATE_NO_WINDOW);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        tokio::process::Command::new("git")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/routa-core/src/trace/vcs.rs
+++ b/crates/routa-core/src/trace/vcs.rs
@@ -3,8 +3,8 @@
 //! Populates TraceVcs with Git information (revision, branch, repo_root).
 
 use super::types::TraceVcs;
+use crate::git::git_command;
 use std::path::Path;
-use std::process::Command;
 
 /// Get VCS context for a workspace directory.
 /// Returns Git information if the directory is a git repository.
@@ -52,7 +52,7 @@ pub fn get_vcs_context_light(cwd: &str) -> Option<TraceVcs> {
 
 /// Check if a directory is a git repository.
 fn is_git_repo(cwd: &Path) -> bool {
-    Command::new("git")
+    git_command()
         .args(["rev-parse", "--git-dir"])
         .current_dir(cwd)
         .output()
@@ -62,7 +62,7 @@ fn is_git_repo(cwd: &Path) -> bool {
 
 /// Get the current git revision (commit SHA).
 fn get_git_revision(cwd: &Path) -> Option<String> {
-    Command::new("git")
+    git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(cwd)
         .output()
@@ -74,7 +74,7 @@ fn get_git_revision(cwd: &Path) -> Option<String> {
 
 /// Get the current git branch name.
 fn get_git_branch(cwd: &Path) -> Option<String> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(cwd)
         .output()
@@ -94,7 +94,7 @@ fn get_git_branch(cwd: &Path) -> Option<String> {
 
 /// Get the git repository root directory.
 fn get_git_repo_root(cwd: &Path) -> Option<String> {
-    Command::new("git")
+    git_command()
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(cwd)
         .output()

--- a/crates/routa-server/src/api/clone.rs
+++ b/crates/routa-server/src/api/clone.rs
@@ -117,7 +117,7 @@ async fn clone_repo(
         tokio::task::spawn_blocking({
             let target_str = target_str.clone();
             move || {
-                let _ = std::process::Command::new("git")
+                let _ = git::git_command()
                     .args(["pull", "--ff-only"])
                     .current_dir(&target_str)
                     .output();
@@ -151,7 +151,7 @@ async fn clone_repo(
         let clone_url = clone_url.clone();
         let target = target_dir_str.clone();
         move || {
-            std::process::Command::new("git")
+            git::git_command()
                 .args(["clone", "--depth", "1", &clone_url, &target])
                 .output()
         }
@@ -171,7 +171,7 @@ async fn clone_repo(
     let _ = tokio::task::spawn_blocking({
         let ts = target_str.clone();
         move || {
-            let _ = std::process::Command::new("git")
+            let _ = git::git_command()
                 .args(["fetch", "--all"])
                 .current_dir(&ts)
                 .output();

--- a/crates/routa-server/src/api/clone_progress.rs
+++ b/crates/routa-server/src/api/clone_progress.rs
@@ -16,6 +16,16 @@ use crate::state::AppState;
 
 type SseStream = Pin<Box<dyn tokio_stream::Stream<Item = Result<Event, Infallible>> + Send>>;
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+fn clone_progress_git_command() -> tokio::process::Command {
+    let mut command = tokio::process::Command::new("git");
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
 pub fn router() -> Router<AppState> {
     Router::new().route("/", post(clone_with_progress))
 }
@@ -146,7 +156,7 @@ async fn clone_with_progress(
             )))
             .await;
 
-        let child = tokio::process::Command::new("git")
+        let child = clone_progress_git_command()
             .args(["clone", "--progress", &clone_url, &target_str])
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -212,7 +222,7 @@ async fn clone_with_progress(
         let status = child.wait().await;
         match status {
             Ok(s) if s.success() => {
-                let _ = std::process::Command::new("git")
+                let _ = git::git_command()
                     .args(["fetch", "--all"])
                     .current_dir(&target_str)
                     .output();

--- a/crates/routa-server/src/api/clone_progress.rs
+++ b/crates/routa-server/src/api/clone_progress.rs
@@ -16,16 +16,6 @@ use crate::state::AppState;
 
 type SseStream = Pin<Box<dyn tokio_stream::Stream<Item = Result<Event, Infallible>> + Send>>;
 
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-
-fn clone_progress_git_command() -> tokio::process::Command {
-    let mut command = tokio::process::Command::new("git");
-    #[cfg(windows)]
-    command.creation_flags(CREATE_NO_WINDOW);
-    command
-}
-
 pub fn router() -> Router<AppState> {
     Router::new().route("/", post(clone_with_progress))
 }
@@ -156,7 +146,7 @@ async fn clone_with_progress(
             )))
             .await;
 
-        let child = clone_progress_git_command()
+        let child = git::git_tokio_command()
             .args(["clone", "--progress", &clone_url, &target_str])
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())

--- a/crates/routa-server/src/api/git.rs
+++ b/crates/routa-server/src/api/git.rs
@@ -7,7 +7,6 @@ use axum::{
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path as FilePath};
-use std::process::Command;
 
 use crate::api::repo_context::{normalize_local_repo_path, validate_local_git_repo_path};
 use crate::error::ServerError;
@@ -122,7 +121,7 @@ fn validate_git_file_paths(files: &[String]) -> Result<(), String> {
 }
 
 fn git_command_output(repo_path: &str, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = crate::git::git_command()
         .args(args)
         .current_dir(repo_path)
         .output()

--- a/crates/routa-server/src/api/review.rs
+++ b/crates/routa-server/src/api/review.rs
@@ -339,7 +339,7 @@ fn resolve_repo_root(repo_path: Option<&str>) -> Result<PathBuf, ServerError> {
     let cwd = repo_path
         .map(PathBuf::from)
         .unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-    let output = Command::new("git")
+    let output = crate::git::git_command()
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(&cwd)
         .output()
@@ -393,7 +393,7 @@ fn load_review_rules(
 }
 
 fn git_exec<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String, ServerError> {
-    let output = Command::new("git")
+    let output = crate::git::git_command()
         .args(args)
         .current_dir(cwd)
         .output()

--- a/crates/routa-server/src/api/skills_clone.rs
+++ b/crates/routa-server/src/api/skills_clone.rs
@@ -50,13 +50,13 @@ async fn clone_skills(
     let target_path = target_dir.clone();
     tokio::task::spawn_blocking(move || {
         if target_path.exists() {
-            let _ = std::process::Command::new("git")
+            let _ = git::git_command()
                 .args(["pull", "--ff-only"])
                 .current_dir(&target_path)
                 .output();
         } else {
             let clone_url = format!("https://github.com/{}/{}.git", parsed.owner, parsed.repo);
-            let _ = std::process::Command::new("git")
+            let _ = git::git_command()
                 .args([
                     "clone",
                     "--depth",

--- a/crates/routa-server/src/api/tasks_github.rs
+++ b/crates/routa-server/src/api/tasks_github.rs
@@ -49,7 +49,7 @@ pub struct GitHubPullListItem {
 
 pub fn resolve_github_repo(repo_path: Option<&str>) -> Option<String> {
     let repo_path = repo_path?;
-    let output = Command::new("git")
+    let output = crate::git::git_command()
         .args(["config", "--get", "remote.origin.url"])
         .current_dir(repo_path)
         .output()

--- a/crates/routa-server/src/api/worktrees.rs
+++ b/crates/routa-server/src/api/worktrees.rs
@@ -243,7 +243,7 @@ async fn delete_worktree(
 
         // Optionally delete the branch
         if query.delete_branch.unwrap_or(false) {
-            let _ = std::process::Command::new("git")
+            let _ = crate::git::git_command()
                 .args(["branch", "-D", &worktree.branch])
                 .current_dir(repo_path)
                 .output();

--- a/docs/issues/2026-04-15-gh-457-tauri-sidebar-spawns-terminal-windows.md
+++ b/docs/issues/2026-04-15-gh-457-tauri-sidebar-spawns-terminal-windows.md
@@ -1,0 +1,53 @@
+---
+title: "GH-457 Tauri sidebar navigation spawns terminal windows on Windows"
+date: "2026-04-15"
+kind: issue
+status: investigating
+severity: high
+area: "desktop"
+tags: [desktop, tauri, windows, git, process, sidebar]
+reported_by: "Codex"
+related_issues: ["https://github.com/phodal/routa/issues/457"]
+github_issue: 457
+github_state: open
+github_url: "https://github.com/phodal/routa/issues/457"
+---
+
+# GH-457 Tauri sidebar navigation spawns terminal windows on Windows
+
+## What Happened
+
+On Windows desktop builds, opening a workspace and switching sidebar views can cause multiple terminal windows to flash open.
+
+The strongest local match is the Kanban/workspace navigation path: when the page mounts, the desktop Rust backend computes per-repository git status and file changes for every codebase in the workspace. Those git calls are background diagnostics and should not create visible console windows.
+
+## Expected Behavior
+
+Desktop background checks such as git status inspection and ACP warmup should run headlessly on Windows.
+
+## Reproduction Context
+
+- Environment: desktop / Tauri / Windows
+- Trigger: add a project, then switch sidebar views in a workspace
+
+## Why This Might Happen
+
+- The Rust desktop backend shells out to `git` multiple times per repository when loading workspace codebase changes.
+- Some Rust child processes already opt into `CREATE_NO_WINDOW`, but the git helpers used by workspace/sidebar data loading did not apply the same Windows behavior.
+- ACP warmup also launches background package-manager commands and should follow the same hidden-window policy.
+
+## Relevant Files
+
+- `crates/routa-core/src/git.rs`
+- `crates/routa-core/src/acp/warmup.rs`
+- `crates/routa-server/src/api/codebases.rs`
+- `src/app/workspace/[workspaceId]/kanban/kanban-page-client.tsx`
+
+## Observations
+
+- `GET /api/workspaces/{workspaceId}/codebases/changes` loads on the Kanban page and fans out into git status calls for each codebase.
+- Packaged desktop mode defaults to the Rust backend, so the fix needs to be in the Rust command paths rather than only in Next.js routes.
+
+## References
+
+- https://github.com/phodal/routa/issues/457


### PR DESCRIPTION
## Summary
- hide Windows console windows for background git commands used by desktop workspace/codebase status loading
- hide Windows console windows for ACP warmup background processes as well
- add a local issue tracker entry for GitHub issue #457

## Why
Issue #457 reports multiple terminal windows popping up on Windows when switching the desktop sidebar after adding a project. The strongest matching path is desktop background repo status loading, which shells out to `git` per codebase.

## Verification
- `cargo fmt --all --check`

## Current build blockers on this machine
- Rust desktop build is still blocked by an ARM64 Rust toolchain vs x86 MSVC/Windows SDK linker environment mismatch
- `tauri build` is also blocked because root frontend dependencies are not installed locally, so the static frontend hook falls back to bare `npm` and fails with `spawnSync npm ENOENT`

Closes #457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented terminal windows from flashing on Windows by running background Git and warmup operations without showing a window.

* **Documentation**
  * Added an issue doc describing the Windows sidebar terminal-window behavior and its resolution (GH-457).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->