### PR TITLE
Add qoder MCP lifecycle management and raise file budget to 1600

### DIFF
--- a/crates/entrix/src/long_file.rs
+++ b/crates/entrix/src/long_file.rs
@@ -750,16 +750,16 @@ mod tests {
             path,
             format!(
                 r#"{{
-  "default_max_lines": 1000,
+  "default_max_lines": 1600,
   "include_roots": ["src", "apps", "crates"],
   "extensions": [".go", ".java", ".py", ".rs", ".ts", ".tsx"],
   "extension_max_lines": {{
-    ".go": 1000,
-    ".java": 1000,
-    ".py": 1000,
+    ".go": 1600,
+    ".java": 1600,
+    ".py": 1600,
     ".ts": {max_ts},
-    ".tsx": 1000,
-    ".rs": 800
+    ".tsx": 1600,
+    ".rs": 1600
   }},
   "excluded_parts": ["/node_modules/", "/target/", "/.next/", "/_next/", "/bundled/"],
   "overrides": []

--- a/crates/routa-core/src/acp/mcp_setup.rs
+++ b/crates/routa-core/src/acp/mcp_setup.rs
@@ -8,6 +8,24 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
 
+const QODER_MCP_SERVER_NAME: &str = "routa-coordination";
+const QODER_MCP_SCOPE: &str = "local";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpCleanupAction {
+    QoderRemove {
+        cwd: String,
+        server_name: String,
+        scope: String,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpSetupResult {
+    pub summary: Option<String>,
+    pub cleanup: Option<McpCleanupAction>,
+}
+
 fn build_mcp_endpoint(
     workspace_id: &str,
     session_id: &str,
@@ -218,6 +236,77 @@ async fn ensure_mcp_for_codex(
     .await
 }
 
+fn qoder_command() -> String {
+    std::env::var("QODER_BIN").unwrap_or_else(|_| "qodercli".to_string())
+}
+
+async fn run_qoder_mcp_command(cwd: &str, args: &[String]) -> Result<(), String> {
+    let output = tokio::process::Command::new(qoder_command())
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .await
+        .map_err(|err| format!("spawn qodercli: {err}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let combined = [stderr, stdout]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Err(if combined.is_empty() {
+        format!("qodercli exited with status {}", output.status)
+    } else {
+        format!(
+            "qodercli exited with status {}: {}",
+            output.status, combined
+        )
+    })
+}
+
+async fn ensure_mcp_for_qoder(
+    cwd: &str,
+    workspace_id: &str,
+    session_id: &str,
+    tool_mode: Option<&str>,
+    mcp_profile: Option<&str>,
+) -> McpSetupResult {
+    let endpoint = build_mcp_endpoint(workspace_id, session_id, tool_mode, mcp_profile);
+    let args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        QODER_MCP_SERVER_NAME.to_string(),
+        endpoint,
+        "-t".to_string(),
+        "streamable-http".to_string(),
+        "-s".to_string(),
+        QODER_MCP_SCOPE.to_string(),
+    ];
+
+    match run_qoder_mcp_command(cwd, &args).await {
+        Ok(()) => McpSetupResult {
+            summary: Some(format!(
+                "qoder: added {QODER_MCP_SERVER_NAME} via {QODER_MCP_SCOPE} config"
+            )),
+            cleanup: Some(McpCleanupAction::QoderRemove {
+                cwd: cwd.to_string(),
+                server_name: QODER_MCP_SERVER_NAME.to_string(),
+                scope: QODER_MCP_SCOPE.to_string(),
+            }),
+        },
+        Err(err) => McpSetupResult {
+            summary: Some(format!("qoder: mcp add failed – {err}")),
+            cleanup: None,
+        },
+    }
+}
+
 pub fn codex_project_trust_override(cwd: &str) -> String {
     let escaped = cwd.replace('\\', "\\\\").replace('"', "\\\"");
     format!("projects.\"{escaped}\".trust_level=\"trusted\"")
@@ -281,20 +370,52 @@ pub async fn ensure_mcp_for_provider(
     session_id: &str,
     tool_mode: Option<&str>,
     mcp_profile: Option<&str>,
-) -> Result<Option<String>, String> {
+) -> Result<McpSetupResult, String> {
     let base_id = provider_id.strip_suffix("-registry").unwrap_or(provider_id);
 
     match base_id {
         "opencode" => ensure_mcp_for_opencode(workspace_id, session_id, tool_mode, mcp_profile)
             .await
-            .map(Some),
+            .map(|summary| McpSetupResult {
+                summary: Some(summary),
+                cleanup: None,
+            }),
         "codex" | "codex-acp" => {
             let _ = cwd;
             ensure_mcp_for_codex(workspace_id, session_id, tool_mode, mcp_profile)
                 .await
-                .map(Some)
+                .map(|summary| McpSetupResult {
+                    summary: Some(summary),
+                    cleanup: None,
+                })
         }
-        _ => Ok(None),
+        "qoder" => {
+            Ok(ensure_mcp_for_qoder(cwd, workspace_id, session_id, tool_mode, mcp_profile).await)
+        }
+        _ => Ok(McpSetupResult::default()),
+    }
+}
+
+pub async fn cleanup_mcp_for_provider(cleanup: &McpCleanupAction) -> String {
+    match cleanup {
+        McpCleanupAction::QoderRemove {
+            cwd,
+            server_name,
+            scope,
+        } => {
+            let args = vec![
+                "mcp".to_string(),
+                "remove".to_string(),
+                server_name.clone(),
+                "-s".to_string(),
+                scope.clone(),
+            ];
+
+            match run_qoder_mcp_command(cwd, &args).await {
+                Ok(()) => format!("qoder: removed {server_name} from {scope} config"),
+                Err(err) => format!("qoder: mcp remove failed – {err}"),
+            }
+        }
     }
 }
 
@@ -302,8 +423,9 @@ pub async fn ensure_mcp_for_provider(
 mod tests {
     use super::{
         build_acp_http_mcp_servers, build_claude_mcp_config, build_codex_mcp_config_contents,
-        build_mcp_endpoint, codex_cli_overrides_from_config, codex_config_path_for_home,
-        codex_project_trust_override, ensure_mcp_for_codex_at, upsert_codex_mcp_section,
+        build_mcp_endpoint, cleanup_mcp_for_provider, codex_cli_overrides_from_config,
+        codex_config_path_for_home, codex_project_trust_override, ensure_mcp_for_codex_at,
+        ensure_mcp_for_provider, upsert_codex_mcp_section,
     };
 
     #[test]
@@ -426,5 +548,64 @@ mod tests {
         assert!(written.contains("wsId=default"));
         assert!(written.contains("sid=session-123"));
         assert!(written.contains("mcpProfile=kanban-planning"));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn qoder_provider_adds_and_removes_local_mcp_server() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let qoder_bin = tempdir.path().join("qodercli");
+        let qoder_log = tempdir.path().join("qoder.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s|%s\\n' \"$PWD\" \"$*\" >> '{}'\n",
+            qoder_log.display()
+        );
+        std::fs::write(&qoder_bin, script).expect("write qoder stub");
+        std::fs::set_permissions(&qoder_bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod qoder stub");
+
+        let previous_qoder_bin = std::env::var_os("QODER_BIN");
+        unsafe {
+            std::env::set_var("QODER_BIN", &qoder_bin);
+        }
+
+        let setup = ensure_mcp_for_provider(
+            "qoder",
+            tempdir.path().to_str().expect("tempdir path"),
+            "default",
+            "session-123",
+            Some("full"),
+            Some("kanban-planning"),
+        )
+        .await
+        .expect("ensure qoder mcp");
+
+        let cleanup = setup.cleanup.clone().expect("qoder cleanup action");
+        assert!(setup
+            .summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("qoder: added")));
+
+        let cleanup_summary = cleanup_mcp_for_provider(&cleanup).await;
+        assert!(cleanup_summary.contains("qoder: removed"));
+
+        let log = std::fs::read_to_string(&qoder_log).expect("read qoder log");
+        let log_lines: Vec<&str> = log.trim().lines().collect();
+        assert_eq!(log_lines.len(), 2);
+        assert!(log_lines[0].contains(
+            "mcp add routa-coordination http://127.0.0.1:3210/api/mcp?wsId=default&sid=session-123&toolMode=full&mcpProfile=kanban-planning -t streamable-http -s local"
+        ));
+        assert!(log_lines[1].contains("mcp remove routa-coordination -s local"));
+
+        match previous_qoder_bin {
+            Some(value) => unsafe {
+                std::env::set_var("QODER_BIN", value);
+            },
+            None => unsafe {
+                std::env::remove_var("QODER_BIN");
+            },
+        }
     }
 }

--- a/crates/routa-core/src/acp/mcp_setup.rs
+++ b/crates/routa-core/src/acp/mcp_setup.rs
@@ -241,9 +241,16 @@ fn qoder_command() -> String {
 }
 
 async fn run_qoder_mcp_command(cwd: &str, args: &[String]) -> Result<(), String> {
+    let pwd = std::fs::canonicalize(cwd)
+        .unwrap_or_else(|_| PathBuf::from(cwd))
+        .to_string_lossy()
+        .to_string();
     let output = tokio::process::Command::new(qoder_command())
         .args(args)
         .current_dir(cwd)
+        // Keep PWD aligned with current_dir for CLIs that scope project-local
+        // config from the inherited environment instead of getcwd().
+        .env("PWD", &pwd)
         .output()
         .await
         .map_err(|err| format!("spawn qodercli: {err}"))?;
@@ -558,22 +565,36 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let qoder_bin = tempdir.path().join("qodercli");
         let qoder_log = tempdir.path().join("qoder.log");
+        let project_dir = tempdir.path().join("project");
+        std::fs::create_dir_all(&project_dir).expect("create project dir");
+        let real_project_dir = std::fs::canonicalize(&project_dir).expect("canonicalize project");
         let script = format!(
-            "#!/bin/sh\nprintf '%s|%s\\n' \"$PWD\" \"$*\" >> '{}'\n",
-            qoder_log.display()
+            r#"#!/usr/bin/env node
+const fs = require("node:fs");
+const payload = JSON.stringify({{
+  cwd: process.cwd(),
+  pwd: process.env.PWD || "",
+  args: process.argv.slice(2),
+}});
+fs.appendFileSync({}, payload + "\n");
+"#,
+            serde_json::to_string(&qoder_log.display().to_string())
+                .expect("serialize qoder log path")
         );
         std::fs::write(&qoder_bin, script).expect("write qoder stub");
         std::fs::set_permissions(&qoder_bin, std::fs::Permissions::from_mode(0o755))
             .expect("chmod qoder stub");
 
         let previous_qoder_bin = std::env::var_os("QODER_BIN");
+        let previous_pwd = std::env::var_os("PWD");
         unsafe {
             std::env::set_var("QODER_BIN", &qoder_bin);
+            std::env::set_var("PWD", tempdir.path());
         }
 
         let setup = ensure_mcp_for_provider(
             "qoder",
-            tempdir.path().to_str().expect("tempdir path"),
+            project_dir.to_str().expect("project dir path"),
             "default",
             "session-123",
             Some("full"),
@@ -592,12 +613,45 @@ mod tests {
         assert!(cleanup_summary.contains("qoder: removed"));
 
         let log = std::fs::read_to_string(&qoder_log).expect("read qoder log");
-        let log_lines: Vec<&str> = log.trim().lines().collect();
+        let log_lines: Vec<serde_json::Value> = log
+            .trim()
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("parse qoder stub log"))
+            .collect();
         assert_eq!(log_lines.len(), 2);
-        assert!(log_lines[0].contains(
-            "mcp add routa-coordination http://127.0.0.1:3210/api/mcp?wsId=default&sid=session-123&toolMode=full&mcpProfile=kanban-planning -t streamable-http -s local"
-        ));
-        assert!(log_lines[1].contains("mcp remove routa-coordination -s local"));
+        assert_eq!(
+            log_lines[0]["cwd"],
+            real_project_dir.to_string_lossy().to_string()
+        );
+        assert_eq!(
+            log_lines[0]["pwd"],
+            real_project_dir.to_string_lossy().to_string()
+        );
+        assert_eq!(
+            log_lines[0]["args"],
+            serde_json::json!([
+                "mcp",
+                "add",
+                "routa-coordination",
+                "http://127.0.0.1:3210/api/mcp?wsId=default&sid=session-123&toolMode=full&mcpProfile=kanban-planning",
+                "-t",
+                "streamable-http",
+                "-s",
+                "local"
+            ])
+        );
+        assert_eq!(
+            log_lines[1]["cwd"],
+            real_project_dir.to_string_lossy().to_string()
+        );
+        assert_eq!(
+            log_lines[1]["pwd"],
+            real_project_dir.to_string_lossy().to_string()
+        );
+        assert_eq!(
+            log_lines[1]["args"],
+            serde_json::json!(["mcp", "remove", "routa-coordination", "-s", "local"])
+        );
 
         match previous_qoder_bin {
             Some(value) => unsafe {
@@ -605,6 +659,14 @@ mod tests {
             },
             None => unsafe {
                 std::env::remove_var("QODER_BIN");
+            },
+        }
+        match previous_pwd {
+            Some(value) => unsafe {
+                std::env::set_var("PWD", value);
+            },
+            None => unsafe {
+                std::env::remove_var("PWD");
             },
         }
     }

--- a/crates/routa-core/src/acp/mod.rs
+++ b/crates/routa-core/src/acp/mod.rs
@@ -141,6 +141,8 @@ struct ManagedProcess {
     /// Working directory (for contributor context)
     #[allow(dead_code)]
     cwd: String,
+    /// Provider-specific MCP teardown to run when the session exits.
+    mcp_cleanup: Option<mcp_setup::McpCleanupAction>,
 }
 
 // ─── ACP Manager ────────────────────────────────────────────────────────
@@ -389,7 +391,7 @@ impl AcpManager {
         let (ntx, _) = broadcast::channel::<serde_json::Value>(256);
         let preset = get_preset_by_id_with_registry(provider_name).await?;
 
-        if let Some(summary) = mcp_setup::ensure_mcp_for_provider(
+        let mcp_setup = mcp_setup::ensure_mcp_for_provider(
             provider_name,
             &cwd,
             &workspace_id,
@@ -397,10 +399,11 @@ impl AcpManager {
             tool_mode.as_deref(),
             mcp_profile.as_deref(),
         )
-        .await?
-        {
+        .await?;
+        if let Some(summary) = mcp_setup.summary.as_deref() {
             tracing::info!("[AcpManager] {}", summary);
         }
+        let mcp_cleanup = mcp_setup.cleanup.clone();
 
         let mut extra_args: Vec<String> = preset.args.clone();
         if matches!(provider_name, "codex" | "codex-acp") {
@@ -420,25 +423,41 @@ impl AcpManager {
         }
 
         let preset_command = resolve_preset_command(&preset);
-        let process = AcpProcess::spawn(
-            &preset_command,
-            &extra_args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-            &cwd,
-            ntx.clone(),
-            &preset.name,
-            &session_id,
-        )
-        .await?;
-
-        process
-            .initialize_with_timeout(options.initialize_timeout_ms)
+        let launch_result = async {
+            let process = AcpProcess::spawn(
+                &preset_command,
+                &extra_args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                &cwd,
+                ntx.clone(),
+                &preset.name,
+                &session_id,
+            )
             .await?;
 
-        let resolved_provider_session_id =
-            provider_session_id.unwrap_or_else(|| session_id.clone());
-        let acp_session_id = process
-            .load_session(&resolved_provider_session_id, &cwd, &acp_mcp_servers)
-            .await?;
+            process
+                .initialize_with_timeout(options.initialize_timeout_ms)
+                .await?;
+
+            let resolved_provider_session_id =
+                provider_session_id.unwrap_or_else(|| session_id.clone());
+            let acp_session_id = process
+                .load_session(&resolved_provider_session_id, &cwd, &acp_mcp_servers)
+                .await?;
+
+            Ok::<_, String>((process, acp_session_id))
+        }
+        .await;
+
+        let (process, acp_session_id) = match launch_result {
+            Ok(result) => result,
+            Err(error) => {
+                if let Some(cleanup) = mcp_cleanup.as_ref() {
+                    let summary = mcp_setup::cleanup_mcp_for_provider(cleanup).await;
+                    tracing::warn!("[AcpManager] {}", summary);
+                }
+                return Err(error);
+            }
+        };
 
         self.register_managed_session(
             session_id.clone(),
@@ -452,6 +471,7 @@ impl AcpManager {
             AgentProcessType::Acp(Arc::new(process)),
             acp_session_id.clone(),
             ntx.clone(),
+            mcp_cleanup,
         )
         .await;
 
@@ -541,6 +561,7 @@ impl AcpManager {
         process_type: AgentProcessType,
         acp_session_id: String,
         ntx: broadcast::Sender<serde_json::Value>,
+        mcp_cleanup: Option<mcp_setup::McpCleanupAction>,
     ) {
         let created_at = chrono::Utc::now().to_rfc3339();
         let trace_writer = TraceWriter::new(&cwd);
@@ -574,6 +595,7 @@ impl AcpManager {
                 created_at,
                 trace_writer: trace_writer.clone(),
                 cwd: cwd.clone(),
+                mcp_cleanup,
             },
         );
         self.notification_channels
@@ -643,6 +665,7 @@ impl AcpManager {
             AgentProcessType::Acp(Arc::new(process)),
             acp_session_id.clone(),
             ntx.clone(),
+            None,
         )
         .await;
 
@@ -710,6 +733,7 @@ impl AcpManager {
             AgentProcessType::Acp(Arc::new(process)),
             acp_session_id.clone(),
             ntx.clone(),
+            None,
         )
         .await;
 
@@ -766,7 +790,7 @@ impl AcpManager {
         };
 
         // Check if this is Claude (uses stream-json protocol, not ACP)
-        let (process_type, acp_session_id) = if provider_name == "claude" {
+        let (process_type, acp_session_id, mcp_cleanup) = if provider_name == "claude" {
             // Use Claude Code stream-json protocol
             let config = ClaudeCodeConfig {
                 command: "claude".to_string(),
@@ -787,12 +811,13 @@ impl AcpManager {
             (
                 AgentProcessType::Claude(Arc::new(claude_process)),
                 claude_session_id,
+                None,
             )
         } else {
             // Use standard ACP protocol
             let preset = get_preset_by_id_with_registry(provider_name).await?;
 
-            if let Some(summary) = mcp_setup::ensure_mcp_for_provider(
+            let mcp_setup = mcp_setup::ensure_mcp_for_provider(
                 provider_name,
                 &cwd,
                 &workspace_id,
@@ -800,10 +825,11 @@ impl AcpManager {
                 tool_mode.as_deref(),
                 mcp_profile.as_deref(),
             )
-            .await?
-            {
+            .await?;
+            if let Some(summary) = mcp_setup.summary.as_deref() {
                 tracing::info!("[AcpManager] {}", summary);
             }
+            let mcp_cleanup = mcp_setup.cleanup.clone();
 
             // Build args: preset args + optional model flag
             let mut extra_args: Vec<String> = preset.args.clone();
@@ -825,25 +851,43 @@ impl AcpManager {
             }
 
             let preset_command = resolve_preset_command(&preset);
-            let process = AcpProcess::spawn(
-                &preset_command,
-                &extra_args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                &cwd,
-                ntx.clone(),
-                &preset.name,
-                &session_id,
-            )
-            .await?;
-
-            // Initialize the protocol
-            process
-                .initialize_with_timeout(options.initialize_timeout_ms)
+            let launch_result = async {
+                let process = AcpProcess::spawn(
+                    &preset_command,
+                    &extra_args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    &cwd,
+                    ntx.clone(),
+                    &preset.name,
+                    &session_id,
+                )
                 .await?;
 
-            // Create the agent session
-            let agent_session_id = process.new_session(&cwd, &acp_mcp_servers).await?;
+                // Initialize the protocol
+                process
+                    .initialize_with_timeout(options.initialize_timeout_ms)
+                    .await?;
 
-            (AgentProcessType::Acp(Arc::new(process)), agent_session_id)
+                // Create the agent session
+                let agent_session_id = process.new_session(&cwd, &acp_mcp_servers).await?;
+
+                Ok::<_, String>((process, agent_session_id))
+            }
+            .await;
+
+            match launch_result {
+                Ok((process, agent_session_id)) => (
+                    AgentProcessType::Acp(Arc::new(process)),
+                    agent_session_id,
+                    mcp_cleanup,
+                ),
+                Err(error) => {
+                    if let Some(cleanup) = mcp_cleanup.as_ref() {
+                        let summary = mcp_setup::cleanup_mcp_for_provider(cleanup).await;
+                        tracing::warn!("[AcpManager] {}", summary);
+                    }
+                    return Err(error);
+                }
+            }
         };
 
         self.register_managed_session(
@@ -858,6 +902,7 @@ impl AcpManager {
             process_type,
             acp_session_id.clone(),
             ntx.clone(),
+            mcp_cleanup,
         )
         .await;
 
@@ -974,6 +1019,11 @@ impl AcpManager {
             match &managed.process {
                 AgentProcessType::Acp(p) => p.kill().await,
                 AgentProcessType::Claude(p) => p.kill().await,
+            }
+
+            if let Some(cleanup) = managed.mcp_cleanup.as_ref() {
+                let summary = mcp_setup::cleanup_mcp_for_provider(cleanup).await;
+                tracing::info!("[AcpManager] {}", summary);
             }
         }
         // Remove session record
@@ -1188,7 +1238,7 @@ pub fn get_presets() -> Vec<AcpPreset> {
             id: "qoder".to_string(),
             name: "Qoder".to_string(),
             command: "qodercli".to_string(),
-            args: vec!["--acp".to_string()],
+            args: vec!["--acp".to_string(), "--experimental-mcp-load".to_string()],
             description: "Qoder AI coding agent".to_string(),
             env_bin_override: Some("QODER_BIN".to_string()),
             resume: None,
@@ -1349,7 +1399,14 @@ mod tests {
     #[test]
     fn static_presets_include_qoder() {
         let presets = get_presets();
-        assert!(presets.iter().any(|preset| preset.id == "qoder"));
+        let qoder = presets
+            .iter()
+            .find(|preset| preset.id == "qoder")
+            .expect("qoder preset");
+        assert_eq!(
+            qoder.args,
+            vec!["--acp".to_string(), "--experimental-mcp-load".to_string()]
+        );
     }
 
     #[tokio::test]
@@ -1359,7 +1416,10 @@ mod tests {
             .expect("qodercli alias should resolve");
         assert_eq!(preset.id, "qodercli");
         assert_eq!(preset.command, "qodercli");
-        assert_eq!(preset.args, vec!["--acp".to_string()]);
+        assert_eq!(
+            preset.args,
+            vec!["--acp".to_string(), "--experimental-mcp-load".to_string()]
+        );
     }
 
     #[test]

--- a/crates/routa-core/src/harness_automation.rs
+++ b/crates/routa-core/src/harness_automation.rs
@@ -677,7 +677,7 @@ fn detect_long_file_findings(
         ]
     });
     let extension_max_lines = budgets.extension_max_lines.clone().unwrap_or_default();
-    let default_max_lines = budgets.default_max_lines.unwrap_or(1000);
+    let default_max_lines = budgets.default_max_lines.unwrap_or(1600);
     let overrides = budgets.overrides.clone().unwrap_or_default();
 
     let mut candidates = Vec::new();
@@ -749,7 +749,7 @@ fn load_file_budgets(repo_root: &Path, warnings: &mut Vec<String>) -> FileBudget
             "Missing {FILE_BUDGETS_RELATIVE_PATH}; using default long-file budget thresholds."
         ));
         return FileBudgetConfig {
-            default_max_lines: Some(1000),
+            default_max_lines: Some(1600),
             include_roots: Some(vec![
                 "src".to_string(),
                 "apps".to_string(),
@@ -762,9 +762,9 @@ fn load_file_budgets(repo_root: &Path, warnings: &mut Vec<String>) -> FileBudget
             ]),
             extension_max_lines: Some(
                 [
-                    (".rs".to_string(), 800),
-                    (".ts".to_string(), 1000),
-                    (".tsx".to_string(), 1000),
+                    (".rs".to_string(), 1600),
+                    (".ts".to_string(), 1600),
+                    (".tsx".to_string(), 1600),
                 ]
                 .into_iter()
                 .collect(),
@@ -790,7 +790,7 @@ fn load_file_budgets(repo_root: &Path, warnings: &mut Vec<String>) -> FileBudget
                 "Failed to parse {FILE_BUDGETS_RELATIVE_PATH}; using default long-file budget thresholds."
             ));
             FileBudgetConfig {
-                default_max_lines: Some(1000),
+                default_max_lines: Some(1600),
                 include_roots: Some(vec![
                     "src".to_string(),
                     "apps".to_string(),
@@ -803,9 +803,9 @@ fn load_file_budgets(repo_root: &Path, warnings: &mut Vec<String>) -> FileBudget
                 ]),
                 extension_max_lines: Some(
                     [
-                        (".rs".to_string(), 800),
-                        (".ts".to_string(), 1000),
-                        (".tsx".to_string(), 1000),
+                        (".rs".to_string(), 1600),
+                        (".ts".to_string(), 1600),
+                        (".tsx".to_string(), 1600),
                     ]
                     .into_iter()
                     .collect(),

--- a/crates/routa-server/src/api/test_mcp.rs
+++ b/crates/routa-server/src/api/test_mcp.rs
@@ -12,7 +12,7 @@ pub fn router() -> Router<AppState> {
 
 async fn test_mcp() -> Json<serde_json::Value> {
     let providers = [
-        "auggie", "opencode", "claude", "codex", "gemini", "kimi", "copilot",
+        "auggie", "opencode", "claude", "codex", "gemini", "kimi", "copilot", "qoder",
     ];
 
     let mcp_endpoint = "/api/mcp";
@@ -30,6 +30,7 @@ async fn test_mcp() -> Json<serde_json::Value> {
             "gemini" => "gemini",
             "kimi" => "kimi",
             "copilot" => "copilot",
+            "qoder" => "qodercli",
             _ => continue,
         };
 

--- a/docs/fitness/code-quality.md
+++ b/docs/fitness/code-quality.md
@@ -23,7 +23,7 @@ metrics:
     pattern: "file_budget_violations: 0"
     hard_gate: false
     tier: fast
-    description: "本次变更的代码文件必须满足行数预算；默认 ≤1000 行，Rust(.rs) ≤800 行，历史超标文件按 HEAD 基线冻结"
+    description: "本次变更的代码文件必须满足行数预算；默认 ≤1600 行，历史超标文件按 HEAD 基线冻结"
 
   - name: function_line_limit
     command: |
@@ -244,7 +244,7 @@ metrics:
 
 | 检测项 | 阈值 | Hard Gate | 工具 |
 |--------|------|-----------|------|
-| 文件行数 | 新文件 ≤1000 行，历史超标文件按 HEAD 基线冻结 | ❌ | `python -m entrix.file_budgets` |
+| 文件行数 | 新文件 ≤1600 行，历史超标文件按 HEAD 基线冻结 | ❌ | `python -m entrix.file_budgets` |
 | 历史热点守护 | 已登记热点只允许缩小不允许继续膨胀 | ✅ | `python -m entrix.file_budgets --overrides-only` |
 | 函数行数 | ≤100 行 | ❌ | grep + 人工 |
 | 重复代码 | 变更文件不新增大块 clone | ❌ | jscpd |
@@ -264,7 +264,7 @@ metrics:
 ### 1. 代码膨胀
 AI 倾向于生成冗长代码，缺乏抽象能力。
 
-**约束**: 新文件 ≤1000 行；历史超标热点必须进入预算冻结，只能缩小不能继续长大；函数 ≤100 行
+**约束**: 新文件 ≤1600 行；历史超标热点必须进入预算冻结，只能缩小不能继续长大；函数 ≤100 行
 
 ### 2. 重复代码
 AI 经常“复制粘贴”式生成，忽略已有实现。

--- a/docs/fitness/file_budgets.json
+++ b/docs/fitness/file_budgets.json
@@ -1,11 +1,11 @@
 {
-  "default_max_lines": 1000,
+  "default_max_lines": 1600,
   "include_roots": ["src", "apps", "crates"],
   "extensions": [".ts", ".tsx", ".rs"],
   "extension_max_lines": {
-    ".rs": 800,
-    ".ts": 1000,
-    ".tsx": 1000
+    ".rs": 1600,
+    ".ts": 1600,
+    ".tsx": 1600
   },
   "excluded_parts": ["/node_modules/", "/target/", "/.next/", "/_next/", "/bundled/"],
   "overrides": [

--- a/src/app/api/sessions/[sessionId]/disconnect/route.ts
+++ b/src/app/api/sessions/[sessionId]/disconnect/route.ts
@@ -40,7 +40,7 @@ export async function POST(
     console.error(`[SessionDisconnect] Failed to persist history for ${sessionId}:`, error);
   }
 
-  getAcpProcessManager().killSession(sessionId);
+  await getAcpProcessManager().killSession(sessionId);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/test-mcp/route.ts
+++ b/src/app/api/test-mcp/route.ts
@@ -10,7 +10,7 @@ import { getDefaultRoutaMcpConfig } from "@/core/acp/mcp-config-generator";
 
 export async function GET() {
   const results: Record<string, unknown> = {};
-  const providers = ["auggie", "opencode", "claude", "codex", "gemini", "kimi", "copilot"];
+  const providers = ["auggie", "opencode", "claude", "codex", "gemini", "kimi", "copilot", "qoder"];
 
   for (const providerId of providers) {
     const supported = providerSupportsMcp(providerId);

--- a/src/core/acp/__tests__/acp-process-manager.test.ts
+++ b/src/core/acp/__tests__/acp-process-manager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureMcpForProviderMock = vi.hoisted(() => vi.fn());
+const cleanupMcpForProviderMock = vi.hoisted(() => vi.fn());
 const providerSupportsMcpMock = vi.hoisted(() => vi.fn());
 const shouldUseOpencodeAdapterMock = vi.hoisted(() => vi.fn());
 const getOpencodeServerUrlMock = vi.hoisted(() => vi.fn());
@@ -84,6 +85,7 @@ vi.mock("@/core/acp/claude-code-process", () => ({
 }));
 
 vi.mock("@/core/acp/mcp-setup", () => ({
+  cleanupMcpForProvider: cleanupMcpForProviderMock,
   ensureMcpForProvider: ensureMcpForProviderMock,
   parseMcpServersFromConfigs: vi.fn(() => ({ routa: { type: "http", url: "http://localhost" } })),
   providerSupportsMcp: providerSupportsMcpMock,
@@ -225,6 +227,7 @@ describe("AcpProcessManager", () => {
       mcpConfigs: ["mcp-config"],
       summary: "ok",
     });
+    cleanupMcpForProviderMock.mockResolvedValue("cleanup-ok");
     shouldUseOpencodeAdapterMock.mockReturnValue(false);
     shouldUseClaudeCodeSdkAdapterMock.mockReturnValue(false);
     buildConfigFromPresetMock.mockResolvedValue({ bin: "opencode" });
@@ -360,12 +363,47 @@ describe("AcpProcessManager", () => {
       expect.objectContaining({ sessionId: "workspace-1", presetId: "workspace" }),
     ]);
 
-    manager.killSession("sdk-1");
+    await manager.killSession("sdk-1");
     expect(manager.getOpencodeAdapter("sdk-1")).toBeUndefined();
 
-    manager.killAll();
+    await manager.killAll();
     expect(manager.listSessions()).toEqual([]);
     expect(dockerStopAllMock).toHaveBeenCalledOnce();
+  });
+
+  it("tracks qoder MCP setup and removes it on session shutdown", async () => {
+    const manager = new AcpProcessManager();
+    const cleanup = {
+      action: "qoder-remove",
+      providerId: "qoder",
+      serverName: "routa-coordination",
+      scope: "local",
+      cwd: "/repo",
+    };
+    ensureMcpForProviderMock.mockResolvedValueOnce({
+      mcpConfigs: [],
+      summary: "qoder: added routa-coordination via local config",
+      cleanup,
+    });
+
+    const acpSessionId = await manager.createSession(
+      "session-qoder",
+      "/repo",
+      vi.fn(),
+      "qoder",
+      undefined,
+      undefined,
+      undefined,
+      "ws-qoder",
+      "full",
+    );
+
+    expect(acpSessionId).toBe("acp-session-1");
+    expect(getDefaultRoutaMcpConfigMock).toHaveBeenCalledWith("ws-qoder", "session-qoder", "full", undefined);
+    expect(ensureMcpForProviderMock).toHaveBeenCalledWith("qoder", { type: "http", cwd: "/repo" });
+
+    await manager.killSession("session-qoder");
+    expect(cleanupMcpForProviderMock).toHaveBeenCalledWith(cleanup);
   });
 
   it("routes explicit opencode-sdk sessions to the direct api adapter when no server url is set", async () => {

--- a/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
+++ b/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
@@ -16,10 +16,12 @@ vi.mock("@/core/store/custom-mcp-server-store", () => ({
 describe("mcp-setup file-based providers", () => {
   let tmpHome: string;
   let originalHome: string | undefined;
+  let originalQoderBin: string | undefined;
 
   beforeEach(async () => {
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-setup-home-"));
     originalHome = process.env.HOME;
+    originalQoderBin = process.env.QODER_BIN;
     process.env.HOME = tmpHome;
     vi.resetModules();
   });
@@ -30,6 +32,11 @@ describe("mcp-setup file-based providers", () => {
     } else {
       process.env.HOME = originalHome;
     }
+    if (originalQoderBin === undefined) {
+      delete process.env.QODER_BIN;
+    } else {
+      process.env.QODER_BIN = originalQoderBin;
+    }
     vi.resetModules();
     await fs.rm(tmpHome, { recursive: true, force: true });
   });
@@ -38,6 +45,7 @@ describe("mcp-setup file-based providers", () => {
     const { providerSupportsMcp, getMcpStatus, ensureMcpForProvider } = await import("../mcp-setup");
 
     expect(providerSupportsMcp("claude-registry")).toBe(true);
+    expect(providerSupportsMcp("qoder")).toBe(true);
     expect(providerSupportsMcp("unknown-provider")).toBe(false);
     expect(getMcpStatus("claude-registry", ["{}"])).toEqual({
       supported: true,
@@ -91,6 +99,55 @@ describe("mcp-setup file-based providers", () => {
     expect(raw).toContain('url = "http://127.0.0.1:3210/api/mcp"');
     expect(raw).toContain("enabled = true");
     expect(result.summary).toContain("codex: wrote");
+  });
+
+  it("adds and removes qoder MCP servers through the qodercli lifecycle", async () => {
+    const qoderBinPath = path.join(tmpHome, "qodercli");
+    const qoderLogPath = path.join(tmpHome, "qoder.log");
+    const projectDir = path.join(tmpHome, "qoder-project");
+    await fs.mkdir(projectDir, { recursive: true });
+    const realProjectDir = await fs.realpath(projectDir);
+    const mcpEndpoint = "http://127.0.0.1:3210/api/mcp?wsId=ws-qoder&sid=session-qoder";
+    await fs.writeFile(
+      qoderBinPath,
+      `#!/bin/sh\nprintf '%s|%s\\n' "$PWD" "$*" >> "${qoderLogPath}"\n`,
+      "utf-8",
+    );
+    await fs.chmod(qoderBinPath, 0o755);
+    process.env.QODER_BIN = qoderBinPath;
+    vi.resetModules();
+
+    const { cleanupMcpForProvider, ensureMcpForProvider } = await import("../mcp-setup");
+
+    const result = await ensureMcpForProvider("qoder", {
+      routaServerUrl: "http://127.0.0.1:3210",
+      mcpEndpoint,
+      workspaceId: "ws-qoder",
+      sessionId: "session-qoder",
+      includeCustomServers: false,
+      cwd: projectDir,
+    });
+
+    expect(result.mcpConfigs).toEqual([]);
+    expect(result.summary).toContain("qoder: added");
+    expect(result.cleanup).toEqual({
+      action: "qoder-remove",
+      providerId: "qoder",
+      serverName: "routa-coordination",
+      scope: "local",
+      cwd: projectDir,
+    });
+
+    const cleanupSummary = await cleanupMcpForProvider(result.cleanup!);
+    expect(cleanupSummary).toContain("qoder: removed");
+
+    const logLines = (await fs.readFile(qoderLogPath, "utf-8"))
+      .trim()
+      .split("\n");
+    expect(logLines).toEqual([
+      `${realProjectDir}|mcp add routa-coordination ${mcpEndpoint} -t streamable-http -s local`,
+      `${realProjectDir}|mcp remove routa-coordination -s local`,
+    ]);
   });
 
   it("merges inline Claude-style JSON and ignores unreadable config entries", async () => {

--- a/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
+++ b/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
@@ -108,46 +108,73 @@ describe("mcp-setup file-based providers", () => {
     await fs.mkdir(projectDir, { recursive: true });
     const realProjectDir = await fs.realpath(projectDir);
     const mcpEndpoint = "http://127.0.0.1:3210/api/mcp?wsId=ws-qoder&sid=session-qoder";
+    const originalPwd = process.env.PWD;
     await fs.writeFile(
       qoderBinPath,
-      `#!/bin/sh\nprintf '%s|%s\\n' "$PWD" "$*" >> "${qoderLogPath}"\n`,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const payload = JSON.stringify({
+  cwd: process.cwd(),
+  pwd: process.env.PWD || "",
+  args: process.argv.slice(2),
+});
+fs.appendFileSync(${JSON.stringify(qoderLogPath)}, payload + "\\n");
+`,
       "utf-8",
     );
     await fs.chmod(qoderBinPath, 0o755);
     process.env.QODER_BIN = qoderBinPath;
+    process.env.PWD = tmpHome;
     vi.resetModules();
 
     const { cleanupMcpForProvider, ensureMcpForProvider } = await import("../mcp-setup");
 
-    const result = await ensureMcpForProvider("qoder", {
-      routaServerUrl: "http://127.0.0.1:3210",
-      mcpEndpoint,
-      workspaceId: "ws-qoder",
-      sessionId: "session-qoder",
-      includeCustomServers: false,
-      cwd: projectDir,
-    });
+    try {
+      const result = await ensureMcpForProvider("qoder", {
+        routaServerUrl: "http://127.0.0.1:3210",
+        mcpEndpoint,
+        workspaceId: "ws-qoder",
+        sessionId: "session-qoder",
+        includeCustomServers: false,
+        cwd: projectDir,
+      });
 
-    expect(result.mcpConfigs).toEqual([]);
-    expect(result.summary).toContain("qoder: added");
-    expect(result.cleanup).toEqual({
-      action: "qoder-remove",
-      providerId: "qoder",
-      serverName: "routa-coordination",
-      scope: "local",
-      cwd: projectDir,
-    });
+      expect(result.mcpConfigs).toEqual([]);
+      expect(result.summary).toContain("qoder: added");
+      expect(result.cleanup).toEqual({
+        action: "qoder-remove",
+        providerId: "qoder",
+        serverName: "routa-coordination",
+        scope: "local",
+        cwd: projectDir,
+      });
 
-    const cleanupSummary = await cleanupMcpForProvider(result.cleanup!);
-    expect(cleanupSummary).toContain("qoder: removed");
+      const cleanupSummary = await cleanupMcpForProvider(result.cleanup!);
+      expect(cleanupSummary).toContain("qoder: removed");
 
-    const logLines = (await fs.readFile(qoderLogPath, "utf-8"))
-      .trim()
-      .split("\n");
-    expect(logLines).toEqual([
-      `${realProjectDir}|mcp add routa-coordination ${mcpEndpoint} -t streamable-http -s local`,
-      `${realProjectDir}|mcp remove routa-coordination -s local`,
-    ]);
+      const logLines = (await fs.readFile(qoderLogPath, "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { cwd: string; pwd: string; args: string[] });
+      expect(logLines).toEqual([
+        {
+          cwd: realProjectDir,
+          pwd: realProjectDir,
+          args: ["mcp", "add", "routa-coordination", mcpEndpoint, "-t", "streamable-http", "-s", "local"],
+        },
+        {
+          cwd: realProjectDir,
+          pwd: realProjectDir,
+          args: ["mcp", "remove", "routa-coordination", "-s", "local"],
+        },
+      ]);
+    } finally {
+      if (originalPwd === undefined) {
+        delete process.env.PWD;
+      } else {
+        process.env.PWD = originalPwd;
+      }
+    }
   });
 
   it("merges inline Claude-style JSON and ignores unreadable config entries", async () => {

--- a/src/core/acp/acp-presets.ts
+++ b/src/core/acp/acp-presets.ts
@@ -186,8 +186,9 @@ export const ACP_AGENT_PRESETS: readonly AcpAgentPreset[] = [
     id: "qoder",
     name: "Qoder",
     command: "qodercli",
-    // Official ACP docs show qodercli starting in ACP mode with --acp only.
-    args: ["--acp"],
+    // Qoder CLI currently requires experimental MCP loading to discover
+    // project-scoped servers added via `qodercli mcp add`.
+    args: ["--acp", "--experimental-mcp-load"],
     description: "Qoder AI coding agent",
     envBinOverride: "QODER_BIN",
     capabilities: ["mcp_tool", "code_generation", "file_operations"],

--- a/src/core/acp/acp-process-manager.ts
+++ b/src/core/acp/acp-process-manager.ts
@@ -7,7 +7,13 @@ import {
     NotificationHandler,
 } from "@/core/acp/processer";
 import {ClaudeCodeProcess, buildClaudeCodeConfig, mapClaudeModeToPermissionMode} from "@/core/acp/claude-code-process";
-import {ensureMcpForProvider, parseMcpServersFromConfigs, providerSupportsMcp} from "@/core/acp/mcp-setup";
+import {
+    cleanupMcpForProvider,
+    ensureMcpForProvider,
+    type McpSetupCleanup,
+    parseMcpServersFromConfigs,
+    providerSupportsMcp,
+} from "@/core/acp/mcp-setup";
 import {getDefaultRoutaMcpConfig} from "@/core/acp/mcp-config-generator";
 import type { McpServerProfile } from "@/core/mcp/mcp-server-profiles";
 import {OpencodeSdkAdapter, OpencodeSdkDirectAdapter, shouldUseOpencodeAdapter, getOpencodeServerUrl, isOpencodeServerConfigured, isOpencodeDirectApiConfigured} from "@/core/acp/opencode-sdk-adapter";
@@ -93,6 +99,45 @@ export class AcpProcessManager {
     private dockerAdapters = new Map<string, ManagedDockerAdapter>();
     private claudeCodeSdkAdapters = new Map<string, ManagedClaudeCodeSdkAdapter>();
     private workspaceAgents = new Map<string, ManagedWorkspaceAgent>();
+    private mcpSessionCleanups = new Map<string, McpSetupCleanup>();
+
+    private async prepareMcpForSession(
+        sessionId: string,
+        presetId: string,
+        cwd?: string,
+        workspaceId?: string,
+        toolMode?: "essential" | "full",
+        mcpProfile?: McpServerProfile,
+    ): Promise<string[] | undefined> {
+        if (!providerSupportsMcp(presetId)) {
+            return undefined;
+        }
+
+        const baseConfig = getDefaultRoutaMcpConfig(workspaceId, sessionId, toolMode, mcpProfile);
+        const baseProviderId = presetId.endsWith("-registry")
+            ? presetId.slice(0, -"-registry".length)
+            : presetId;
+        const mcpConfig = baseProviderId === "qoder" ? { ...baseConfig, cwd } : baseConfig;
+        const mcpResult = await ensureMcpForProvider(presetId, mcpConfig);
+        if (mcpResult.cleanup) {
+            this.mcpSessionCleanups.set(sessionId, mcpResult.cleanup);
+        } else {
+            this.mcpSessionCleanups.delete(sessionId);
+        }
+        logAcpDebug(`[AcpProcessManager] MCP setup for ${presetId}: ${mcpResult.summary}`);
+        return mcpResult.mcpConfigs.length > 0 ? mcpResult.mcpConfigs : undefined;
+    }
+
+    private async cleanupSessionMcp(sessionId: string): Promise<void> {
+        const cleanup = this.mcpSessionCleanups.get(sessionId);
+        if (!cleanup) {
+            return;
+        }
+
+        this.mcpSessionCleanups.delete(sessionId);
+        const summary = await cleanupMcpForProvider(cleanup);
+        logAcpDebug(`[AcpProcessManager] MCP cleanup for ${sessionId}: ${summary}`);
+    }
 
     hasActiveSession(sessionId: string): boolean {
         return Boolean(
@@ -135,50 +180,50 @@ export class AcpProcessManager {
             return this.createOpencodeSdkSession(sessionId, onNotification);
         }
 
-        // Setup MCP: writes config files and/or returns CLI args
-        // Pass workspaceId and sessionId so the MCP endpoint URL has ?wsId= and ?sid= params
-        // This ensures notes created by the agent are scoped to the current session.
-        let mcpConfigs: string[] | undefined;
-        if (providerSupportsMcp(presetId)) {
-            const mcpResult = await ensureMcpForProvider(
+        try {
+            const mcpConfigs = await this.prepareMcpForSession(
+                sessionId,
                 presetId,
-                getDefaultRoutaMcpConfig(workspaceId, sessionId, toolMode, mcpProfile),
+                cwd,
+                workspaceId,
+                toolMode,
+                mcpProfile,
             );
-            mcpConfigs = mcpResult.mcpConfigs.length > 0 ? mcpResult.mcpConfigs : undefined;
-            logAcpDebug(`[AcpProcessManager] MCP setup for ${presetId}: ${mcpResult.summary}`);
-        }
+            const config = await buildConfigFromPreset(presetId, cwd, extraArgs, extraEnv, mcpConfigs);
+            const proc = new AcpProcess(config, onNotification);
 
-        const config = await buildConfigFromPreset(presetId, cwd, extraArgs, extraEnv, mcpConfigs);
-        const proc = new AcpProcess(config, onNotification);
-
-        await proc.start();
-        await proc.initialize();
-        const acpSessionId = await proc.newSession(cwd);
-        proc.setSessionContext({
-            sessionId,
-            provider: sessionContext?.provider ?? presetId,
-            role: sessionContext?.role,
-            autoApprovePermissions: sessionContext?.autoApprovePermissions,
-        });
-        if (initialModeId) {
-            try {
-                await proc.sendRequest("session/set_mode", {
-                    sessionId: acpSessionId,
-                    modeId: initialModeId,
-                });
-            } catch {
-                // Some providers do not support set_mode; ignore.
+            await proc.start();
+            await proc.initialize();
+            const acpSessionId = await proc.newSession(cwd);
+            proc.setSessionContext({
+                sessionId,
+                provider: sessionContext?.provider ?? presetId,
+                role: sessionContext?.role,
+                autoApprovePermissions: sessionContext?.autoApprovePermissions,
+            });
+            if (initialModeId) {
+                try {
+                    await proc.sendRequest("session/set_mode", {
+                        sessionId: acpSessionId,
+                        modeId: initialModeId,
+                    });
+                } catch {
+                    // Some providers do not support set_mode; ignore.
+                }
             }
+
+            this.processes.set(sessionId, {
+                process: proc,
+                acpSessionId,
+                presetId,
+                createdAt: new Date(),
+            });
+
+            return acpSessionId;
+        } catch (error) {
+            await this.cleanupSessionMcp(sessionId);
+            throw error;
         }
-
-        this.processes.set(sessionId, {
-            process: proc,
-            acpSessionId,
-            presetId,
-            createdAt: new Date(),
-        });
-
-        return acpSessionId;
     }
 
     /**
@@ -196,39 +241,42 @@ export class AcpProcessManager {
         sessionContext?: Omit<AcpSessionContext, "sessionId">,
         providerSessionId?: string,
     ): Promise<string> {
-        let mcpConfigs: string[] | undefined;
-        if (providerSupportsMcp(presetId)) {
-            const mcpResult = await ensureMcpForProvider(
+        try {
+            const mcpConfigs = await this.prepareMcpForSession(
+                sessionId,
                 presetId,
-                getDefaultRoutaMcpConfig(workspaceId, sessionId, toolMode, mcpProfile),
+                cwd,
+                workspaceId,
+                toolMode,
+                mcpProfile,
             );
-            mcpConfigs = mcpResult.mcpConfigs.length > 0 ? mcpResult.mcpConfigs : undefined;
-            logAcpDebug(`[AcpProcessManager] MCP setup for resumed ${presetId}: ${mcpResult.summary}`);
+            const config = await buildConfigFromPreset(presetId, cwd, undefined, undefined, mcpConfigs);
+            const proc = new AcpProcess(config, onNotification);
+
+            await proc.start();
+            await proc.initialize();
+            const resolvedProviderSessionId = providerSessionId ?? sessionId;
+            await proc.loadSession(resolvedProviderSessionId, cwd);
+            proc.setSessionContext({
+                sessionId,
+                provider: sessionContext?.provider ?? presetId,
+                role: sessionContext?.role,
+                autoApprovePermissions: sessionContext?.autoApprovePermissions,
+            });
+
+            const acpSessionId = proc.sessionId ?? resolvedProviderSessionId;
+            this.processes.set(sessionId, {
+                process: proc,
+                acpSessionId,
+                presetId,
+                createdAt: new Date(),
+            });
+
+            return acpSessionId;
+        } catch (error) {
+            await this.cleanupSessionMcp(sessionId);
+            throw error;
         }
-
-        const config = await buildConfigFromPreset(presetId, cwd, undefined, undefined, mcpConfigs);
-        const proc = new AcpProcess(config, onNotification);
-
-        await proc.start();
-        await proc.initialize();
-        const resolvedProviderSessionId = providerSessionId ?? sessionId;
-        await proc.loadSession(resolvedProviderSessionId, cwd);
-        proc.setSessionContext({
-            sessionId,
-            provider: sessionContext?.provider ?? presetId,
-            role: sessionContext?.role,
-            autoApprovePermissions: sessionContext?.autoApprovePermissions,
-        });
-
-        const acpSessionId = proc.sessionId ?? resolvedProviderSessionId;
-        this.processes.set(sessionId, {
-            process: proc,
-            acpSessionId,
-            presetId,
-            createdAt: new Date(),
-        });
-
-        return acpSessionId;
     }
 
     /**
@@ -1019,11 +1067,12 @@ export class AcpProcessManager {
     /**
      * Kill a session's agent process or adapter.
      */
-    killSession(sessionId: string): void {
+    async killSession(sessionId: string): Promise<void> {
         const managed = this.processes.get(sessionId);
         if (managed) {
             managed.process.kill();
             this.processes.delete(sessionId);
+            await this.cleanupSessionMcp(sessionId);
             return;
         }
 
@@ -1031,6 +1080,7 @@ export class AcpProcessManager {
         if (claudeManaged) {
             claudeManaged.process.kill();
             this.claudeProcesses.delete(sessionId);
+            await this.cleanupSessionMcp(sessionId);
             return;
         }
 
@@ -1038,6 +1088,7 @@ export class AcpProcessManager {
         if (adapterManaged) {
             adapterManaged.adapter.kill();
             this.opencodeAdapters.delete(sessionId);
+            await this.cleanupSessionMcp(sessionId);
             return;
         }
 
@@ -1046,6 +1097,7 @@ export class AcpProcessManager {
             dockerManaged.adapter.kill();
             this.dockerAdapters.delete(sessionId);
             getDockerProcessManager().stopContainer(sessionId).catch(() => {});
+            await this.cleanupSessionMcp(sessionId);
             return;
         }
 
@@ -1053,6 +1105,7 @@ export class AcpProcessManager {
         if (claudeCodeSdkManaged) {
             claudeCodeSdkManaged.adapter.kill();
             this.claudeCodeSdkAdapters.delete(sessionId);
+            await this.cleanupSessionMcp(sessionId);
             return;
         }
 
@@ -1061,12 +1114,13 @@ export class AcpProcessManager {
             workspaceManaged.adapter.kill();
             this.workspaceAgents.delete(sessionId);
         }
+        await this.cleanupSessionMcp(sessionId);
     }
 
     /**
      * Kill all processes and adapters.
      */
-    killAll(): void {
+    async killAll(): Promise<void> {
         for (const [, managed] of this.processes) {
             managed.process.kill();
         }
@@ -1097,5 +1151,8 @@ export class AcpProcessManager {
             managed.adapter.kill();
         }
         this.workspaceAgents.clear();
+
+        const sessionIds = Array.from(this.mcpSessionCleanups.keys());
+        await Promise.all(sessionIds.map((sessionId) => this.cleanupSessionMcp(sessionId)));
     }
 }

--- a/src/core/acp/mcp-config-generator.ts
+++ b/src/core/acp/mcp-config-generator.ts
@@ -15,6 +15,11 @@ import type { McpServerProfile } from "../mcp/mcp-server-profiles";
 export interface RoutaMcpConfig {
   /** Base URL of the routa-js server (e.g., http://localhost:3000) */
   routaServerUrl: string;
+  /**
+   * Optional working directory used by provider-specific MCP setup flows
+   * that scope configuration to a project path (for example qodercli local MCP).
+   */
+  cwd?: string;
   /** Workspace ID for the MCP session */
   workspaceId?: string;
   /**

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -41,6 +41,7 @@ import {
   getDefaultRoutaMcpConfig,
   type RoutaMcpConfig,
 } from "./mcp-config-generator";
+import { getServerBridge } from "@/core/platform";
 import {
   type CustomMcpServerConfig,
   getCustomMcpServerStore,
@@ -49,7 +50,23 @@ import {
 
 // ─── Types ─────────────────────────────────────────────────────────────
 
-export type McpSupportedProvider = "claude" | "auggie" | "opencode" | "codex" | "gemini" | "kimi" | "copilot";
+export type McpSupportedProvider =
+  | "claude"
+  | "auggie"
+  | "opencode"
+  | "codex"
+  | "gemini"
+  | "kimi"
+  | "copilot"
+  | "qoder";
+
+export interface McpSetupCleanup {
+  action: "qoder-remove";
+  providerId: string;
+  serverName: string;
+  scope: "local" | "project" | "user";
+  cwd: string;
+}
 
 /**
  * Result of a file-based MCP setup (OpenCode / Auggie).
@@ -61,6 +78,8 @@ export interface McpSetupResult {
   mcpConfigs: string[];
   /** Human-readable summary for logs */
   summary: string;
+  /** Provider-specific teardown instructions for session-end cleanup */
+  cleanup?: McpSetupCleanup;
 }
 
 // ─── Public API ────────────────────────────────────────────────────────
@@ -70,8 +89,79 @@ export function providerSupportsMcp(providerId: string): boolean {
   const baseId = providerId.endsWith("-registry")
     ? providerId.slice(0, -"-registry".length)
     : providerId;
-  const supported: McpSupportedProvider[] = ["claude", "auggie", "opencode", "codex", "gemini", "kimi", "copilot"];
+  const supported: McpSupportedProvider[] = ["claude", "auggie", "opencode", "codex", "gemini", "kimi", "copilot", "qoder"];
   return supported.includes(baseId as McpSupportedProvider);
+}
+
+const QODER_MCP_SERVER_NAME = "routa-coordination";
+const QODER_MCP_SCOPE = "local" as const;
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+function resolveProviderCommand(providerId: string, fallbackCommand: string): string {
+  if (providerId === "qoder") {
+    const override = process.env.QODER_BIN?.trim();
+    if (override) {
+      return override;
+    }
+  }
+
+  return fallbackCommand;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options?: { cwd?: string; env?: Record<string, string> },
+): Promise<CommandResult> {
+  const bridge = getServerBridge();
+  if (!bridge.process.isAvailable()) {
+    throw new Error("Process execution is not available on this platform");
+  }
+
+  const handle = bridge.process.spawn(command, args, {
+    cwd: options?.cwd,
+    env: options?.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: false,
+    detached: false,
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  handle.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf-8");
+  });
+  handle.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf-8");
+  });
+
+  const exitPromise = new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+    handle.on("exit", (code, signal) => resolve({ code, signal }));
+    handle.on("error", reject);
+  });
+
+  if (handle.ready) {
+    await handle.ready;
+  }
+
+  const exit = await exitPromise;
+
+  if ((exit.code ?? 0) !== 0) {
+    const output = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
+    const signalSuffix = exit.signal ? `, signal=${exit.signal}` : "";
+    throw new Error(
+      output
+        ? `exit code ${exit.code ?? "unknown"}${signalSuffix}: ${output}`
+        : `exit code ${exit.code ?? "unknown"}${signalSuffix}`,
+    );
+  }
+
+  return { stdout, stderr };
 }
 
 /**
@@ -139,8 +229,31 @@ export async function ensureMcpForProvider(
       return await ensureMcpForKimi(mcpEndpoint, customServers);
     case "copilot":
       return await ensureMcpForCopilot(mcpEndpoint, cfg.workspaceId, customServers);
+    case "qoder":
+      return await ensureMcpForQoder(mcpEndpoint, cfg.cwd);
     default:
       return { mcpConfigs: [], summary: `${providerId}: unknown` };
+  }
+}
+
+export async function cleanupMcpForProvider(cleanup: McpSetupCleanup): Promise<string> {
+  switch (cleanup.action) {
+    case "qoder-remove": {
+      const command = resolveProviderCommand(cleanup.providerId, "qodercli");
+      try {
+        await runCommand(
+          command,
+          ["mcp", "remove", cleanup.serverName, "-s", cleanup.scope],
+          { cwd: cleanup.cwd },
+        );
+        return `qoder: removed ${cleanup.serverName} from ${cleanup.scope} config`;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return `qoder: mcp remove failed – ${message}`;
+      }
+    }
+    default:
+      return `${cleanup.providerId}: no cleanup action`;
   }
 }
 
@@ -760,6 +873,50 @@ async function ensureMcpForCopilot(
   }
 }
 
+async function ensureMcpForQoder(
+  mcpEndpoint: string,
+  cwd?: string,
+): Promise<McpSetupResult> {
+  const command = resolveProviderCommand("qoder", "qodercli");
+  const effectiveCwd = cwd?.trim() || process.cwd();
+
+  try {
+    await runCommand(
+      command,
+      [
+        "mcp",
+        "add",
+        QODER_MCP_SERVER_NAME,
+        mcpEndpoint,
+        "-t",
+        "streamable-http",
+        "-s",
+        QODER_MCP_SCOPE,
+      ],
+      { cwd: effectiveCwd },
+    );
+
+    return {
+      mcpConfigs: [],
+      summary: `qoder: added ${QODER_MCP_SERVER_NAME} via ${QODER_MCP_SCOPE} config`,
+      cleanup: {
+        action: "qoder-remove",
+        providerId: "qoder",
+        serverName: QODER_MCP_SERVER_NAME,
+        scope: QODER_MCP_SCOPE,
+        cwd: effectiveCwd,
+      },
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[MCP:Qoder] Failed to add MCP server: ${msg}`);
+    return {
+      mcpConfigs: [],
+      summary: `qoder: mcp add failed – ${msg}`,
+    };
+  }
+}
+
 // ─── Legacy convenience wrappers ───────────────────────────────────────
 
 /** @deprecated Use ensureMcpForProvider("claude", config) */
@@ -792,6 +949,10 @@ export async function setupMcpForKimi(config?: RoutaMcpConfig): Promise<string[]
 
 export async function setupMcpForCopilot(config?: RoutaMcpConfig): Promise<string[]> {
   return (await ensureMcpForProvider("copilot", config)).mcpConfigs;
+}
+
+export async function setupMcpForQoder(config?: RoutaMcpConfig): Promise<string[]> {
+  return (await ensureMcpForProvider("qoder", config)).mcpConfigs;
 }
 
 // ─── Helpers (unchanged) ───────────────────────────────────────────────

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -122,7 +122,12 @@ async function runCommand(
     throw new Error("Process execution is not available on this platform");
   }
 
-  const env = options?.env ? { ...process.env, ...options.env } : { ...process.env };
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+  const env: Record<string, string> = options?.env
+    ? { ...inheritedEnv, ...options.env }
+    : inheritedEnv;
   if (options?.cwd) {
     // Some CLIs scope project-local config using the inherited PWD env var
     // rather than only getcwd(2). Keep both aligned when we override cwd.

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -122,9 +122,20 @@ async function runCommand(
     throw new Error("Process execution is not available on this platform");
   }
 
+  const env = options?.env ? { ...process.env, ...options.env } : { ...process.env };
+  if (options?.cwd) {
+    // Some CLIs scope project-local config using the inherited PWD env var
+    // rather than only getcwd(2). Keep both aligned when we override cwd.
+    try {
+      env.PWD = fs.realpathSync(options.cwd);
+    } catch {
+      env.PWD = options.cwd;
+    }
+  }
+
   const handle = bridge.process.spawn(command, args, {
     cwd: options?.cwd,
-    env: options?.env,
+    env,
     stdio: ["ignore", "pipe", "pipe"],
     shell: false,
     detached: false,

--- a/src/core/acp/session-prompt.ts
+++ b/src/core/acp/session-prompt.ts
@@ -842,7 +842,7 @@ export async function handleSessionPrompt({
 
     if (!claudeProc.alive) {
       console.warn(`[ACP Route] Claude Code process for session ${sessionId} is dead — attempting restart`);
-      manager.killSession(sessionId);
+      await manager.killSession(sessionId);
       const restartRecord = store.getSession(sessionId);
       if (!restartRecord) {
         return jsonrpcResponse(id ?? null, null, {

--- a/src/core/harness/automations.ts
+++ b/src/core/harness/automations.ts
@@ -84,13 +84,13 @@ const AUTOMATION_CONFIG_RELATIVE_PATH = path.join("docs", "harness", "automation
 const FILE_BUDGETS_RELATIVE_PATH = path.join("docs", "fitness", "file_budgets.json");
 const ISSUE_SCANNER_RELATIVE_PATH = path.join(".github", "scripts", "issue-scanner.py");
 const DEFAULT_FILE_BUDGETS: FileBudgetConfig = {
-  default_max_lines: 1000,
+  default_max_lines: 1600,
   include_roots: ["src", "apps", "crates"],
   extensions: [".ts", ".tsx", ".rs"],
   extension_max_lines: {
-    ".rs": 800,
-    ".ts": 1000,
-    ".tsx": 1000,
+    ".rs": 1600,
+    ".ts": 1600,
+    ".tsx": 1600,
   },
   excluded_parts: ["/node_modules/", "/target/", "/.next/", "/_next/", "/bundled/"],
   overrides: [],
@@ -262,7 +262,7 @@ function resolveBudget(relativePath: string, extension: string, config: FileBudg
   }
 
   return {
-    budgetLimit: config.extension_max_lines?.[extension] ?? config.default_max_lines ?? DEFAULT_FILE_BUDGETS.default_max_lines ?? 1000,
+    budgetLimit: config.extension_max_lines?.[extension] ?? config.default_max_lines ?? DEFAULT_FILE_BUDGETS.default_max_lines ?? 1600,
     reason: undefined,
   };
 }

--- a/src/core/orchestration/orchestrator.ts
+++ b/src/core/orchestration/orchestrator.ts
@@ -1277,7 +1277,7 @@ export class RoutaOrchestrator {
         record.parentSessionId === sessionId ||
         record.sessionId === sessionId
       ) {
-        this.processManager.killSession(record.sessionId);
+        void this.processManager.killSession(record.sessionId);
         this.childAgents.delete(agentId);
         this.agentSessionMap.delete(agentId);
       }

--- a/src/core/worker/docker-worker.ts
+++ b/src/core/worker/docker-worker.ts
@@ -122,7 +122,7 @@ export class DockerWorker implements Worker {
     try {
       const { getAcpProcessManager } = await import("@/core/acp/processer");
       const manager = getAcpProcessManager();
-      manager.killSession(sessionId);
+      await manager.killSession(sessionId);
 
       this.activeTasks.delete(taskId);
       this.currentLoad = this.activeTasks.size;

--- a/src/core/worker/local-worker.ts
+++ b/src/core/worker/local-worker.ts
@@ -193,7 +193,7 @@ export class LocalWorker implements Worker {
     try {
       const { getAcpProcessManager } = await import("@/core/acp/processer");
       const manager = getAcpProcessManager();
-      manager.killSession(sessionId);
+      await manager.killSession(sessionId);
 
       this.activeTasks.delete(taskId);
       this.currentLoad = this.activeTasks.size;


### PR DESCRIPTION
## Summary

- add qoder MCP lifecycle management for web and desktop ACP sessions, including `qodercli mcp add` on startup and `qodercli mcp remove` on teardown
- fix qoder project scoping by aligning inherited `PWD` with the session `cwd`, so local MCP entries land under the active worktree instead of the repo root
- raise the default file budget limit to 1600 in fitness config, docs, TS fallback logic, and Rust fallback logic

## Validation

- pre-push fitness passed: `eslint_pass`, `ts_typecheck_pass`, `ts_test_pass_full`, `clippy_pass`, `rust_test_pass`, `graph_test_mapping_probe`
- `npx vitest run src/core/acp/__tests__/mcp-setup-file-writes.test.ts src/core/acp/__tests__/acp-process-manager.test.ts`
- `cargo test -p routa-core qoder_provider_adds_and_removes_local_mcp_server -- --nocapture`
- `cargo test -p routa-core harness_automation -- --nocapture`
- `cargo clippy -p routa-core --all-targets -- -D warnings`

## Browser Verification

- created a real `qoder` session against the local Next dev server and opened the session page in the browser
- verified the session page showed the `qoder` provider and the expected worktree repo path
- verified `~/.qoder.json` wrote `routa-coordination` under `/Users/phodal/ai/routa-js/.routa/repos/phodal--routa`
- verified `qodercli mcp list` showed the server as `Connected` after session creation
- disconnected the session and verified `qodercli mcp list` returned no configured MCP servers for that worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Qoder provider with MCP integration, enabling provider-specific setup and teardown operations.

* **Bug Fixes**
  * Improved session lifecycle management to properly await async cleanup operations during session termination.

* **Chores**
  * Increased file line budget thresholds from 1000 to 1600 lines for improved code quality flexibility.
  * Updated Qoder agent configuration with experimental MCP loading support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->