### PR TITLE
fix(acp): unlock SDK mode for third-party API providers via ROUTA_USE_SDK_MODE

### DIFF
--- a/src/core/acp/claude-code-sdk-adapter.ts
+++ b/src/core/acp/claude-code-sdk-adapter.ts
@@ -310,8 +310,9 @@ export class ClaudeCodeSdkAdapter {
     // Ensure CLAUDE_CONFIG_DIR points to /tmp/.claude in the current process
     // so the SDK's trace writer resolves to a writable path — this is the
     // primary fix for the ENOENT crash on Vercel (the serverless-fs-patch
-    // import above acts as a safety net).
-    if (!process.env.CLAUDE_CONFIG_DIR) {
+    // import above acts as a safety net). Only override in serverless envs;
+    // local (SDK mode via ROUTA_USE_SDK_MODE) should use the default ~/.claude.
+    if (!process.env.CLAUDE_CONFIG_DIR && isServerlessEnvironment()) {
       process.env.CLAUDE_CONFIG_DIR = "/tmp/.claude";
     }
 
@@ -409,7 +410,7 @@ export class ClaudeCodeSdkAdapter {
         ...(systemPromptOption ?? {}),
         env: {
           ...process.env,
-          CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? "/tmp/.claude",
+          ...(isServerlessEnvironment() && { CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? "/tmp/.claude" }),
         },
         ...(this._mcpServers ? { mcpServers: this._mcpServers } : {}),
         ...(shouldContinue && { continue: true }),
@@ -639,12 +640,12 @@ export class ClaudeCodeSdkAdapter {
           return this.canUseConfiguredTool(sessionId, toolName, input, options.toolUseID, options.signal);
         },
         ...(systemPromptOption ?? {}),
-        // Set CLAUDE_CONFIG_DIR to /tmp so the child process can write its
-        // config/cache files in serverless environments (like Vercel Lambda)
-        // where HOME or the default config directory is read-only.
+        // Set CLAUDE_CONFIG_DIR to /tmp in serverless environments so the child
+        // process can write config/cache files (HOME may be read-only on Vercel).
+        // In local SDK mode, leave it unset to use the default ~/.claude.
         env: {
           ...process.env,
-          CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? "/tmp/.claude",
+          ...(isServerlessEnvironment() && { CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? "/tmp/.claude" }),
         },
         ...(this._mcpServers ? { mcpServers: this._mcpServers } : {}),
         // Session continuity: use `continue: true` for follow-up prompts
@@ -1146,7 +1147,11 @@ export class ClaudeCodeSdkAdapter {
  * Check if we should use the Claude Code SDK adapter
  */
 export function shouldUseClaudeCodeSdkAdapter(): boolean {
-  return isServerlessEnvironment() && isClaudeCodeSdkConfigured();
+  if (!isClaudeCodeSdkConfigured()) return false;
+  // Enable SDK mode in serverless environments, or when explicitly opted-in
+  // (e.g. for third-party API providers like Zhipu GLM Coding Plan that
+  // require SDK mode to bypass TTY-based usage detection).
+  return isServerlessEnvironment() || process.env.ROUTA_USE_SDK_MODE === "1";
 }
 
 /**


### PR DESCRIPTION
## Summary

- Unlock Claude Code SDK adapter for non-serverless environments via `ROUTA_USE_SDK_MODE=1` env var
- Gate `CLAUDE_CONFIG_DIR` overrides to serverless environments only, preserving default `~/.claude` in local SDK mode

Fixes #469

## Root Cause

Third-party Anthropic-compatible API providers (e.g., Zhipu GLM Coding Plan) detect usage via TTY presence. The SDK adapter's `query()` method spawns `claude` without the `-p` flag (via stdin JSONL), bypassing this detection. However, the adapter was gated behind `isServerlessEnvironment()` only, preventing local use.

## Changes

- `shouldUseClaudeCodeSdkAdapter()` — accepts `ROUTA_USE_SDK_MODE === "1"` in addition to serverless detection
- `connect()` — `CLAUDE_CONFIG_DIR` override gated by `isServerlessEnvironment()`
- `promptStream()` — same `CLAUDE_CONFIG_DIR` gating
- `prompt()` — same `CLAUDE_CONFIG_DIR` gating

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Gate logic verified: `ROUTA_USE_SDK_MODE=1` enables SDK mode in non-serverless env
- [x] End-to-end SDK call to Zhipu API succeeds (no 429): session created, response received
- [ ] Full Routa application test with `ROUTA_USE_SDK_MODE=1` (multi-turn, MCP injection)
- [ ] Verify default behavior unchanged (no env var → process mode as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced serverless environment detection and configuration handling.
  * Improved SDK adapter initialization with conditional environment variable support.
  * Added explicit activation mode for SDK features in various deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->