### PR TITLE
refactor(traces): extract POST export endpoint to dedicated route

### DIFF
--- a/api-contract.yaml
+++ b/api-contract.yaml
@@ -4731,18 +4731,20 @@ paths:
                     type: array
                     items:
                       type: object
+
+  /api/traces/export:
     post:
-      operationId: createTrace
-      summary: Create a new trace record
+      operationId: exportTraces
+      summary: Export trace records in Agent Trace JSON format
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
               type: object
       responses:
         "200":
-          description: Created trace
+          description: Exported trace payload
 
   /api/traces/stats:
     get:

--- a/crates/routa-server/src/api/traces.rs
+++ b/crates/routa-server/src/api/traces.rs
@@ -1,17 +1,21 @@
 use axum::{
     extract::{Query as QueryParams, State},
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use crate::error::ServerError;
 use crate::state::AppState;
-use routa_core::trace::{TraceQuery, TraceReader};
+use routa_core::trace::{TraceQuery, TraceReader, TraceRecord};
 
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route("/", get(query_traces).post(export_traces))
+        .route("/", get(query_traces))
+        .route("/export", post(export_traces))
         .route("/stats", get(get_trace_stats))
         .route("/{id}", get(get_trace_by_id))
 }
@@ -87,19 +91,21 @@ async fn get_trace_by_id(
 
 /// POST /api/traces/export — Export traces in Agent Trace JSON format.
 async fn export_traces(
-    State(_state): State<AppState>,
-    QueryParams(params): QueryParams<TraceQueryParams>,
+    State(state): State<AppState>,
+    QueryParams(mut params): QueryParams<TraceQueryParams>,
+    body: String,
 ) -> Result<Json<serde_json::Value>, ServerError> {
     let cwd = std::env::current_dir()
         .map_err(|e| ServerError::Internal(format!("Failed to get cwd: {e}")))?;
 
-    let reader = TraceReader::new(&cwd);
-    let query = params.to_trace_query();
+    if !body.trim().is_empty() {
+        let body_params: TraceQueryParams = serde_json::from_str(&body)
+            .map_err(|error| ServerError::BadRequest(format!("Invalid JSON body: {error}")))?;
+        params.apply_overrides(body_params);
+    }
 
-    let traces_json = reader
-        .export(&query)
-        .await
-        .map_err(|e| ServerError::Internal(format!("Failed to export traces: {e}")))?;
+    let query = params.to_trace_query();
+    let traces_json = export_traces_payload(&state, &cwd, &query).await?;
 
     Ok(Json(serde_json::json!({
         "export": traces_json,
@@ -123,6 +129,33 @@ struct TraceQueryParams {
 }
 
 impl TraceQueryParams {
+    fn apply_overrides(&mut self, overrides: TraceQueryParams) {
+        if overrides.session_id.is_some() {
+            self.session_id = overrides.session_id;
+        }
+        if overrides.workspace_id.is_some() {
+            self.workspace_id = overrides.workspace_id;
+        }
+        if overrides.file.is_some() {
+            self.file = overrides.file;
+        }
+        if overrides.event_type.is_some() {
+            self.event_type = overrides.event_type;
+        }
+        if overrides.start_date.is_some() {
+            self.start_date = overrides.start_date;
+        }
+        if overrides.end_date.is_some() {
+            self.end_date = overrides.end_date;
+        }
+        if overrides.limit.is_some() {
+            self.limit = overrides.limit;
+        }
+        if overrides.offset.is_some() {
+            self.offset = overrides.offset;
+        }
+    }
+
     fn to_trace_query(&self) -> TraceQuery {
         TraceQuery {
             session_id: self.session_id.clone(),
@@ -135,4 +168,95 @@ impl TraceQueryParams {
             offset: self.offset,
         }
     }
+}
+
+async fn export_traces_payload(
+    state: &AppState,
+    fallback_cwd: &Path,
+    query: &TraceQuery,
+) -> Result<Value, ServerError> {
+    if query.session_id.is_none() {
+        return TraceReader::new(fallback_cwd)
+            .export(query)
+            .await
+            .map_err(|error| ServerError::Internal(format!("Failed to export traces: {error}")));
+    }
+
+    let traces = query_traces_with_session_fallback(state, query, fallback_cwd).await?;
+    serde_json::to_value(traces)
+        .map_err(|error| ServerError::Internal(format!("Failed to serialize traces: {error}")))
+}
+
+async fn query_traces_with_session_fallback(
+    state: &AppState,
+    query: &TraceQuery,
+    fallback_cwd: &Path,
+) -> Result<Vec<TraceRecord>, ServerError> {
+    let session_id = query.session_id.clone().ok_or_else(|| {
+        ServerError::BadRequest("Session trace export requires a sessionId".to_string())
+    })?;
+    let reader_roots = resolve_trace_reader_roots(state, &session_id, fallback_cwd).await?;
+    let trace_query = TraceQuery {
+        limit: None,
+        offset: None,
+        ..query.clone()
+    };
+
+    let mut all_traces = Vec::new();
+    for root in reader_roots {
+        let traces = TraceReader::new(root)
+            .query(&trace_query)
+            .await
+            .map_err(|error| ServerError::Internal(format!("Failed to export traces: {error}")))?;
+        all_traces.extend(traces);
+    }
+
+    let mut deduped = HashMap::new();
+    for trace in all_traces {
+        deduped.entry(trace.id.clone()).or_insert(trace);
+    }
+
+    let mut traces = deduped.into_values().collect::<Vec<_>>();
+    traces.sort_by(|left, right| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let start = query.offset.unwrap_or(0);
+    let end = query
+        .limit
+        .map(|limit| start + limit)
+        .unwrap_or(traces.len());
+    Ok(traces
+        .into_iter()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .collect())
+}
+
+async fn resolve_trace_reader_roots(
+    state: &AppState,
+    session_id: &str,
+    fallback_cwd: &Path,
+) -> Result<Vec<PathBuf>, ServerError> {
+    let mut roots = vec![fallback_cwd.to_path_buf()];
+
+    let session_cwd = if let Some(session) = state.acp_manager.get_session(session_id).await {
+        Some(PathBuf::from(session.cwd))
+    } else {
+        state
+            .acp_session_store
+            .get(session_id)
+            .await?
+            .map(|session| PathBuf::from(session.cwd))
+    };
+
+    if let Some(root) = session_cwd {
+        if !roots.iter().any(|existing| existing == &root) {
+            roots.push(root);
+        }
+    }
+
+    Ok(roots)
 }

--- a/src/app/api/traces/export/__tests__/route.test.ts
+++ b/src/app/api/traces/export/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { exportTraces, queryTracesWithSessionFallback } = vi.hoisted(() => ({
+  exportTraces: vi.fn(),
+  queryTracesWithSessionFallback: vi.fn(),
+}));
+
+vi.mock("@/core/trace", () => ({
+  getTraceReader: () => ({
+    export: exportTraces,
+  }),
+  queryTracesWithSessionFallback,
+}));
+
+import { POST } from "../route";
+
+describe("/api/traces/export route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exportTraces.mockResolvedValue([{ id: "trace-export-1" }]);
+    queryTracesWithSessionFallback.mockResolvedValue([{ id: "trace-session-1" }]);
+  });
+
+  it("rejects malformed JSON bodies", async () => {
+    const response = await POST(new NextRequest("http://localhost/api/traces/export", {
+      method: "POST",
+      body: "{bad json",
+      headers: { "Content-Type": "application/json" },
+    }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: "Invalid JSON body" });
+    expect(exportTraces).not.toHaveBeenCalled();
+    expect(queryTracesWithSessionFallback).not.toHaveBeenCalled();
+  });
+
+  it("preserves zero-valued pagination overrides from the request body", async () => {
+    const response = await POST(new NextRequest("http://localhost/api/traces/export?limit=25&offset=10", {
+      method: "POST",
+      body: JSON.stringify({
+        sessionId: "session-123",
+        limit: 0,
+        offset: 0,
+      }),
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(queryTracesWithSessionFallback).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      workspaceId: undefined,
+      file: undefined,
+      eventType: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      limit: 0,
+      offset: 0,
+    });
+    expect(exportTraces).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid pagination query params", async () => {
+    const response = await POST(new NextRequest("http://localhost/api/traces/export?limit=NaN", {
+      method: "POST",
+    }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: "Invalid limit pagination parameter" });
+    expect(exportTraces).not.toHaveBeenCalled();
+    expect(queryTracesWithSessionFallback).not.toHaveBeenCalled();
+  });
+
+  it("uses the trace reader export when no session fallback is needed", async () => {
+    const response = await POST(new NextRequest("http://localhost/api/traces/export?workspaceId=workspace-1", {
+      method: "POST",
+    }));
+
+    expect(response.status).toBe(200);
+    expect(exportTraces).toHaveBeenCalledWith({
+      sessionId: undefined,
+      workspaceId: "workspace-1",
+      file: undefined,
+      eventType: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+    expect(queryTracesWithSessionFallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/traces/export/route.ts
+++ b/src/app/api/traces/export/route.ts
@@ -1,19 +1,12 @@
 /**
- * GET /api/traces — Query traces with optional filters.
+ * POST /api/traces/export — Export traces in Agent Trace JSON format.
  *
- * Query parameters:
- * - sessionId: Filter by session ID
- * - workspaceId: Filter by workspace ID
- * - file: Filter by file path
- * - eventType: Filter by event type
- * - startDate: Start date (YYYY-MM-DD)
- * - endDate: End date (YYYY-MM-DD)
- * - limit: Max number of results
- * - offset: Skip N results
+ * Static route takes priority over [id] dynamic route,
+ * preventing "export" from being matched as a trace ID.
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { queryTracesWithSessionFallback, type TraceQuery } from "@/core/trace";
+import { getTraceReader, queryTracesWithSessionFallback, type TraceQuery } from "@/core/trace";
 
 export const dynamic = "force-dynamic";
 
@@ -55,25 +48,40 @@ function toTraceQuery(params: TraceQueryParams): TraceQuery {
   };
 }
 
-/**
- * GET /api/traces — Query traces with optional filters.
- */
-export async function GET(request: NextRequest) {
+export async function POST(request: NextRequest) {
   try {
     const params = parseQueryParams(request.url);
-    const query = toTraceQuery(params);
 
-    const traces = await queryTracesWithSessionFallback(query);
+    // Allow body to override query params
+    try {
+      const body = await request.json();
+      if (body.sessionId) params.sessionId = body.sessionId;
+      if (body.workspaceId) params.workspaceId = body.workspaceId;
+      if (body.file) params.file = body.file;
+      if (body.eventType) params.eventType = body.eventType;
+      if (body.startDate) params.startDate = body.startDate;
+      if (body.endDate) params.endDate = body.endDate;
+      if (body.limit) params.limit = String(body.limit);
+      if (body.offset) params.offset = String(body.offset);
+    } catch {
+      // No body or invalid JSON, use query params
+    }
+
+    const query = toTraceQuery(params);
+    const traces = query.sessionId
+      ? await queryTracesWithSessionFallback(query)
+      : await getTraceReader(process.cwd()).export(query);
 
     return NextResponse.json({
-      traces,
-      count: traces.length,
+      export: traces,
+      format: "agent-trace-json",
+      version: "0.1.0",
     });
   } catch (error) {
-    console.error("[Traces API] Error:", error);
+    console.error("[Traces API] Export error:", error);
     return NextResponse.json(
       {
-        error: "Failed to query traces",
+        error: "Failed to export traces",
         message: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }

--- a/src/app/api/traces/export/route.ts
+++ b/src/app/api/traces/export/route.ts
@@ -21,6 +21,8 @@ interface TraceQueryParams {
   offset?: string;
 }
 
+class TraceExportRequestError extends Error {}
+
 function parseQueryParams(requestUrl: string): TraceQueryParams {
   const url = new URL(requestUrl);
   return {
@@ -35,6 +37,17 @@ function parseQueryParams(requestUrl: string): TraceQueryParams {
   };
 }
 
+function parseOptionalInt(value: string | undefined, field: "limit" | "offset"): number | undefined {
+  if (value === undefined) return undefined;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed < 0) {
+    throw new TraceExportRequestError(`Invalid ${field} pagination parameter`);
+  }
+
+  return parsed;
+}
+
 function toTraceQuery(params: TraceQueryParams): TraceQuery {
   return {
     sessionId: params.sessionId,
@@ -43,8 +56,8 @@ function toTraceQuery(params: TraceQueryParams): TraceQuery {
     eventType: params.eventType as any,
     startDate: params.startDate,
     endDate: params.endDate,
-    limit: params.limit ? parseInt(params.limit, 10) : undefined,
-    offset: params.offset ? parseInt(params.offset, 10) : undefined,
+    limit: parseOptionalInt(params.limit, "limit"),
+    offset: parseOptionalInt(params.offset, "offset"),
   };
 }
 
@@ -52,19 +65,26 @@ export async function POST(request: NextRequest) {
   try {
     const params = parseQueryParams(request.url);
 
-    // Allow body to override query params
-    try {
-      const body = await request.json();
+    const rawBody = await request.text();
+    if (rawBody.trim().length > 0) {
+      let body: Partial<TraceQueryParams>;
+      try {
+        body = JSON.parse(rawBody) as Partial<TraceQueryParams>;
+      } catch {
+        return NextResponse.json(
+          { error: "Invalid JSON body" },
+          { status: 400 }
+        );
+      }
+
       if (body.sessionId) params.sessionId = body.sessionId;
       if (body.workspaceId) params.workspaceId = body.workspaceId;
       if (body.file) params.file = body.file;
       if (body.eventType) params.eventType = body.eventType;
       if (body.startDate) params.startDate = body.startDate;
       if (body.endDate) params.endDate = body.endDate;
-      if (body.limit) params.limit = String(body.limit);
-      if (body.offset) params.offset = String(body.offset);
-    } catch {
-      // No body or invalid JSON, use query params
+      if (body.limit !== undefined) params.limit = String(body.limit);
+      if (body.offset !== undefined) params.offset = String(body.offset);
     }
 
     const query = toTraceQuery(params);
@@ -78,6 +98,14 @@ export async function POST(request: NextRequest) {
       version: "0.1.0",
     });
   } catch (error) {
+    if (error instanceof TraceExportRequestError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+        },
+        { status: 400 }
+      );
+    }
     console.error("[Traces API] Export error:", error);
     return NextResponse.json(
       {

--- a/src/client/components/trace-panel.tsx
+++ b/src/client/components/trace-panel.tsx
@@ -659,7 +659,11 @@ export function TracePanel({ sessionId }: TracePanelProps) {
 
     try {
       const params = new URLSearchParams({ sessionId });
-      const res = await desktopAwareFetch(`/api/traces/export?${params}`, { cache: "no-store" });
+      const res = await desktopAwareFetch(`/api/traces/export?${params}`, {
+        cache: "no-store",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
 
       if (!res.ok) {
         throw new Error(`Failed to export traces: ${res.statusText}`);

--- a/src/client/components/trace-panel.tsx
+++ b/src/client/components/trace-panel.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { resolveApiPath } from "@/client/config/backend";
 import { desktopAwareFetch } from "../utils/diagnostics";
 import type { TraceRecord } from "@/core/trace";
 import type { LaneHandoffInfo, LaneSessionInfo, SessionKanbanContext } from "@/client/types/kanban-context";
@@ -658,11 +659,11 @@ export function TracePanel({ sessionId }: TracePanelProps) {
     if (!sessionId) return;
 
     try {
-      const params = new URLSearchParams({ sessionId });
-      const res = await desktopAwareFetch(`/api/traces/export?${params}`, {
+      const res = await desktopAwareFetch(resolveApiPath("/traces/export"), {
         cache: "no-store",
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId }),
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary

- Extract POST /api/traces/export handler from traces/route.ts to traces/export/route.ts
- Static route takes priority over [id] dynamic route, preventing export from being matched as a trace ID
- Update client fetch call to use explicit POST method with JSON headers

## Root Cause

The export endpoint was mixed into the main traces route file as a POST handler. The Next.js [id] dynamic route could match export as a trace ID if the static export route did not exist, causing incorrect routing behavior.

## Changes

- src/app/api/traces/export/route.ts — New dedicated POST handler for trace export
- src/app/api/traces/route.ts — Remove POST handler, keep only GET query
- src/client/components/trace-panel.tsx — Update fetch to use POST with Content-Type header

## Test Plan

- [ ] Verify GET /api/traces still returns trace list with query filters
- [ ] Verify POST /api/traces/export returns exported trace data
- [ ] Verify export is no longer matched as a trace ID by the [id] route
- [ ] Verify client trace export UI works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated trace export endpoint that returns exports in Agent Trace JSON format with optional JSON body overrides and pagination.

* **Refactor**
  * Moved export logic to its own endpoint and updated the client to POST to the new export route.

* **Tests**
  * Added tests covering JSON body parsing, pagination overrides, validation errors, and session vs. non-session export paths.

* **Chores**
  * Updated API contract to reflect the new export operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->