### PR TITLE
Stop Routa from overwriting shared Codex MCP settings

### DIFF
--- a/src/core/acp/__tests__/acp-process-manager.test.ts
+++ b/src/core/acp/__tests__/acp-process-manager.test.ts
@@ -273,7 +273,7 @@ describe("AcpProcessManager", () => {
 
     expect(acpSessionId).toBe("acp-session-1");
     expect(getDefaultRoutaMcpConfigMock).toHaveBeenCalledWith("ws-1", "session-1", "full", undefined);
-    expect(ensureMcpForProviderMock).toHaveBeenCalledWith("codex", { type: "http" });
+    expect(ensureMcpForProviderMock).toHaveBeenCalledWith("codex", { type: "http", cwd: "/repo" });
     expect(buildConfigFromPresetMock).toHaveBeenCalledWith(
       "codex",
       "/repo",
@@ -404,6 +404,34 @@ describe("AcpProcessManager", () => {
 
     await manager.killSession("session-qoder");
     expect(cleanupMcpForProviderMock).toHaveBeenCalledWith(cleanup);
+  });
+
+  it("prepends MCP provider args before caller extra args", async () => {
+    const manager = new AcpProcessManager();
+    ensureMcpForProviderMock.mockResolvedValueOnce({
+      mcpConfigs: ["mcp-config"],
+      providerArgs: ["-c", 'mcp_servers.routa-coordination.url="http://localhost:3210/api/mcp"'],
+      summary: "codex: wrote private overlay",
+    });
+
+    await manager.createSession(
+      "session-args",
+      "/repo",
+      vi.fn(),
+      "codex",
+      undefined,
+      ["--verbose"],
+      undefined,
+      "ws-1",
+    );
+
+    expect(buildConfigFromPresetMock).toHaveBeenCalledWith(
+      "codex",
+      "/repo",
+      ["-c", 'mcp_servers.routa-coordination.url="http://localhost:3210/api/mcp"', "--verbose"],
+      undefined,
+      ["mcp-config"],
+    );
   });
 
   it("routes explicit opencode-sdk sessions to the direct api adapter when no server url is set", async () => {

--- a/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
+++ b/src/core/acp/__tests__/mcp-setup-file-writes.test.ts
@@ -83,22 +83,32 @@ describe("mcp-setup file-based providers", () => {
     expect(result.summary).toContain("--mcp-config");
   });
 
-  it("writes Codex MCP config in TOML format", async () => {
+  it("writes Codex MCP config to a private overlay and returns CLI overrides", async () => {
     const { ensureMcpForProvider } = await import("../mcp-setup");
 
     const result = await ensureMcpForProvider("codex", {
       routaServerUrl: "http://127.0.0.1:3210",
       includeCustomServers: false,
+      cwd: "/workspace/routa-overlay",
     });
 
     expect(result.mcpConfigs).toEqual([]);
-    const configPath = path.join(tmpHome, ".codex", "config.toml");
+    expect(result.providerArgs).toEqual([
+      "-c",
+      'projects."/workspace/routa-overlay".trust_level="trusted"',
+      "-c",
+      'mcp_servers.routa-coordination.url="http://127.0.0.1:3210/api/mcp"',
+      "-c",
+      "mcp_servers.routa-coordination.enabled=true",
+    ]);
+
+    const configPath = path.join(tmpHome, ".routa", "codex", "config.toml");
     const raw = await fs.readFile(configPath, "utf-8");
 
-    expect(raw).toContain("[mcp_servers.routa-coordination]");
+    expect(raw).toContain("routa-coordination");
     expect(raw).toContain('url = "http://127.0.0.1:3210/api/mcp"');
     expect(raw).toContain("enabled = true");
-    expect(result.summary).toContain("codex: wrote");
+    expect(result.summary).toContain("codex: wrote private overlay");
   });
 
   it("adds and removes qoder MCP servers through the qodercli lifecycle", async () => {

--- a/src/core/acp/acp-process-manager.ts
+++ b/src/core/acp/acp-process-manager.ts
@@ -101,6 +101,14 @@ export class AcpProcessManager {
     private workspaceAgents = new Map<string, ManagedWorkspaceAgent>();
     private mcpSessionCleanups = new Map<string, McpSetupCleanup>();
 
+    private combineProviderArgs(
+        providerArgs?: string[],
+        extraArgs?: string[],
+    ): string[] | undefined {
+        const combined = [...(providerArgs ?? []), ...(extraArgs ?? [])];
+        return combined.length > 0 ? combined : undefined;
+    }
+
     private async prepareMcpForSession(
         sessionId: string,
         presetId: string,
@@ -108,16 +116,13 @@ export class AcpProcessManager {
         workspaceId?: string,
         toolMode?: "essential" | "full",
         mcpProfile?: McpServerProfile,
-    ): Promise<string[] | undefined> {
+    ): Promise<{ mcpConfigs?: string[]; providerArgs?: string[] } | undefined> {
         if (!providerSupportsMcp(presetId)) {
             return undefined;
         }
 
         const baseConfig = getDefaultRoutaMcpConfig(workspaceId, sessionId, toolMode, mcpProfile);
-        const baseProviderId = presetId.endsWith("-registry")
-            ? presetId.slice(0, -"-registry".length)
-            : presetId;
-        const mcpConfig = baseProviderId === "qoder" ? { ...baseConfig, cwd } : baseConfig;
+        const mcpConfig = cwd ? { ...baseConfig, cwd } : baseConfig;
         const mcpResult = await ensureMcpForProvider(presetId, mcpConfig);
         if (mcpResult.cleanup) {
             this.mcpSessionCleanups.set(sessionId, mcpResult.cleanup);
@@ -125,7 +130,12 @@ export class AcpProcessManager {
             this.mcpSessionCleanups.delete(sessionId);
         }
         logAcpDebug(`[AcpProcessManager] MCP setup for ${presetId}: ${mcpResult.summary}`);
-        return mcpResult.mcpConfigs.length > 0 ? mcpResult.mcpConfigs : undefined;
+        return {
+            mcpConfigs: mcpResult.mcpConfigs.length > 0 ? mcpResult.mcpConfigs : undefined,
+            providerArgs: mcpResult.providerArgs && mcpResult.providerArgs.length > 0
+                ? mcpResult.providerArgs
+                : undefined,
+        };
     }
 
     private async cleanupSessionMcp(sessionId: string): Promise<void> {
@@ -181,7 +191,7 @@ export class AcpProcessManager {
         }
 
         try {
-            const mcpConfigs = await this.prepareMcpForSession(
+            const mcpSetup = await this.prepareMcpForSession(
                 sessionId,
                 presetId,
                 cwd,
@@ -189,7 +199,13 @@ export class AcpProcessManager {
                 toolMode,
                 mcpProfile,
             );
-            const config = await buildConfigFromPreset(presetId, cwd, extraArgs, extraEnv, mcpConfigs);
+            const config = await buildConfigFromPreset(
+                presetId,
+                cwd,
+                this.combineProviderArgs(mcpSetup?.providerArgs, extraArgs),
+                extraEnv,
+                mcpSetup?.mcpConfigs,
+            );
             const proc = new AcpProcess(config, onNotification);
 
             await proc.start();
@@ -242,7 +258,7 @@ export class AcpProcessManager {
         providerSessionId?: string,
     ): Promise<string> {
         try {
-            const mcpConfigs = await this.prepareMcpForSession(
+            const mcpSetup = await this.prepareMcpForSession(
                 sessionId,
                 presetId,
                 cwd,
@@ -250,7 +266,13 @@ export class AcpProcessManager {
                 toolMode,
                 mcpProfile,
             );
-            const config = await buildConfigFromPreset(presetId, cwd, undefined, undefined, mcpConfigs);
+            const config = await buildConfigFromPreset(
+                presetId,
+                cwd,
+                this.combineProviderArgs(mcpSetup?.providerArgs),
+                undefined,
+                mcpSetup?.mcpConfigs,
+            );
             const proc = new AcpProcess(config, onNotification);
 
             await proc.start();

--- a/src/core/acp/mcp-setup.ts
+++ b/src/core/acp/mcp-setup.ts
@@ -76,6 +76,8 @@ export interface McpSetupCleanup {
 export interface McpSetupResult {
   /** Strings to pass as --mcp-config <value> */
   mcpConfigs: string[];
+  /** Additional provider-specific CLI arguments (for example Codex -c overrides) */
+  providerArgs?: string[];
   /** Human-readable summary for logs */
   summary: string;
   /** Provider-specific teardown instructions for session-end cleanup */
@@ -238,7 +240,7 @@ export async function ensureMcpForProvider(
     case "claude":
       return await ensureMcpForClaude(mcpEndpoint, cfg.workspaceId, customServers);
     case "codex":
-      return await ensureMcpForCodex(mcpEndpoint, customServers);
+      return await ensureMcpForCodex(mcpEndpoint, customServers, cfg.cwd);
     case "gemini":
       return await ensureMcpForGemini(mcpEndpoint, customServers);
     case "kimi":
@@ -593,73 +595,125 @@ function ensureMcpForClaude(
 
 // ─── Codex (OpenAI) ─────────────────────────────────────────────────────
 //
-// Codex stores MCP config in TOML format at ~/.codex/config.toml
-// https://developers.openai.com/codex/mcp/
-//
-// Streamable HTTP servers use:
-//   [mcp_servers.<server-name>]
-//   url = "http://..."
-//   enabled = true
-//
-// We merge a "routa-coordination" entry preserving all existing settings.
+// Routa keeps Codex MCP state in a private overlay and passes the effective
+// values via `codex-acp -c key=value` overrides. This avoids mutating the
+// user's shared ~/.codex/config.toml while still using Codex's highest-
+// precedence config surface.
 
-const CODEX_CONFIG_DIR = path.join(os.homedir(), ".codex");
-const CODEX_CONFIG_FILE = path.join(CODEX_CONFIG_DIR, "config.toml");
+const ROUTA_CODEX_CONFIG_DIR = path.join(os.homedir(), ".routa", "codex");
+const ROUTA_CODEX_CONFIG_FILE = path.join(ROUTA_CODEX_CONFIG_DIR, "config.toml");
 
-async function ensureMcpForCodex(mcpEndpoint: string, customServers: CustomMcpServerConfig[] = []): Promise<McpSetupResult> {
-  try {
-    // Read existing config (or start fresh)
-    let existing: Record<string, unknown> = {};
-    try {
-      const raw = await fs.promises.readFile(CODEX_CONFIG_FILE, "utf-8");
-      existing = TOML.parse(raw) as Record<string, unknown>;
-    } catch {
-      // file doesn't exist yet
+type CodexServerConfig = {
+  enabled: boolean;
+  url?: string;
+  type?: "stdio";
+  command?: string;
+  args?: string[];
+};
+
+function normalizeCodexServerConfigs(
+  mcpEndpoint: string,
+  customServers: CustomMcpServerConfig[] = [],
+): Record<string, CodexServerConfig> {
+  const builtIn: Record<string, unknown> = {
+    "routa-coordination": { url: mcpEndpoint, enabled: true },
+  };
+  const merged = mergeCustomMcpServers(builtIn, customServers);
+  const normalized: Record<string, CodexServerConfig> = {};
+
+  for (const [name, cfg] of Object.entries(merged)) {
+    const serverCfg = cfg as Record<string, unknown>;
+    if (serverCfg.type === "stdio") {
+      const args = Array.isArray(serverCfg.args)
+        ? serverCfg.args.filter((arg): arg is string => typeof arg === "string")
+        : undefined;
+      normalized[name] = {
+        type: "stdio",
+        enabled: true,
+        ...(typeof serverCfg.command === "string" ? { command: serverCfg.command } : {}),
+        ...(args ? { args } : {}),
+      };
+      continue;
     }
 
-    // Ensure "mcp_servers" key exists as an object
-    const mcpServers = (existing.mcp_servers ?? {}) as Record<string, unknown>;
-
-    // Built-in server
-    const builtIn: Record<string, unknown> = {
-      "routa-coordination": { url: mcpEndpoint, enabled: true },
+    normalized[name] = {
+      enabled: true,
+      ...(typeof serverCfg.url === "string" ? { url: serverCfg.url } : {}),
     };
-    // Merge custom servers — Codex uses url-based entries with enabled flag
-    const merged = mergeCustomMcpServers(builtIn, customServers);
-    for (const [name, cfg] of Object.entries(merged)) {
-      const serverCfg = cfg as Record<string, unknown>;
-      if (serverCfg.type === "stdio") {
-        mcpServers[name] = { command: serverCfg.command, args: serverCfg.args ?? [], enabled: true };
-      } else {
-        mcpServers[name] = { url: serverCfg.url, enabled: true };
-      }
+  }
+
+  return normalized;
+}
+
+function quoteCodexConfigSegment(segment: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(segment) ? segment : JSON.stringify(segment);
+}
+
+function buildCodexProjectTrustOverride(cwd: string): string {
+  return `projects.${JSON.stringify(cwd)}.trust_level="trusted"`;
+}
+
+function buildCodexProviderArgs(
+  cwd: string | undefined,
+  mcpServers: Record<string, CodexServerConfig>,
+): string[] {
+  const overrides: string[] = [];
+
+  if (cwd) {
+    overrides.push(buildCodexProjectTrustOverride(cwd));
+  }
+
+  for (const [name, serverCfg] of Object.entries(mcpServers)) {
+    const serverPath = `mcp_servers.${quoteCodexConfigSegment(name)}`;
+    if (serverCfg.url) {
+      overrides.push(`${serverPath}.url=${JSON.stringify(serverCfg.url)}`);
     }
+    if (serverCfg.type) {
+      overrides.push(`${serverPath}.type=${JSON.stringify(serverCfg.type)}`);
+    }
+    if (serverCfg.command) {
+      overrides.push(`${serverPath}.command=${JSON.stringify(serverCfg.command)}`);
+    }
+    if (serverCfg.args) {
+      overrides.push(`${serverPath}.args=${JSON.stringify(serverCfg.args)}`);
+    }
+    overrides.push(`${serverPath}.enabled=${serverCfg.enabled ? "true" : "false"}`);
+  }
 
-    existing.mcp_servers = mcpServers;
+  return overrides.flatMap((override) => ["-c", override]);
+}
 
-    // Write back
-    await fs.promises.mkdir(CODEX_CONFIG_DIR, { recursive: true });
+async function ensureMcpForCodex(
+  mcpEndpoint: string,
+  customServers: CustomMcpServerConfig[] = [],
+  cwd?: string,
+): Promise<McpSetupResult> {
+  try {
+    const mcpServers = normalizeCodexServerConfigs(mcpEndpoint, customServers);
+
+    await fs.promises.mkdir(ROUTA_CODEX_CONFIG_DIR, { recursive: true });
     await fs.promises.writeFile(
-      CODEX_CONFIG_FILE,
-      TOML.stringify(existing as Record<string, unknown>) + "\n",
+      ROUTA_CODEX_CONFIG_FILE,
+      TOML.stringify({ mcp_servers: mcpServers }) + "\n",
       "utf-8",
     );
 
     console.log(
-      `[MCP:Codex] Wrote routa-coordination to ${CODEX_CONFIG_FILE}`,
+      `[MCP:Codex] Wrote private Routa overlay to ${ROUTA_CODEX_CONFIG_FILE}`,
     );
 
-    // Codex reads the config file itself – nothing to pass on the CLI
     return {
       mcpConfigs: [],
-      summary: `codex: wrote ${CODEX_CONFIG_FILE}`,
+      providerArgs: buildCodexProviderArgs(cwd, mcpServers),
+      summary: `codex: wrote private overlay ${ROUTA_CODEX_CONFIG_FILE}`,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[MCP:Codex] Failed to write config: ${msg}`);
     return {
       mcpConfigs: [],
-      summary: `codex: config write failed – ${msg}`,
+      providerArgs: [],
+      summary: `codex: private overlay write failed – ${msg}`,
     };
   }
 }


### PR DESCRIPTION
Routa currently writes its MCP server directly into the user's shared ~/.codex/config.toml, which makes routine Team runs mutate Codex CLI state outside the app. This moves Routa-managed Codex MCP data into a private ~/.routa/codex/config.toml overlay and passes the effective values through provider -c overrides so the session still gets the MCP endpoint and project trust level without rewriting the user's global config.

Constraint: Codex sessions still need the Routa MCP endpoint and trusted project override at launch time
Rejected: Keep merging into ~/.codex/config.toml | continues to clobber user-managed Codex settings
Rejected: Drop the trust override entirely | breaks Codex MCP startup in untrusted worktrees
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Routa-owned Codex config under ~/.routa and treat ~/.codex/config.toml as user-owned state
Tested: npm test -- --run src/core/acp/__tests__/mcp-setup-file-writes.test.ts src/core/acp/__tests__/acp-process-manager.test.ts
Tested: npx eslint src/core/acp/mcp-setup.ts src/core/acp/acp-process-manager.ts src/core/acp/__tests__/mcp-setup-file-writes.test.ts src/core/acp/__tests__/acp-process-manager.test.ts
Tested: npx tsc --noEmit --pretty false
Not-tested: End-to-end Codex ACP launch against a real codex-acp binary on this branch

## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

## Notes

- Related issue:
- Risks or follow-up work:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured MCP provider configuration handling to improve flexibility and reliability in session setup.
  * Updated Codex configuration storage to use a private overlay directory at `~/.routa/codex/config.toml`.
  * Enhanced repository context awareness in MCP provider initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->