### PR TITLE
fix(kanban): persist board GitHub token updates in Rust API

### DIFF
--- a/crates/routa-server/src/api/kanban.rs
+++ b/crates/routa-server/src/api/kanban.rs
@@ -717,6 +717,10 @@ struct UpdateBoardRequest {
     name: Option<String>,
     columns: Option<serde_json::Value>,
     is_default: Option<bool>,
+    #[serde(rename = "githubToken")]
+    github_token: Option<String>,
+    #[serde(rename = "clearGitHubToken")]
+    clear_github_token: Option<bool>,
     auto_provider_id: Option<String>,
     session_concurrency_limit: Option<u32>,
     dev_session_supervision: Option<PartialKanbanDevSessionSupervision>,
@@ -736,6 +740,12 @@ async fn update_board(
     }
     if let Some(is_default) = body.is_default {
         params["isDefault"] = serde_json::json!(is_default);
+    }
+    if let Some(clear_github_token) = body.clear_github_token {
+        params["clearGitHubToken"] = serde_json::json!(clear_github_token);
+    }
+    if let Some(github_token) = body.github_token {
+        params["githubToken"] = serde_json::json!(github_token);
     }
 
     let rpc_result = rpc_result(&state, "kanban.updateBoard", params).await?;
@@ -1207,7 +1217,7 @@ mod tests {
         default_dev_session_supervision, get_dev_session_supervision,
         normalize_dev_session_supervision, persisted_session_is_explicitly_terminal,
         sanitize_stale_current_lane_automation, translate_agent_event_to_kanban_payload,
-        PartialKanbanDevSessionSupervision,
+        PartialKanbanDevSessionSupervision, UpdateBoardRequest,
     };
     use chrono::Utc;
     use routa_core::events::{AgentEvent, AgentEventType};
@@ -1383,6 +1393,20 @@ mod tests {
         assert_eq!(normalized.inactivity_timeout_minutes, 120);
         assert_eq!(normalized.max_recovery_attempts, 10);
         assert_eq!(normalized.completion_requirement, "turn_complete");
+    }
+
+    #[test]
+    fn update_board_request_deserializes_github_token_fields() {
+        let payload = serde_json::json!({
+            "githubToken": "github_pat_test",
+            "clearGitHubToken": true
+        });
+
+        let request: UpdateBoardRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+
+        assert_eq!(request.github_token.as_deref(), Some("github_pat_test"));
+        assert_eq!(request.clear_github_token, Some(true));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Fix Kanban settings in Rust/Axum backend where board-scoped GitHub personal access tokens entered from the UI were not being persisted and remained in the "待保存" state.

### Description
- Add `github_token` and `clear_github_token` to the Rust request model `UpdateBoardRequest` and annotate them with `#[serde(rename = "githubToken")]` / `#[serde(rename = "clearGitHubToken")]` to preserve the existing camelCase JSON contract used by web/desktop clients (file: `crates/routa-server/src/api/kanban.rs`).
- Forward `githubToken` and `clearGitHubToken` values from the `PATCH /api/kanban/boards/{boardId}` handler into the RPC `kanban.updateBoard` parameter payload so board-level credentials are applied by the server (file: `crates/routa-server/src/api/kanban.rs`).
- Add a regression unit test `update_board_request_deserializes_github_token_fields` that verifies the `UpdateBoardRequest` correctly deserializes the camelCase token fields (file: `crates/routa-server/src/api/kanban.rs`).

### Testing
- Ran `cargo test -p routa-server update_board_request_deserializes_github_token_fields`, and the new unit test passed.
- Ran `cargo fmt --all --check` and formatting checks passed.
- Full `routa-server` test run completed without regressions for the exercised tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e081bca144832699b2f61798a581b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now manage GitHub authentication tokens when updating boards. Set or clear GitHub credentials directly in board settings to enable GitHub-integrated features and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->