### PR TITLE
feat(entrix): unify test mapping analysis for #476

### DIFF
--- a/crates/entrix/src/main.rs
+++ b/crates/entrix/src/main.rs
@@ -20,8 +20,8 @@ use entrix::release_trigger::{
 use entrix::reporting::{report_to_dict, write_report_output};
 use entrix::review_context::{
     analyze_file, analyze_history, analyze_impact, analyze_test_radius, build_graph,
-    build_review_context, graph_stats, query_current_graph, GraphNodePayload, ImpactOptions,
-    ReviewBuildMode, ReviewContextOptions, TestRadiusOptions,
+    build_review_context, graph_stats, query_current_graph, ImpactOptions, ReviewBuildMode,
+    ReviewContextOptions, TestRadiusOptions,
 };
 use entrix::review_trigger::{
     collect_changed_files, collect_diff_stats, evaluate_review_triggers, load_review_triggers,
@@ -37,7 +37,7 @@ use entrix::terminal::{
 };
 use entrix::test_mapping;
 use serde_json::json;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -1018,94 +1018,18 @@ fn cmd_graph_test_mapping(args: GraphTestMappingArgs) -> i32 {
     } else {
         args.files
     };
-    let registry = test_mapping::ResolverRegistry::default();
-    let graph_build =
-        (!args.no_graph).then(|| build_graph(&repo_root, parse_build_mode(&args.build_mode)));
-    let graph_test_files_by_source = if args.no_graph {
-        BTreeMap::new()
-    } else {
-        let Some(build) = graph_build.as_ref() else {
-            return 1;
-        };
-        if build.status == "unavailable" {
-            BTreeMap::new()
-        } else {
-            let mut by_source = BTreeMap::new();
-            for source_file in changed_files
-                .iter()
-                .filter(|path| !registry.is_test_file(path))
-            {
-                let query = query_current_graph(
-                    &repo_root,
-                    source_file,
-                    "tests_for",
-                    ReviewBuildMode::Skip,
-                );
-                if query.status != "ok" {
-                    continue;
-                }
-                let graph_files = query
-                    .results
-                    .iter()
-                    .map(|node| match node {
-                        GraphNodePayload::File(node) => node.file_path.clone(),
-                        GraphNodePayload::Symbol(node) => node.file_path.clone(),
-                    })
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                if !graph_files.is_empty() {
-                    by_source.insert(source_file.clone(), graph_files);
-                }
-            }
-            by_source
-        }
-    };
-    let report = registry.analyze_changed_files_with_graph(
+    let report = test_mapping::analyze_test_mappings(
         &repo_root,
         &changed_files,
-        &graph_test_files_by_source,
+        test_mapping::TestMappingAnalysisOptions {
+            base: &args.base,
+            build_mode: parse_build_mode(&args.build_mode),
+            use_graph: !args.no_graph,
+        },
     );
-    let graph_payload = if args.no_graph {
-        json!({
-            "available": false,
-            "status": "disabled",
-            "reason": "graph disabled"
-        })
-    } else {
-        let build = graph_build.expect("graph build");
-        if build.status == "unavailable" {
-            json!({
-                "available": false,
-                "status": "unavailable",
-                "reason": "graph backend unavailable"
-            })
-        } else {
-            json!({
-                "available": true,
-                "status": build.status.clone(),
-                "build": build,
-            })
-        }
-    };
 
     if args.json {
-        let payload = json!({
-            "status": "ok",
-            "summary": format!(
-                "Analyzed test mappings for {} changed source file(s); skipped {} changed test file(s).",
-                report.mappings.len(),
-                report.skipped_test_files.len()
-            ),
-            "base": args.base,
-            "changed_files": report.changed_files,
-            "skipped_test_files": report.skipped_test_files,
-            "mappings": report.mappings,
-            "status_counts": report.status_counts,
-            "resolver_counts": report.resolver_counts,
-            "graph": graph_payload
-        });
-        print_json(&payload);
+        print_json(&report);
     } else {
         println!(
             "test mappings: {} source files, {} skipped test files",

--- a/crates/entrix/src/run_support.rs
+++ b/crates/entrix/src/run_support.rs
@@ -245,7 +245,15 @@ fn probe_test_mapping(repo_root: &Path, changed_files: &[String], _base: &str) -
         .filter(|file| is_code_file(repo_root, file))
         .cloned()
         .collect::<Vec<_>>();
-    let report = test_mapping::analyze_changed_files(repo_root, &code_files);
+    let report = test_mapping::analyze_test_mappings(
+        repo_root,
+        &code_files,
+        test_mapping::TestMappingAnalysisOptions {
+            base: _base,
+            build_mode: ReviewBuildMode::Auto,
+            use_graph: true,
+        },
+    );
     let source_file_count = report.mappings.len();
     if source_file_count == 0 {
         return MetricResult::new(
@@ -295,8 +303,8 @@ fn probe_test_mapping(repo_root: &Path, changed_files: &[String], _base: &str) -
             inline,
             missing,
             unknown,
-            mapping_source_preview(&report, "missing"),
-            mapping_source_preview(&report, "unknown"),
+            mapping_source_preview(&report.mappings, "missing"),
+            mapping_source_preview(&report.mappings, "unknown"),
             resolver_breakdown(&report.resolver_counts),
         ),
         crate::model::Tier::Normal,
@@ -312,9 +320,8 @@ fn is_code_file(repo_root: &Path, rel_path: &str) -> bool {
     CODE_EXTENSIONS.contains(&extension.as_str()) && repo_root.join(rel_path).exists()
 }
 
-fn mapping_source_preview(report: &test_mapping::TestMappingReport, status: &str) -> String {
-    let preview = report
-        .mappings
+fn mapping_source_preview(mappings: &[test_mapping::TestMappingRecord], status: &str) -> String {
+    let preview = mappings
         .iter()
         .filter(|mapping| mapping.status.as_str() == status)
         .map(|mapping| mapping.source_file.clone())
@@ -336,4 +343,55 @@ fn resolver_breakdown(counts: &BTreeMap<String, usize>) -> String {
         .map(|(name, count)| format!("{name}:{count}"))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn probe_test_mapping_skips_when_no_changed_source_files() {
+        let temp = tempdir().expect("tempdir");
+        let result = probe_test_mapping(temp.path(), &[], "HEAD");
+        assert_eq!(result.state, ResultState::Skipped);
+        assert!(result.output.contains("changed_source_files: 0"));
+    }
+
+    #[test]
+    fn probe_test_mapping_passes_on_unknown_without_missing() {
+        let temp = tempdir().expect("tempdir");
+        let repo_root = temp.path();
+        std::fs::create_dir_all(repo_root.join("src")).expect("create src");
+        std::fs::write(repo_root.join("src/service.rs"), "pub fn run() {}\n").expect("write source");
+
+        let result = probe_test_mapping(repo_root, &["src/service.rs".to_string()], "HEAD");
+        assert!(result.passed);
+        assert_eq!(result.state, ResultState::Pass);
+        assert!(result.output.contains("unknown_mappings: 1"));
+        assert!(result.output.contains("missing_mappings: 0"));
+    }
+
+    #[test]
+    fn probe_test_mapping_warns_on_missing() {
+        let temp = tempdir().expect("tempdir");
+        let repo_root = temp.path();
+        std::fs::create_dir_all(repo_root.join("src/main/java/com/example"))
+            .expect("create java dir");
+        std::fs::write(
+            repo_root.join("src/main/java/com/example/OrderService.java"),
+            "class OrderService {}\n",
+        )
+        .expect("write java source");
+
+        let result = probe_test_mapping(
+            repo_root,
+            &["src/main/java/com/example/OrderService.java".to_string()],
+            "HEAD",
+        );
+        assert!(!result.passed);
+        assert_eq!(result.state, ResultState::Fail);
+        assert!(result.output.contains("graph_test_mapping: warn"));
+        assert!(result.output.contains("missing_mappings: 1"));
+    }
 }

--- a/crates/entrix/src/test_mapping.rs
+++ b/crates/entrix/src/test_mapping.rs
@@ -5,6 +5,9 @@
 //! was that test also changed, or is the result unknown?
 
 use crate::model::Confidence;
+use crate::review_context::{
+    build_graph, query_current_graph, GraphBuildReport, GraphNodePayload, ReviewBuildMode,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -117,6 +120,36 @@ pub struct TestMappingReport {
     pub mappings: Vec<TestMappingRecord>,
     pub status_counts: BTreeMap<String, usize>,
     pub resolver_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestMappingAnalysisOptions<'a> {
+    pub base: &'a str,
+    pub build_mode: ReviewBuildMode,
+    pub use_graph: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestMappingGraphReport {
+    pub available: bool,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build: Option<GraphBuildReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestMappingAnalysisReport {
+    pub status: String,
+    pub summary: String,
+    pub base: String,
+    pub changed_files: Vec<String>,
+    pub skipped_test_files: Vec<String>,
+    pub mappings: Vec<TestMappingRecord>,
+    pub status_counts: BTreeMap<String, usize>,
+    pub resolver_counts: BTreeMap<String, usize>,
+    pub graph: TestMappingGraphReport,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -324,6 +357,67 @@ impl ResolverRegistry {
 
 pub fn analyze_changed_files(repo_root: &Path, changed_files: &[String]) -> TestMappingReport {
     ResolverRegistry::default().analyze_changed_files(repo_root, changed_files)
+}
+
+pub fn analyze_test_mappings(
+    repo_root: &Path,
+    changed_files: &[String],
+    options: TestMappingAnalysisOptions<'_>,
+) -> TestMappingAnalysisReport {
+    let registry = ResolverRegistry::default();
+    let graph = if options.use_graph {
+        let build = build_graph(repo_root, options.build_mode);
+        if build.status == "unavailable" {
+            TestMappingGraphReport {
+                available: false,
+                status: "unavailable".to_string(),
+                reason: Some("graph backend unavailable".to_string()),
+                build: None,
+            }
+        } else {
+            TestMappingGraphReport {
+                available: true,
+                status: build.status.clone(),
+                reason: None,
+                build: Some(build),
+            }
+        }
+    } else {
+        TestMappingGraphReport {
+            available: false,
+            status: "disabled".to_string(),
+            reason: Some("graph disabled".to_string()),
+            build: None,
+        }
+    };
+
+    let graph_test_files_by_source = graph_test_files_by_source(
+        repo_root,
+        changed_files,
+        &registry,
+        &graph,
+    );
+    let report = registry.analyze_changed_files_with_graph(
+        repo_root,
+        changed_files,
+        &graph_test_files_by_source,
+    );
+
+    TestMappingAnalysisReport {
+        status: "ok".to_string(),
+        summary: format!(
+            "Analyzed test mappings for {} changed source file(s); skipped {} changed test file(s).",
+            report.mappings.len(),
+            report.skipped_test_files.len()
+        ),
+        base: options.base.to_string(),
+        changed_files: report.changed_files,
+        skipped_test_files: report.skipped_test_files,
+        mappings: report.mappings,
+        status_counts: report.status_counts,
+        resolver_counts: report.resolver_counts,
+        graph,
+    }
 }
 
 struct TypeScriptResolver;
@@ -626,6 +720,39 @@ fn normalized_tokens(value: &str) -> BTreeSet<String> {
             }
         })
         .collect()
+}
+
+fn graph_test_files_by_source(
+    repo_root: &Path,
+    changed_files: &[String],
+    registry: &ResolverRegistry,
+    graph: &TestMappingGraphReport,
+) -> BTreeMap<String, Vec<String>> {
+    if !graph.available {
+        return BTreeMap::new();
+    }
+
+    let mut by_source = BTreeMap::new();
+    for source_file in changed_files.iter().filter(|path| !registry.is_test_file(path)) {
+        let query = query_current_graph(repo_root, source_file, "tests_for", ReviewBuildMode::Skip);
+        if query.status != "ok" {
+            continue;
+        }
+        let graph_files = query
+            .results
+            .iter()
+            .map(|node| match node {
+                GraphNodePayload::File(node) => node.file_path.clone(),
+                GraphNodePayload::Symbol(node) => node.file_path.clone(),
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if !graph_files.is_empty() {
+            by_source.insert(source_file.clone(), graph_files);
+        }
+    }
+    by_source
 }
 
 #[cfg(test)]

--- a/crates/entrix/src/test_mapping/tests.rs
+++ b/crates/entrix/src/test_mapping/tests.rs
@@ -166,3 +166,53 @@ fn graph_enrichment_upgrades_mapping_and_merges_related_tests() {
     assert_eq!(report.status_counts.get("exists"), Some(&1));
     assert_eq!(report.resolver_counts.get("semantic_graph"), Some(&1));
 }
+
+#[test]
+fn shared_analysis_reports_graph_disabled() {
+    let temp = tempdir().expect("tempdir");
+    let repo_root = temp.path();
+    fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    fs::write(repo_root.join("src/service.ts"), "export function run() {}\n").expect("write source");
+
+    let report = analyze_test_mappings(
+        repo_root,
+        &["src/service.ts".to_string()],
+        TestMappingAnalysisOptions {
+            base: "HEAD",
+            build_mode: ReviewBuildMode::Auto,
+            use_graph: false,
+        },
+    );
+
+    assert_eq!(report.status, "ok");
+    assert_eq!(report.base, "HEAD");
+    assert_eq!(report.graph.status, "disabled");
+    assert!(!report.graph.available);
+    assert_eq!(report.graph.reason.as_deref(), Some("graph disabled"));
+    assert!(report.graph.build.is_none());
+}
+
+#[test]
+fn shared_analysis_reports_graph_ok_when_enabled() {
+    let temp = tempdir().expect("tempdir");
+    let repo_root = temp.path();
+    fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    fs::write(repo_root.join("src/service.ts"), "export function run() {}\n").expect("write source");
+
+    let report = analyze_test_mappings(
+        repo_root,
+        &["src/service.ts".to_string()],
+        TestMappingAnalysisOptions {
+            base: "HEAD~1",
+            build_mode: ReviewBuildMode::Auto,
+            use_graph: true,
+        },
+    );
+
+    assert_eq!(report.status, "ok");
+    assert_eq!(report.base, "HEAD~1");
+    assert_eq!(report.graph.status, "ok");
+    assert!(report.graph.available);
+    assert!(report.graph.reason.is_none());
+    assert!(report.graph.build.is_some());
+}

--- a/crates/harness-monitor/src/ui/cache.rs
+++ b/crates/harness-monitor/src/ui/cache.rs
@@ -19,6 +19,7 @@ const FITNESS_HISTORY_FILE: &str = "fitness-history.json";
 const TEST_MAPPING_HISTORY_SCHEMA_VERSION: u32 = 1;
 const TEST_MAPPING_HISTORY_FILE: &str = "test-mapping-history.json";
 const TEST_MAPPING_HISTORY_CAPACITY: usize = 6;
+const TEST_MAPPING_FULL_REFRESH_MAX_FILES: usize = 12;
 const FITNESS_TREND_CAPACITY: usize = 12;
 const INITIAL_FILE_PREVIEW_LINE_LIMIT: usize = 100;
 const DIRECTORY_PREVIEW_ENTRY_LIMIT: usize = 200;
@@ -197,6 +198,7 @@ pub(super) struct AppCache {
     pending_fitness: bool,
     pending_test_mapping_fast_key: Option<String>,
     pending_test_mapping_full_key: Option<String>,
+    test_mapping_full_refresh_note: Option<String>,
     test_mapping_not_before_ms: Option<i64>,
     pending_scc: bool,
     queued_fitness_refresh: Option<(String, String, bool, fitness::FitnessRunMode)>,
@@ -301,6 +303,7 @@ impl AppCache {
             pending_fitness: false,
             pending_test_mapping_fast_key: None,
             pending_test_mapping_full_key: None,
+            test_mapping_full_refresh_note: None,
             test_mapping_not_before_ms: Some(
                 chrono::Utc::now().timestamp_millis() + TEST_MAPPING_STARTUP_DELAY_MS,
             ),
@@ -526,7 +529,8 @@ impl AppCache {
                                 self.pending_test_mapping_fast_key = None
                             }
                             TestMappingAnalysisMode::Full => {
-                                self.pending_test_mapping_full_key = None
+                                self.pending_test_mapping_full_key = None;
+                                self.test_mapping_full_refresh_note = None;
                             }
                         }
                         self.test_mapping_not_before_ms = None;
@@ -547,6 +551,7 @@ impl AppCache {
                             }
                             TestMappingAnalysisMode::Full => {
                                 self.pending_test_mapping_full_key = None;
+                                self.test_mapping_full_refresh_note = None;
                             }
                         }
                         self.test_mapping_not_before_ms = Some(
@@ -700,6 +705,7 @@ impl AppCache {
         if files.is_empty() {
             self.pending_test_mapping_fast_key = None;
             self.pending_test_mapping_full_key = None;
+            self.test_mapping_full_refresh_note = None;
             self.test_mapping_snapshot = None;
             return;
         }
@@ -724,6 +730,7 @@ impl AppCache {
             {
                 self.pending_test_mapping_fast_key = None;
                 self.pending_test_mapping_full_key = None;
+                self.test_mapping_full_refresh_note = None;
                 self.test_mapping_not_before_ms = None;
                 self.test_mapping_snapshot = Some(snapshot);
                 return;
@@ -747,6 +754,15 @@ impl AppCache {
         if current_mode == Some(TestMappingAnalysisMode::Fast)
             && self.pending_test_mapping_full_key.as_deref() != Some(cache_key.as_str())
         {
+            if files.len() > TEST_MAPPING_FULL_REFRESH_MAX_FILES {
+                self.pending_test_mapping_full_key = None;
+                self.test_mapping_full_refresh_note = Some(format!(
+                    "graph refresh skipped: {} dirty files exceeds budget {}",
+                    files.len(),
+                    TEST_MAPPING_FULL_REFRESH_MAX_FILES
+                ));
+                return;
+            }
             let _ = self.eval_worker_tx.send(EvalCommand::TestMapping {
                 repo_root: state.repo_root.clone(),
                 files,
@@ -755,6 +771,7 @@ impl AppCache {
                 analysis_mode: TestMappingAnalysisMode::Full,
             });
             self.pending_test_mapping_full_key = Some(cache_key);
+            self.test_mapping_full_refresh_note = None;
         }
     }
 
@@ -943,6 +960,13 @@ impl AppCache {
     #[cfg(test)]
     pub(super) fn set_test_mapping_graph_pending_for_tests(&mut self, cache_key: String) {
         self.pending_test_mapping_full_key = Some(cache_key);
+        self.test_mapping_full_refresh_note = None;
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_test_mapping_graph_note_for_tests(&mut self, note: String) {
+        self.pending_test_mapping_full_key = None;
+        self.test_mapping_full_refresh_note = Some(note);
     }
 
     fn active_fitness_history(&self) -> Option<&FitnessHistoryEntry> {
@@ -1115,6 +1139,10 @@ impl AppCache {
 
     pub(super) fn test_mapping_graph_enrichment_pending(&self) -> bool {
         self.pending_test_mapping_full_key.is_some()
+    }
+
+    pub(super) fn test_mapping_graph_enrichment_note(&self) -> Option<&str> {
+        self.test_mapping_full_refresh_note.as_deref()
     }
 
     pub(super) fn repo_review_hints(

--- a/crates/harness-monitor/src/ui/cache.rs
+++ b/crates/harness-monitor/src/ui/cache.rs
@@ -792,12 +792,17 @@ impl AppCache {
         &mut self,
         entries: Vec<TestMappingEntry>,
         skipped_test_files: Vec<String>,
+        graph_status: Option<String>,
+        graph_reason: Option<String>,
     ) {
-        self.test_mapping_snapshot = Some(build_test_mapping_snapshot(
+        let mut snapshot = build_test_mapping_snapshot(
             "test".to_string(),
             entries,
             skipped_test_files,
-        ));
+        );
+        snapshot.graph_status = graph_status.unwrap_or_default();
+        snapshot.graph_reason = graph_reason;
+        self.test_mapping_snapshot = Some(snapshot);
     }
 
     fn active_fitness_history(&self) -> Option<&FitnessHistoryEntry> {
@@ -940,6 +945,16 @@ impl AppCache {
         self.test_mapping_snapshot
             .as_ref()
             .map(|snapshot| &snapshot.status_counts)
+    }
+
+    pub(super) fn test_mapping_graph_status(&self) -> Option<(&str, Option<&str>)> {
+        self.test_mapping_snapshot.as_ref().and_then(|snapshot| {
+            if snapshot.graph_status.is_empty() {
+                None
+            } else {
+                Some((snapshot.graph_status.as_str(), snapshot.graph_reason.as_deref()))
+            }
+        })
     }
 
     pub(super) fn repo_review_hints(

--- a/crates/harness-monitor/src/ui/cache.rs
+++ b/crates/harness-monitor/src/ui/cache.rs
@@ -16,6 +16,9 @@ use std::thread;
 
 const FITNESS_HISTORY_SCHEMA_VERSION: u32 = 1;
 const FITNESS_HISTORY_FILE: &str = "fitness-history.json";
+const TEST_MAPPING_HISTORY_SCHEMA_VERSION: u32 = 1;
+const TEST_MAPPING_HISTORY_FILE: &str = "test-mapping-history.json";
+const TEST_MAPPING_HISTORY_CAPACITY: usize = 6;
 const FITNESS_TREND_CAPACITY: usize = 12;
 const INITIAL_FILE_PREVIEW_LINE_LIMIT: usize = 100;
 const DIRECTORY_PREVIEW_ENTRY_LIMIT: usize = 200;
@@ -115,6 +118,8 @@ enum EvalCommand {
         repo_root: String,
         files: Vec<String>,
         cache_key: String,
+        full_cache_key: Option<String>,
+        analysis_mode: TestMappingAnalysisMode,
     },
     Scc {
         repo_root: String,
@@ -141,6 +146,8 @@ enum BackgroundResult {
         result: Box<Result<fitness::FitnessSnapshot, String>>,
     },
     TestMapping {
+        analysis_mode: TestMappingAnalysisMode,
+        full_cache_key: Option<String>,
         result: Result<TestMappingSnapshot, String>,
     },
     Scc {
@@ -163,7 +170,8 @@ struct PendingFactsCommands {
 #[derive(Debug, Default)]
 struct PendingEvalCommands {
     fitness: Option<(String, String, fitness::FitnessRunMode)>,
-    test_mapping: Option<(String, Vec<String>, String)>,
+    test_mapping_fast: Option<(String, Vec<String>, String, Option<String>)>,
+    test_mapping_full: Option<(String, Vec<String>, String, Option<String>)>,
     scc: Option<String>,
 }
 
@@ -187,7 +195,8 @@ pub(super) struct AppCache {
     pending_facts_key: Option<String>,
     pending_git_history_key: Option<String>,
     pending_fitness: bool,
-    pending_test_mapping_key: Option<String>,
+    pending_test_mapping_fast_key: Option<String>,
+    pending_test_mapping_full_key: Option<String>,
     test_mapping_not_before_ms: Option<i64>,
     pending_scc: bool,
     queued_fitness_refresh: Option<(String, String, bool, fitness::FitnessRunMode)>,
@@ -197,6 +206,7 @@ pub(super) struct AppCache {
     fitness_cache_key: Option<String>,
     fitness_repo_root: String,
     test_mapping_snapshot: Option<TestMappingSnapshot>,
+    test_mapping_full_history: BTreeMap<String, TestMappingHistoryEntry>,
     scc_summary: Option<SccSummary>,
     review_triggers: ReviewTriggerCache,
     preview_worker_tx: Sender<PreviewCommand>,
@@ -238,6 +248,22 @@ struct FitnessHistoryRecord {
     cache_key: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct TestMappingHistoryEntry {
+    #[serde(default)]
+    snapshot: Option<TestMappingSnapshot>,
+    #[serde(default)]
+    observed_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct TestMappingHistoryRecord {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    histories: BTreeMap<String, TestMappingHistoryEntry>,
+}
+
 impl AppCache {
     pub(super) fn new(repo_root: &str) -> Self {
         let (preview_worker_tx, preview_worker_rx_cmd) = mpsc::channel();
@@ -273,7 +299,8 @@ impl AppCache {
             pending_facts_key: None,
             pending_git_history_key: None,
             pending_fitness: false,
-            pending_test_mapping_key: None,
+            pending_test_mapping_fast_key: None,
+            pending_test_mapping_full_key: None,
             test_mapping_not_before_ms: Some(
                 chrono::Utc::now().timestamp_millis() + TEST_MAPPING_STARTUP_DELAY_MS,
             ),
@@ -285,6 +312,7 @@ impl AppCache {
             fitness_cache_key: None,
             fitness_repo_root: repo_root.to_string(),
             test_mapping_snapshot: None,
+            test_mapping_full_history: BTreeMap::new(),
             scc_summary: None,
             review_triggers: ReviewTriggerCache::load(repo_root),
             preview_worker_tx,
@@ -294,6 +322,7 @@ impl AppCache {
             result_signal_rx: Some(result_signal_rx),
         };
         cache.load_fitness_history();
+        cache.load_test_mapping_history();
         cache
     }
 
@@ -362,6 +391,51 @@ impl AppCache {
             }
         }
         self.sync_cache_key_from_active_mode();
+    }
+
+    fn persist_test_mapping_history(&self) {
+        let path = match test_mapping_history_path(&self.fitness_repo_root) {
+            Some(path) => path,
+            None => return,
+        };
+        let payload = serde_json::to_vec_pretty(&TestMappingHistoryRecord {
+            schema_version: TEST_MAPPING_HISTORY_SCHEMA_VERSION,
+            histories: self.test_mapping_full_history.clone(),
+        });
+        let Ok(payload) = payload else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(path, payload);
+    }
+
+    fn load_test_mapping_history(&mut self) {
+        let Some(record) = read_test_mapping_history_record(&self.fitness_repo_root) else {
+            return;
+        };
+        if record.schema_version > TEST_MAPPING_HISTORY_SCHEMA_VERSION {
+            return;
+        }
+        self.test_mapping_full_history = record.histories;
+        self.trim_test_mapping_history();
+    }
+
+    fn trim_test_mapping_history(&mut self) {
+        if self.test_mapping_full_history.len() <= TEST_MAPPING_HISTORY_CAPACITY {
+            return;
+        }
+        let mut entries = self
+            .test_mapping_full_history
+            .iter()
+            .map(|(key, entry)| (key.clone(), entry.observed_at_ms.unwrap_or_default()))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|(_, observed_at_ms)| *observed_at_ms);
+        let overflow = self.test_mapping_full_history.len() - TEST_MAPPING_HISTORY_CAPACITY;
+        for (key, _) in entries.into_iter().take(overflow) {
+            self.test_mapping_full_history.remove(&key);
+        }
     }
 
     pub(super) fn sync_results(&mut self) -> bool {
@@ -441,15 +515,40 @@ impl AppCache {
                         self.request_fitness_refresh(repo_root, cache_key, force, mode);
                     }
                 }
-                BackgroundResult::TestMapping { result } => match result {
+                BackgroundResult::TestMapping {
+                    analysis_mode,
+                    full_cache_key,
+                    result,
+                } => match result {
                     Ok(snapshot) => {
-                        self.pending_test_mapping_key = None;
+                        match analysis_mode {
+                            TestMappingAnalysisMode::Fast => {
+                                self.pending_test_mapping_fast_key = None
+                            }
+                            TestMappingAnalysisMode::Full => {
+                                self.pending_test_mapping_full_key = None
+                            }
+                        }
                         self.test_mapping_not_before_ms = None;
+                        if analysis_mode == TestMappingAnalysisMode::Full {
+                            self.store_test_mapping_full_snapshot(
+                                full_cache_key,
+                                chrono::Utc::now().timestamp_millis(),
+                                snapshot.clone(),
+                            );
+                        }
                         self.test_mapping_snapshot = Some(snapshot);
                     }
                     Err(_) => {
-                        self.pending_test_mapping_key = None;
-                        self.test_mapping_snapshot = None;
+                        match analysis_mode {
+                            TestMappingAnalysisMode::Fast => {
+                                self.pending_test_mapping_fast_key = None;
+                                self.test_mapping_snapshot = None;
+                            }
+                            TestMappingAnalysisMode::Full => {
+                                self.pending_test_mapping_full_key = None;
+                            }
+                        }
                         self.test_mapping_not_before_ms = Some(
                             chrono::Utc::now().timestamp_millis() + TEST_MAPPING_FAILURE_BACKOFF_MS,
                         );
@@ -599,26 +698,64 @@ impl AppCache {
             .map(|file| file.rel_path.clone())
             .collect::<Vec<_>>();
         if files.is_empty() {
-            self.pending_test_mapping_key = None;
+            self.pending_test_mapping_fast_key = None;
+            self.pending_test_mapping_full_key = None;
             self.test_mapping_snapshot = None;
             return;
         }
 
         let cache_key = test_mapping_cache_key(state);
-        let already_loaded = self
+        let full_cache_key = test_mapping_full_cache_key(state);
+        let current_mode = self
             .test_mapping_snapshot
             .as_ref()
-            .is_some_and(|snapshot| snapshot.cache_key == cache_key);
-        if already_loaded || self.pending_test_mapping_key.as_deref() == Some(cache_key.as_str()) {
+            .filter(|snapshot| snapshot.cache_key == cache_key)
+            .map(|snapshot| snapshot.analysis_mode);
+        if current_mode == Some(TestMappingAnalysisMode::Full) {
             return;
         }
 
-        let _ = self.eval_worker_tx.send(EvalCommand::TestMapping {
-            repo_root: state.repo_root.clone(),
-            files,
-            cache_key: cache_key.clone(),
-        });
-        self.pending_test_mapping_key = Some(cache_key);
+        if let Some(full_cache_key) = full_cache_key.as_deref() {
+            if let Some(snapshot) = self
+                .test_mapping_full_history
+                .get(full_cache_key)
+                .and_then(|entry| entry.snapshot.clone())
+                .filter(|snapshot| snapshot.cache_key == cache_key)
+            {
+                self.pending_test_mapping_fast_key = None;
+                self.pending_test_mapping_full_key = None;
+                self.test_mapping_not_before_ms = None;
+                self.test_mapping_snapshot = Some(snapshot);
+                return;
+            }
+        }
+
+        if current_mode.is_none()
+            && self.pending_test_mapping_fast_key.as_deref() != Some(cache_key.as_str())
+        {
+            let _ = self.eval_worker_tx.send(EvalCommand::TestMapping {
+                repo_root: state.repo_root.clone(),
+                files: files.clone(),
+                cache_key: cache_key.clone(),
+                full_cache_key: None,
+                analysis_mode: TestMappingAnalysisMode::Fast,
+            });
+            self.pending_test_mapping_fast_key = Some(cache_key);
+            return;
+        }
+
+        if current_mode == Some(TestMappingAnalysisMode::Fast)
+            && self.pending_test_mapping_full_key.as_deref() != Some(cache_key.as_str())
+        {
+            let _ = self.eval_worker_tx.send(EvalCommand::TestMapping {
+                repo_root: state.repo_root.clone(),
+                files,
+                cache_key: cache_key.clone(),
+                full_cache_key,
+                analysis_mode: TestMappingAnalysisMode::Full,
+            });
+            self.pending_test_mapping_full_key = Some(cache_key);
+        }
     }
 
     pub(super) fn diff_stat<'a>(
@@ -790,19 +927,22 @@ impl AppCache {
     #[cfg(test)]
     pub(super) fn set_test_mapping_snapshot_for_tests(
         &mut self,
+        cache_key: String,
+        analysis_mode: TestMappingAnalysisMode,
         entries: Vec<TestMappingEntry>,
         skipped_test_files: Vec<String>,
-        graph_status: Option<String>,
-        graph_reason: Option<String>,
     ) {
-        let mut snapshot = build_test_mapping_snapshot(
-            "test".to_string(),
+        self.test_mapping_snapshot = Some(build_test_mapping_snapshot(
+            cache_key,
+            analysis_mode,
             entries,
             skipped_test_files,
-        );
-        snapshot.graph_status = graph_status.unwrap_or_default();
-        snapshot.graph_reason = graph_reason;
-        self.test_mapping_snapshot = Some(snapshot);
+        ));
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_test_mapping_graph_pending_for_tests(&mut self, cache_key: String) {
+        self.pending_test_mapping_full_key = Some(cache_key);
     }
 
     fn active_fitness_history(&self) -> Option<&FitnessHistoryEntry> {
@@ -857,6 +997,26 @@ impl AppCache {
         self.fitness_is_running = false;
         self.pending_fitness = false;
         self.persist_fitness_history();
+    }
+
+    fn store_test_mapping_full_snapshot(
+        &mut self,
+        full_cache_key: Option<String>,
+        observed_at_ms: i64,
+        snapshot: TestMappingSnapshot,
+    ) {
+        let Some(full_cache_key) = full_cache_key else {
+            return;
+        };
+        self.test_mapping_full_history.insert(
+            full_cache_key,
+            TestMappingHistoryEntry {
+                snapshot: Some(snapshot),
+                observed_at_ms: Some(observed_at_ms),
+            },
+        );
+        self.trim_test_mapping_history();
+        self.persist_test_mapping_history();
     }
 
     fn sync_cache_key_from_active_mode(&mut self) {
@@ -947,14 +1107,14 @@ impl AppCache {
             .map(|snapshot| &snapshot.status_counts)
     }
 
-    pub(super) fn test_mapping_graph_status(&self) -> Option<(&str, Option<&str>)> {
-        self.test_mapping_snapshot.as_ref().and_then(|snapshot| {
-            if snapshot.graph_status.is_empty() {
-                None
-            } else {
-                Some((snapshot.graph_status.as_str(), snapshot.graph_reason.as_deref()))
-            }
-        })
+    pub(super) fn test_mapping_analysis_mode(&self) -> Option<TestMappingAnalysisMode> {
+        self.test_mapping_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.analysis_mode)
+    }
+
+    pub(super) fn test_mapping_graph_enrichment_pending(&self) -> bool {
+        self.pending_test_mapping_full_key.is_some()
     }
 
     pub(super) fn repo_review_hints(
@@ -1399,12 +1559,42 @@ fn eval_worker(
                 },
             );
         }
-        if let Some((repo_root, files, cache_key)) = pending.test_mapping.take() {
-            let result = load_test_mapping_snapshot(&repo_root, &files, cache_key);
+        if let Some((repo_root, files, cache_key, full_cache_key)) =
+            pending.test_mapping_fast.take()
+        {
+            let result = load_test_mapping_snapshot(
+                &repo_root,
+                &files,
+                cache_key,
+                TestMappingAnalysisMode::Fast,
+            );
             send_background_result(
                 &tx,
                 &result_signal_tx,
-                BackgroundResult::TestMapping { result },
+                BackgroundResult::TestMapping {
+                    analysis_mode: TestMappingAnalysisMode::Fast,
+                    full_cache_key,
+                    result,
+                },
+            );
+        }
+        if let Some((repo_root, files, cache_key, full_cache_key)) =
+            pending.test_mapping_full.take()
+        {
+            let result = load_test_mapping_snapshot(
+                &repo_root,
+                &files,
+                cache_key,
+                TestMappingAnalysisMode::Full,
+            );
+            send_background_result(
+                &tx,
+                &result_signal_tx,
+                BackgroundResult::TestMapping {
+                    analysis_mode: TestMappingAnalysisMode::Full,
+                    full_cache_key,
+                    result,
+                },
             );
         }
         if let Some(repo_root) = pending.scc.take() {
@@ -1478,9 +1668,16 @@ fn queue_eval_command(pending: &mut PendingEvalCommands, command: EvalCommand) {
             repo_root,
             files,
             cache_key,
-        } => {
-            pending.test_mapping = Some((repo_root, files, cache_key));
-        }
+            full_cache_key,
+            analysis_mode,
+        } => match analysis_mode {
+            TestMappingAnalysisMode::Fast => {
+                pending.test_mapping_fast = Some((repo_root, files, cache_key, full_cache_key));
+            }
+            TestMappingAnalysisMode::Full => {
+                pending.test_mapping_full = Some((repo_root, files, cache_key, full_cache_key));
+            }
+        },
         EvalCommand::Scc { repo_root } => {
             pending.scc = Some(repo_root);
         }
@@ -1656,12 +1853,19 @@ mod tests;
 mod test_mapping;
 #[cfg(test)]
 use self::test_mapping::build_test_mapping_snapshot;
-use self::test_mapping::{load_test_mapping_snapshot, test_mapping_cache_key};
-pub(super) use self::test_mapping::{TestMappingEntry, TestMappingSnapshot};
+use self::test_mapping::{
+    load_test_mapping_snapshot, test_mapping_cache_key, test_mapping_full_cache_key,
+};
+pub(super) use self::test_mapping::{
+    TestMappingAnalysisMode, TestMappingEntry, TestMappingSnapshot,
+};
 
 #[path = "cache_history.rs"]
 mod history;
-use history::{fitness_history_path, latest_fitness_mailbox_event, read_fitness_history_record};
+use history::{
+    fitness_history_path, latest_fitness_mailbox_event, read_fitness_history_record,
+    read_test_mapping_history_record, test_mapping_history_path,
+};
 
 pub(super) fn load_diff_text(
     repo_root: &str,

--- a/crates/harness-monitor/src/ui/cache_history.rs
+++ b/crates/harness-monitor/src/ui/cache_history.rs
@@ -1,4 +1,6 @@
-use super::{FitnessHistoryRecord, FITNESS_HISTORY_FILE};
+use super::{
+    FitnessHistoryRecord, TestMappingHistoryRecord, FITNESS_HISTORY_FILE, TEST_MAPPING_HISTORY_FILE,
+};
 use crate::observe;
 use crate::shared::models::{FitnessEvent, RuntimeMessage};
 use std::path::{Path, PathBuf};
@@ -12,6 +14,19 @@ pub(super) fn read_fitness_history_record(repo_root: &str) -> Option<FitnessHist
 pub(super) fn fitness_history_path(repo_root: &str) -> Option<PathBuf> {
     let event_path = observe::repo::runtime_event_path(Path::new(repo_root));
     Some(event_path.parent()?.join(FITNESS_HISTORY_FILE))
+}
+
+pub(super) fn read_test_mapping_history_record(
+    repo_root: &str,
+) -> Option<TestMappingHistoryRecord> {
+    let path = test_mapping_history_path(repo_root)?;
+    let payload = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&payload).ok()
+}
+
+pub(super) fn test_mapping_history_path(repo_root: &str) -> Option<PathBuf> {
+    let event_path = observe::repo::runtime_event_path(Path::new(repo_root));
+    Some(event_path.parent()?.join(TEST_MAPPING_HISTORY_FILE))
 }
 
 pub(super) fn latest_fitness_mailbox_event(repo_root: &str, mode: &str) -> Option<FitnessEvent> {

--- a/crates/harness-monitor/src/ui/cache_test_mapping.rs
+++ b/crates/harness-monitor/src/ui/cache_test_mapping.rs
@@ -10,6 +10,8 @@ pub(in crate::ui::tui) struct TestMappingSnapshot {
     pub(in crate::ui::tui) by_file: BTreeMap<String, TestMappingEntry>,
     pub(in crate::ui::tui) skipped_test_files: BTreeSet<String>,
     pub(in crate::ui::tui) status_counts: BTreeMap<String, usize>,
+    pub(in crate::ui::tui) graph_status: String,
+    pub(in crate::ui::tui) graph_reason: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -41,6 +43,16 @@ struct TestMappingCliPayload {
     skipped_test_files: Vec<String>,
     #[serde(default)]
     status_counts: BTreeMap<String, usize>,
+    #[serde(default)]
+    graph: TestMappingGraphPayload,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TestMappingGraphPayload {
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    reason: Option<String>,
 }
 
 #[cfg(test)]
@@ -62,6 +74,8 @@ pub(super) fn build_test_mapping_snapshot(
             .collect(),
         skipped_test_files: skipped_test_files.into_iter().collect(),
         status_counts,
+        graph_status: String::new(),
+        graph_reason: None,
     }
 }
 
@@ -91,8 +105,7 @@ pub(super) fn load_test_mapping_snapshot(
         .current_dir(repo_root)
         .arg("graph")
         .arg("test-mapping")
-        .arg("--json")
-        .arg("--no-graph");
+        .arg("--json");
     if !files.is_empty() {
         command.args(files);
     }
@@ -122,6 +135,8 @@ pub(super) fn load_test_mapping_snapshot(
             .collect(),
         skipped_test_files: payload.skipped_test_files.into_iter().collect(),
         status_counts: payload.status_counts,
+        graph_status: payload.graph.status,
+        graph_reason: payload.graph.reason,
     })
 }
 
@@ -149,4 +164,28 @@ pub(super) fn is_test_like_path(path: &str) -> bool {
         || lower.ends_with(".snapshot")
         || lower.contains("/__snapshots__/")
         || lower.contains("/snapshots/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_payload_parses_graph_status_and_reason() {
+        let payload = serde_json::from_str::<TestMappingCliPayload>(
+            r#"{
+              "mappings": [],
+              "skipped_test_files": [],
+              "status_counts": {"missing": 1},
+              "graph": {
+                "status": "disabled",
+                "reason": "graph disabled"
+              }
+            }"#,
+        )
+        .expect("payload");
+
+        assert_eq!(payload.graph.status, "disabled");
+        assert_eq!(payload.graph.reason.as_deref(), Some("graph disabled"));
+    }
 }

--- a/crates/harness-monitor/src/ui/cache_test_mapping.rs
+++ b/crates/harness-monitor/src/ui/cache_test_mapping.rs
@@ -1,21 +1,40 @@
 use crate::ui::state::RuntimeState;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Command;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(in crate::ui::tui) enum TestMappingAnalysisMode {
+    #[default]
+    Fast,
+    Full,
+}
+
+impl TestMappingAnalysisMode {
+    pub(in crate::ui::tui) fn uses_graph(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub(in crate::ui::tui) fn label(self) -> &'static str {
+        match self {
+            Self::Fast => "fast heuristic",
+            Self::Full => "graph-aware",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(in crate::ui::tui) struct TestMappingSnapshot {
     pub(in crate::ui::tui) cache_key: String,
+    pub(in crate::ui::tui) analysis_mode: TestMappingAnalysisMode,
     pub(in crate::ui::tui) by_file: BTreeMap<String, TestMappingEntry>,
     pub(in crate::ui::tui) skipped_test_files: BTreeSet<String>,
     pub(in crate::ui::tui) status_counts: BTreeMap<String, usize>,
-    pub(in crate::ui::tui) graph_status: String,
-    pub(in crate::ui::tui) graph_reason: Option<String>,
 }
 
 #[allow(dead_code)]
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(in crate::ui::tui) struct TestMappingEntry {
     #[serde(default)]
     pub(in crate::ui::tui) source_file: String,
@@ -43,21 +62,12 @@ struct TestMappingCliPayload {
     skipped_test_files: Vec<String>,
     #[serde(default)]
     status_counts: BTreeMap<String, usize>,
-    #[serde(default)]
-    graph: TestMappingGraphPayload,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct TestMappingGraphPayload {
-    #[serde(default)]
-    status: String,
-    #[serde(default)]
-    reason: Option<String>,
 }
 
 #[cfg(test)]
 pub(super) fn build_test_mapping_snapshot(
     cache_key: String,
+    analysis_mode: TestMappingAnalysisMode,
     entries: Vec<TestMappingEntry>,
     skipped_test_files: Vec<String>,
 ) -> TestMappingSnapshot {
@@ -68,14 +78,13 @@ pub(super) fn build_test_mapping_snapshot(
 
     TestMappingSnapshot {
         cache_key,
+        analysis_mode,
         by_file: entries
             .into_iter()
             .map(|entry| (entry.source_file.clone(), entry))
             .collect(),
         skipped_test_files: skipped_test_files.into_iter().collect(),
         status_counts,
-        graph_status: String::new(),
-        graph_reason: None,
     }
 }
 
@@ -95,20 +104,26 @@ pub(super) fn test_mapping_cache_key(state: &RuntimeState) -> String {
     markers.join("|")
 }
 
+pub(super) fn test_mapping_full_cache_key(state: &RuntimeState) -> Option<String> {
+    let branch_oid = state.branch_oid.as_deref()?.trim();
+    if branch_oid.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "head={branch_oid};files={}",
+        test_mapping_cache_key(state)
+    ))
+}
+
 pub(super) fn load_test_mapping_snapshot(
     repo_root: &str,
     files: &[String],
     cache_key: String,
+    analysis_mode: TestMappingAnalysisMode,
 ) -> Result<TestMappingSnapshot, String> {
     let mut command = entrix_command(Path::new(repo_root));
-    command
-        .current_dir(repo_root)
-        .arg("graph")
-        .arg("test-mapping")
-        .arg("--json");
-    if !files.is_empty() {
-        command.args(files);
-    }
+    command.current_dir(repo_root);
+    command.args(test_mapping_cli_args(files, analysis_mode));
 
     let output = command.output().map_err(|error| error.to_string())?;
     if !output.status.success() {
@@ -128,6 +143,7 @@ pub(super) fn load_test_mapping_snapshot(
         serde_json::from_slice(&output.stdout).map_err(|error| error.to_string())?;
     Ok(TestMappingSnapshot {
         cache_key,
+        analysis_mode,
         by_file: payload
             .mappings
             .into_iter()
@@ -135,8 +151,6 @@ pub(super) fn load_test_mapping_snapshot(
             .collect(),
         skipped_test_files: payload.skipped_test_files.into_iter().collect(),
         status_counts: payload.status_counts,
-        graph_status: payload.graph.status,
-        graph_reason: payload.graph.reason,
     })
 }
 
@@ -158,6 +172,19 @@ fn entrix_command(repo_root: &Path) -> Command {
     }
 }
 
+fn test_mapping_cli_args(files: &[String], analysis_mode: TestMappingAnalysisMode) -> Vec<String> {
+    let mut args = vec![
+        "graph".to_string(),
+        "test-mapping".to_string(),
+        "--json".to_string(),
+    ];
+    if !analysis_mode.uses_graph() {
+        args.push("--no-graph".to_string());
+    }
+    args.extend(files.iter().cloned());
+    args
+}
+
 pub(super) fn is_test_like_path(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
     lower.ends_with(".snap")
@@ -168,24 +195,32 @@ pub(super) fn is_test_like_path(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{test_mapping_cli_args, TestMappingAnalysisMode};
 
     #[test]
-    fn cli_payload_parses_graph_status_and_reason() {
-        let payload = serde_json::from_str::<TestMappingCliPayload>(
-            r#"{
-              "mappings": [],
-              "skipped_test_files": [],
-              "status_counts": {"missing": 1},
-              "graph": {
-                "status": "disabled",
-                "reason": "graph disabled"
-              }
-            }"#,
-        )
-        .expect("payload");
+    fn fast_mode_uses_no_graph_flag() {
+        let args = test_mapping_cli_args(
+            &["src/lib.rs".to_string(), "tests/lib_test.rs".to_string()],
+            TestMappingAnalysisMode::Fast,
+        );
 
-        assert_eq!(payload.graph.status, "disabled");
-        assert_eq!(payload.graph.reason.as_deref(), Some("graph disabled"));
+        assert_eq!(
+            args,
+            vec![
+                "graph",
+                "test-mapping",
+                "--json",
+                "--no-graph",
+                "src/lib.rs",
+                "tests/lib_test.rs",
+            ]
+        );
+    }
+
+    #[test]
+    fn full_mode_runs_without_no_graph_flag() {
+        let args = test_mapping_cli_args(&[], TestMappingAnalysisMode::Full);
+
+        assert_eq!(args, vec!["graph", "test-mapping", "--json"]);
     }
 }

--- a/crates/harness-monitor/src/ui/cache_tests.rs
+++ b/crates/harness-monitor/src/ui/cache_tests.rs
@@ -1,7 +1,10 @@
 use super::{
-    detail_cache_key, display_status_code, facts_cache_key, fitness, load_diff_text,
-    load_file_preview, AppCache, FileFactsEntry, FilePreviewScope, FitnessHistoryEntry,
-    FitnessHistoryRecord, FITNESS_HISTORY_FILE, FITNESS_HISTORY_SCHEMA_VERSION,
+    build_test_mapping_snapshot, detail_cache_key, display_status_code, facts_cache_key, fitness,
+    load_diff_text, load_file_preview, read_test_mapping_history_record, test_mapping_cache_key,
+    test_mapping_full_cache_key, test_mapping_history_path, AppCache, FileFactsEntry,
+    FilePreviewScope, FitnessHistoryEntry, FitnessHistoryRecord, TestMappingAnalysisMode,
+    TestMappingEntry, TestMappingHistoryRecord, FITNESS_HISTORY_FILE,
+    FITNESS_HISTORY_SCHEMA_VERSION,
 };
 use crate::observe as repo;
 use crate::shared::models::{
@@ -13,6 +16,7 @@ use tempfile::tempdir;
 
 fn sample_runtime_state_with_dirty_file() -> RuntimeState {
     let mut state = RuntimeState::new("/tmp/project".to_string(), "main".to_string());
+    state.set_branch_oid(Some("abc123".to_string()));
     state.files.insert(
         "src/lib.rs".to_string(),
         FileView {
@@ -559,7 +563,123 @@ fn warm_test_mappings_waits_for_startup_delay() {
 
     cache.warm_test_mappings(&state);
 
-    assert!(cache.pending_test_mapping_key.is_none());
+    assert!(cache.pending_test_mapping_fast_key.is_none());
+    assert!(cache.pending_test_mapping_full_key.is_none());
+}
+
+#[test]
+fn store_test_mapping_full_snapshot_persists_history_record() {
+    let dir = tempdir().expect("tempdir");
+    let repo_root = dir.path().to_string_lossy().to_string();
+    let mut cache = AppCache::new(&repo_root);
+    let cache_key = "src/lib.rs:modify:1".to_string();
+    let full_cache_key = "head=abc123;files=src/lib.rs:modify:1".to_string();
+    let snapshot = build_test_mapping_snapshot(
+        cache_key,
+        TestMappingAnalysisMode::Full,
+        vec![TestMappingEntry {
+            source_file: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            status: "changed".to_string(),
+            related_test_files: vec!["tests/lib_test.rs".to_string()],
+            graph_test_files: Vec::new(),
+            resolver_kind: "hybrid_heuristic".to_string(),
+            confidence: "high".to_string(),
+            has_inline_tests: false,
+        }],
+        Vec::new(),
+    );
+
+    cache.store_test_mapping_full_snapshot(Some(full_cache_key.clone()), 123, snapshot);
+
+    let record = read_test_mapping_history_record(&repo_root).expect("history record");
+    assert_eq!(record.schema_version, 1);
+    assert_eq!(
+        record
+            .histories
+            .get(&full_cache_key)
+            .and_then(|entry| entry.observed_at_ms),
+        Some(123)
+    );
+    assert_eq!(
+        record
+            .histories
+            .get(&full_cache_key)
+            .and_then(|entry| entry.snapshot.as_ref())
+            .map(|snapshot| snapshot.analysis_mode),
+        Some(TestMappingAnalysisMode::Full)
+    );
+}
+
+#[test]
+fn warm_test_mappings_prefers_persisted_full_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let repo_root = dir.path().to_string_lossy().to_string();
+    let mut state = RuntimeState::new(repo_root.clone(), "main".to_string());
+    state.set_branch_oid(Some("persisted-head".to_string()));
+    state.files.insert(
+        "src/lib.rs".to_string(),
+        FileView {
+            rel_path: "src/lib.rs".to_string(),
+            dirty: true,
+            state_code: "modify".to_string(),
+            entry_kind: EntryKind::File,
+            last_modified_at_ms: 1,
+            last_session_id: None,
+            last_task_id: None,
+            confidence: AttributionConfidence::Unknown,
+            conflicted: false,
+            touched_by: BTreeSet::new(),
+            recent_events: Vec::new(),
+        },
+    );
+    state.refresh_views();
+    let cache_key = test_mapping_cache_key(&state);
+    let full_cache_key = test_mapping_full_cache_key(&state).expect("full cache key");
+    let history_path = test_mapping_history_path(&repo_root).expect("history path");
+    std::fs::create_dir_all(history_path.parent().expect("history parent")).expect("create dir");
+    std::fs::write(
+        &history_path,
+        serde_json::to_vec_pretty(&TestMappingHistoryRecord {
+            schema_version: 1,
+            histories: [(
+                full_cache_key,
+                super::TestMappingHistoryEntry {
+                    snapshot: Some(build_test_mapping_snapshot(
+                        cache_key.clone(),
+                        TestMappingAnalysisMode::Full,
+                        vec![TestMappingEntry {
+                            source_file: "src/lib.rs".to_string(),
+                            language: "rust".to_string(),
+                            status: "changed".to_string(),
+                            related_test_files: vec!["tests/lib_test.rs".to_string()],
+                            graph_test_files: Vec::new(),
+                            resolver_kind: "hybrid_heuristic".to_string(),
+                            confidence: "high".to_string(),
+                            has_inline_tests: false,
+                        }],
+                        Vec::new(),
+                    )),
+                    observed_at_ms: Some(456),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        })
+        .expect("serialize history"),
+    )
+    .expect("write history");
+
+    let mut cache = AppCache::new(&repo_root);
+    cache.test_mapping_not_before_ms = None;
+    cache.warm_test_mappings(&state);
+
+    assert_eq!(
+        cache.test_mapping_analysis_mode(),
+        Some(TestMappingAnalysisMode::Full)
+    );
+    assert!(cache.pending_test_mapping_fast_key.is_none());
+    assert!(cache.pending_test_mapping_full_key.is_none());
 }
 
 #[test]
@@ -570,5 +690,52 @@ fn warm_test_mappings_respects_retry_backoff() {
 
     cache.warm_test_mappings(&state);
 
-    assert!(cache.pending_test_mapping_key.is_none());
+    assert!(cache.pending_test_mapping_fast_key.is_none());
+    assert!(cache.pending_test_mapping_full_key.is_none());
+}
+
+#[test]
+fn warm_test_mappings_requests_fast_snapshot_first() {
+    let state = sample_runtime_state_with_dirty_file();
+    let mut cache = AppCache::new(&state.repo_root);
+    cache.test_mapping_not_before_ms = None;
+
+    cache.warm_test_mappings(&state);
+
+    assert_eq!(
+        cache.pending_test_mapping_fast_key.as_deref(),
+        Some(test_mapping_cache_key(&state).as_str())
+    );
+    assert!(cache.pending_test_mapping_full_key.is_none());
+}
+
+#[test]
+fn warm_test_mappings_enqueues_full_refresh_after_fast_snapshot() {
+    let state = sample_runtime_state_with_dirty_file();
+    let mut cache = AppCache::new(&state.repo_root);
+    let cache_key = test_mapping_cache_key(&state);
+    cache.test_mapping_not_before_ms = None;
+    cache.set_test_mapping_snapshot_for_tests(
+        cache_key.clone(),
+        TestMappingAnalysisMode::Fast,
+        vec![TestMappingEntry {
+            source_file: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            status: "changed".to_string(),
+            related_test_files: vec!["tests/lib_test.rs".to_string()],
+            graph_test_files: Vec::new(),
+            resolver_kind: "path_heuristic".to_string(),
+            confidence: "medium".to_string(),
+            has_inline_tests: false,
+        }],
+        Vec::new(),
+    );
+
+    cache.warm_test_mappings(&state);
+
+    assert_eq!(
+        cache.pending_test_mapping_full_key.as_deref(),
+        Some(cache_key.as_str())
+    );
+    assert!(cache.pending_test_mapping_fast_key.is_none());
 }

--- a/crates/harness-monitor/src/ui/cache_tests.rs
+++ b/crates/harness-monitor/src/ui/cache_tests.rs
@@ -739,3 +739,55 @@ fn warm_test_mappings_enqueues_full_refresh_after_fast_snapshot() {
     );
     assert!(cache.pending_test_mapping_fast_key.is_none());
 }
+
+#[test]
+fn warm_test_mappings_skips_full_refresh_when_dirty_set_exceeds_budget() {
+    let mut state = RuntimeState::new("/tmp/project".to_string(), "main".to_string());
+    state.set_branch_oid(Some("budget-head".to_string()));
+    for idx in 0..13 {
+        let rel_path = format!("src/file_{idx}.rs");
+        state.files.insert(
+            rel_path.clone(),
+            FileView {
+                rel_path,
+                dirty: true,
+                state_code: "modify".to_string(),
+                entry_kind: EntryKind::File,
+                last_modified_at_ms: idx,
+                last_session_id: None,
+                last_task_id: None,
+                confidence: AttributionConfidence::Unknown,
+                conflicted: false,
+                touched_by: BTreeSet::new(),
+                recent_events: Vec::new(),
+            },
+        );
+    }
+    state.refresh_views();
+
+    let mut cache = AppCache::new(&state.repo_root);
+    cache.test_mapping_not_before_ms = None;
+    cache.set_test_mapping_snapshot_for_tests(
+        test_mapping_cache_key(&state),
+        TestMappingAnalysisMode::Fast,
+        vec![TestMappingEntry {
+            source_file: "src/file_0.rs".to_string(),
+            language: "rust".to_string(),
+            status: "changed".to_string(),
+            related_test_files: vec!["tests/file_0_test.rs".to_string()],
+            graph_test_files: Vec::new(),
+            resolver_kind: "path_heuristic".to_string(),
+            confidence: "medium".to_string(),
+            has_inline_tests: false,
+        }],
+        Vec::new(),
+    );
+
+    cache.warm_test_mappings(&state);
+
+    assert!(cache.pending_test_mapping_full_key.is_none());
+    assert_eq!(
+        cache.test_mapping_graph_enrichment_note(),
+        Some("graph refresh skipped: 13 dirty files exceeds budget 12")
+    );
+}

--- a/crates/harness-monitor/src/ui/panels.rs
+++ b/crates/harness-monitor/src/ui/panels.rs
@@ -182,16 +182,19 @@ pub(super) fn render_details_panel(
                 Span::styled("Confidence: ", Style::default().fg(colors.muted)),
                 Span::styled(mapping.confidence.clone(), Style::default().fg(colors.text)),
             ]));
-            if let Some((graph_status, graph_reason)) = cache.test_mapping_graph_status() {
-                lines.push(Line::from(vec![
-                    Span::styled("Graph: ", Style::default().fg(colors.muted)),
-                    Span::styled(graph_status.to_string(), Style::default().fg(colors.text)),
-                    Span::raw("  "),
-                    Span::styled(
-                        graph_reason.unwrap_or("semantic enrichment active").to_string(),
+            if let Some(analysis_mode) = cache.test_mapping_analysis_mode() {
+                let mut row = vec![
+                    Span::styled("Analysis: ", Style::default().fg(colors.muted)),
+                    Span::styled(analysis_mode.label(), Style::default().fg(colors.text)),
+                ];
+                if cache.test_mapping_graph_enrichment_pending() {
+                    row.push(Span::raw("  "));
+                    row.push(Span::styled(
+                        "graph refresh pending",
                         Style::default().fg(colors.muted),
-                    ),
-                ]));
+                    ));
+                }
+                lines.push(Line::from(row));
             }
             if !mapping.related_test_files.is_empty() {
                 let preview = summarize_test_paths(&mapping.related_test_files, 2);

--- a/crates/harness-monitor/src/ui/panels.rs
+++ b/crates/harness-monitor/src/ui/panels.rs
@@ -182,6 +182,17 @@ pub(super) fn render_details_panel(
                 Span::styled("Confidence: ", Style::default().fg(colors.muted)),
                 Span::styled(mapping.confidence.clone(), Style::default().fg(colors.text)),
             ]));
+            if let Some((graph_status, graph_reason)) = cache.test_mapping_graph_status() {
+                lines.push(Line::from(vec![
+                    Span::styled("Graph: ", Style::default().fg(colors.muted)),
+                    Span::styled(graph_status.to_string(), Style::default().fg(colors.text)),
+                    Span::raw("  "),
+                    Span::styled(
+                        graph_reason.unwrap_or("semantic enrichment active").to_string(),
+                        Style::default().fg(colors.muted),
+                    ),
+                ]));
+            }
             if !mapping.related_test_files.is_empty() {
                 let preview = summarize_test_paths(&mapping.related_test_files, 2);
                 lines.push(Line::from(vec![

--- a/crates/harness-monitor/src/ui/panels.rs
+++ b/crates/harness-monitor/src/ui/panels.rs
@@ -193,6 +193,12 @@ pub(super) fn render_details_panel(
                         "graph refresh pending",
                         Style::default().fg(colors.muted),
                     ));
+                } else if let Some(note) = cache.test_mapping_graph_enrichment_note() {
+                    row.push(Span::raw("  "));
+                    row.push(Span::styled(
+                        note.to_string(),
+                        Style::default().fg(colors.muted),
+                    ));
                 }
                 lines.push(Line::from(row));
             }

--- a/crates/harness-monitor/src/ui/state.rs
+++ b/crates/harness-monitor/src/ui/state.rs
@@ -177,6 +177,7 @@ impl PromptSessionListItem {
 pub struct RuntimeState {
     pub repo_root: String,
     pub branch: String,
+    pub branch_oid: Option<String>,
     pub ahead_count: Option<usize>,
     pub committed_change_summary: Option<(usize, usize)>,
     pub worktree_count: Option<usize>,
@@ -217,6 +218,7 @@ impl RuntimeState {
         let mut state = Self {
             repo_root,
             branch,
+            branch_oid: None,
             ahead_count: None,
             committed_change_summary: None,
             worktree_count: None,
@@ -442,6 +444,10 @@ impl RuntimeState {
 
     pub fn set_ahead_count(&mut self, count: Option<usize>) {
         self.ahead_count = count;
+    }
+
+    pub fn set_branch_oid(&mut self, branch_oid: Option<String>) {
+        self.branch_oid = branch_oid;
     }
 
     pub fn set_committed_change_summary(&mut self, summary: Option<(usize, usize)>) {

--- a/crates/harness-monitor/src/ui/tests.rs
+++ b/crates/harness-monitor/src/ui/tests.rs
@@ -177,6 +177,7 @@ fn sample_state() -> RuntimeState {
     ]);
 
     let mut state = RuntimeState::new("/tmp/project".to_string(), "main".to_string());
+    state.set_branch_oid(Some("abcdef".to_string()));
     state.tasks = tasks;
     state.task_change_paths.insert(
         live_task_id,
@@ -355,6 +356,8 @@ fn sample_cache(state: &RuntimeState) -> AppCache {
         },
     );
     cache.set_test_mapping_snapshot_for_tests(
+        "test".to_string(),
+        TestMappingAnalysisMode::Full,
         vec![
             TestMappingEntry {
                 source_file: "crates/harness-monitor/src/tui.rs".to_string(),
@@ -378,8 +381,6 @@ fn sample_cache(state: &RuntimeState) -> AppCache {
             },
         ],
         Vec::new(),
-        Some("ok".to_string()),
-        None,
     );
     cache
 }
@@ -755,13 +756,42 @@ fn tui_snapshot_run_details_decision_first() {
 fn file_detail_surfaces_test_mapping_context() {
     let state = sample_state();
     let mut cache = sample_cache(&state);
-    assert_eq!(cache.test_mapping_graph_status(), Some(("ok", None)));
 
-    let snapshot = render_snapshot(&state, &mut cache, 180, 32);
+    let snapshot = render_snapshot(&state, &mut cache, 180, 40);
 
     assert!(snapshot.contains("Test mapping:"));
     assert!(snapshot.contains("changed") || snapshot.contains("missing"));
+    assert!(snapshot.contains("Analysis:"));
+    assert!(snapshot.contains("graph-aware"));
     assert!(snapshot.contains("TM "));
+}
+
+#[test]
+fn file_detail_shows_fast_test_mapping_pending_graph_refresh() {
+    let state = sample_state();
+    let mut cache = sample_cache(&state);
+    let cache_key = "test".to_string();
+    cache.set_test_mapping_snapshot_for_tests(
+        cache_key.clone(),
+        TestMappingAnalysisMode::Fast,
+        vec![TestMappingEntry {
+            source_file: "crates/harness-monitor/src/tui.rs".to_string(),
+            language: "rust".to_string(),
+            status: "changed".to_string(),
+            related_test_files: vec!["crates/harness-monitor/src/tui_tests.rs".to_string()],
+            graph_test_files: Vec::new(),
+            resolver_kind: "hybrid_heuristic".to_string(),
+            confidence: "medium".to_string(),
+            has_inline_tests: false,
+        }],
+        Vec::new(),
+    );
+    cache.set_test_mapping_graph_pending_for_tests(cache_key);
+
+    let snapshot = render_snapshot(&state, &mut cache, 180, 40);
+
+    assert!(snapshot.contains("fast heuristic"));
+    assert!(snapshot.contains("graph refresh pending"));
 }
 
 #[test]
@@ -1250,6 +1280,7 @@ fn parse_repo_status_reads_branch_and_ahead_count() {
     );
 
     assert_eq!(status.branch.as_deref(), Some("main"));
+    assert_eq!(status.branch_oid.as_deref(), Some("abcdef"));
     assert_eq!(status.upstream.as_deref(), Some("origin/main"));
     assert_eq!(status.ahead_count, Some(7));
     assert_eq!(status.committed_change_summary, None);

--- a/crates/harness-monitor/src/ui/tests.rs
+++ b/crates/harness-monitor/src/ui/tests.rs
@@ -795,6 +795,36 @@ fn file_detail_shows_fast_test_mapping_pending_graph_refresh() {
 }
 
 #[test]
+fn file_detail_shows_graph_refresh_budget_note() {
+    let state = sample_state();
+    let mut cache = sample_cache(&state);
+    cache.set_test_mapping_snapshot_for_tests(
+        "test".to_string(),
+        TestMappingAnalysisMode::Fast,
+        vec![TestMappingEntry {
+            source_file: "crates/harness-monitor/src/tui.rs".to_string(),
+            language: "rust".to_string(),
+            status: "changed".to_string(),
+            related_test_files: vec!["crates/harness-monitor/src/tui_tests.rs".to_string()],
+            graph_test_files: Vec::new(),
+            resolver_kind: "hybrid_heuristic".to_string(),
+            confidence: "medium".to_string(),
+            has_inline_tests: false,
+        }],
+        Vec::new(),
+    );
+    cache.set_test_mapping_graph_note_for_tests(
+        "graph refresh skipped: 17 dirty files exceeds budget 12".to_string(),
+    );
+
+    let snapshot = render_snapshot(&state, &mut cache, 180, 40);
+
+    assert!(snapshot.contains("fast heuristic"));
+    assert!(snapshot.contains("graph refresh skipped"));
+    assert!(snapshot.contains("budget 12"));
+}
+
+#[test]
 fn selecting_prompt_session_scopes_files_to_prompt_changes() {
     let mut state = sample_state();
     state.selected_run = state

--- a/crates/harness-monitor/src/ui/tests.rs
+++ b/crates/harness-monitor/src/ui/tests.rs
@@ -378,6 +378,8 @@ fn sample_cache(state: &RuntimeState) -> AppCache {
             },
         ],
         Vec::new(),
+        Some("ok".to_string()),
+        None,
     );
     cache
 }
@@ -753,6 +755,7 @@ fn tui_snapshot_run_details_decision_first() {
 fn file_detail_surfaces_test_mapping_context() {
     let state = sample_state();
     let mut cache = sample_cache(&state);
+    assert_eq!(cache.test_mapping_graph_status(), Some(("ok", None)));
 
     let snapshot = render_snapshot(&state, &mut cache, 180, 32);
 

--- a/crates/harness-monitor/src/ui/tui.rs
+++ b/crates/harness-monitor/src/ui/tui.rs
@@ -61,6 +61,7 @@ const RUNTIME_FEED_SIGNAL_MS: u64 = 120;
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct RepoStatusSummary {
     branch: Option<String>,
+    branch_oid: Option<String>,
     upstream: Option<String>,
     ahead_count: Option<usize>,
     committed_change_summary: Option<(usize, usize)>,
@@ -581,6 +582,7 @@ fn refresh_fitness_from_event(
 fn apply_repo_status(state: &mut RuntimeState, repo_status: Option<RepoStatusSummary>) {
     let repo_status = repo_status.unwrap_or_default();
     state.branch = repo_status.branch.unwrap_or_else(|| "-".to_string());
+    state.set_branch_oid(repo_status.branch_oid);
     state.set_ahead_count(repo_status.ahead_count);
     state.set_committed_change_summary(repo_status.committed_change_summary);
 }
@@ -610,11 +612,17 @@ fn read_repo_status(ctx: &RepoContext) -> Result<RepoStatusSummary> {
 
 fn parse_repo_status(output: &str) -> RepoStatusSummary {
     let mut branch = None;
+    let mut branch_oid = None;
     let mut upstream = None;
     let mut ahead_count = None;
 
     for line in output.lines().map(str::trim) {
-        if let Some(value) = line.strip_prefix("# branch.head ") {
+        if let Some(value) = line.strip_prefix("# branch.oid ") {
+            let value = value.trim();
+            if !value.is_empty() && value != "(initial)" {
+                branch_oid = Some(value.to_string());
+            }
+        } else if let Some(value) = line.strip_prefix("# branch.head ") {
             branch = normalize_branch_name(value.trim());
         } else if let Some(value) = line.strip_prefix("# branch.upstream ") {
             upstream = Some(value.trim().to_string());
@@ -625,6 +633,7 @@ fn parse_repo_status(output: &str) -> RepoStatusSummary {
 
     RepoStatusSummary {
         branch,
+        branch_oid,
         upstream,
         ahead_count,
         committed_change_summary: None,

--- a/docs/fitness/unit-test.md
+++ b/docs/fitness/unit-test.md
@@ -47,7 +47,7 @@ metrics:
     description: "通过代码图估算 changed targets 的测试半径；图后端缺失时跳过不计分"
 
   - name: graph_test_mapping_probe
-    command: node --import tsx tools/hook-runtime/src/test-mapping-smart.ts 2>&1
+    command: graph:test-mapping
     tier: normal
     execution_scope: local
     gate: advisory


### PR DESCRIPTION
## Summary

Closes #476.

This unifies Rust `entrix` as the shared authority for graph-aware test mapping, then updates `harness-monitor` to consume that output with a fast-first, cached full-refresh flow.

## What Changed

- moved graph-aware test-mapping orchestration into the shared `test_mapping` module
- updated `entrix graph test-mapping` to use the shared analysis report directly
- updated the `graph_test_mapping_probe` fitness path to reuse the same shared analysis implementation
- switched `docs/fitness/unit-test.md` from the legacy Node entry to the Rust-native `graph:test-mapping` probe
- updated `harness-monitor` to consume the shared graph-aware JSON payload
- changed `harness-monitor` test mapping loading to two stages: fast heuristic first, graph-aware refresh second
- added local persistence for full graph-aware test-mapping snapshots so repeated monitor sessions can reuse the last matching `HEAD + changed-files` result
- surfaced analysis mode and pending graph-refresh state in the file detail panel
- added coverage for shared analysis, probe behavior, two-stage loading, persisted full-cache reuse, and UI context

## Verification

- `cargo test -p entrix`
- `cargo test -p entrix cli_parity_tests -- --nocapture`
- `cargo test -p entrix run_support::tests -- --nocapture`
- `cargo run -q -p entrix -- run --tier normal --dimension testability --dry-run`
- `cargo test -p harness-monitor test_mapping -- --nocapture`
- `cargo test -p harness-monitor parse_repo_status_reads_branch_and_ahead_count -- --nocapture`

## Notes

The remaining performance bottleneck is still the cold graph-aware `entrix graph test-mapping` command on large dirty sets. This PR makes monitor UX responsive by avoiding that cost on first paint and by reusing persisted full snapshots when the repo `HEAD` and dirty-file set match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated graph-aware test-mapping with richer analysis reports and Fast/Full analysis modes; UI shows an “Analysis” line with mode and graph refresh status; branch OID tracking added.

* **Tests**
  * Added unit and UI tests covering probe behavior, graph-enabled analysis, snapshot persistence, warm-up logic, and pending/notification flows.

* **Documentation**
  * Updated fitness metric to invoke the new test-mapping command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->