### PR TITLE
fix(team): query team runs via backend surface

### DIFF
--- a/crates/routa-server/src/api/sessions.rs
+++ b/crates/routa-server/src/api/sessions.rs
@@ -10,6 +10,7 @@ use routa_core::trace::{TraceEventType, TraceQuery, TraceReader};
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::{Path as FsPath, PathBuf};
 
 use crate::application::sessions::{
@@ -104,8 +105,11 @@ struct RepoSlideSessionResult {
 struct ListSessionsQuery {
     workspace_id: Option<String>,
     parent_session_id: Option<String>,
+    surface: Option<String>,
     limit: Option<usize>,
 }
+
+const TEAM_LEAD_SPECIALIST_ID: &str = "team-agent-lead";
 
 /// GET /api/sessions — List ACP sessions.
 /// Compatible with the Next.js frontend's session-panel.tsx and chat-panel.tsx.
@@ -116,15 +120,180 @@ async fn list_sessions(
     Query(query): Query<ListSessionsQuery>,
 ) -> Json<serde_json::Value> {
     let service = SessionApplicationService::new(state);
-    let sessions = service
+    let limit = query.limit;
+    let surface = query.surface.clone();
+    let parent_session_id = query.parent_session_id.clone();
+    let mut sessions = service
         .list_sessions(SessionListQuery {
             workspace_id: query.workspace_id,
-            parent_session_id: query.parent_session_id,
-            limit: query.limit,
+            parent_session_id,
+            limit: if surface.as_deref() == Some("team") {
+                None
+            } else {
+                limit
+            },
         })
         .await;
 
+    if query.parent_session_id.is_none() {
+        sessions.retain(session_is_non_empty);
+    }
+
+    if surface.as_deref() == Some("team") {
+        sessions = list_team_runs(sessions);
+    }
+
+    if let Some(limit) = limit {
+        sessions.truncate(limit);
+    }
+
     Json(serde_json::json!({ "sessions": sessions }))
+}
+
+fn session_is_non_empty(session: &Value) -> bool {
+    session
+        .get("firstPromptSent")
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+fn session_id(session: &Value) -> Option<&str> {
+    session.get("sessionId").and_then(Value::as_str)
+}
+
+fn parent_session_id(session: &Value) -> Option<&str> {
+    session.get("parentSessionId").and_then(Value::as_str)
+}
+
+fn session_role(session: &Value) -> Option<&str> {
+    session.get("role").and_then(Value::as_str)
+}
+
+fn session_name(session: &Value) -> Option<&str> {
+    session.get("name").and_then(Value::as_str)
+}
+
+fn session_specialist_id(session: &Value) -> Option<&str> {
+    session.get("specialistId").and_then(Value::as_str)
+}
+
+fn normalize_session_name(name: Option<&str>) -> String {
+    name.unwrap_or_default().split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+fn has_explicit_team_run_marker(session: &Value) -> bool {
+    if !session_role(session)
+        .map(|role| role.eq_ignore_ascii_case("ROUTA"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    if session_specialist_id(session) == Some(TEAM_LEAD_SPECIALIST_ID) {
+        return true;
+    }
+
+    let normalized_name = normalize_session_name(session_name(session));
+    if normalized_name.is_empty() {
+        return false;
+    }
+
+    normalized_name.starts_with("team -")
+        || normalized_name.starts_with("team run")
+        || normalized_name.contains("team lead")
+}
+
+fn list_team_runs(sessions: Vec<Value>) -> Vec<Value> {
+    let mut child_map: HashMap<String, Vec<String>> = HashMap::new();
+    let ordered_sessions = sessions;
+    let sessions_by_id: HashMap<String, Value> = ordered_sessions
+        .iter()
+        .cloned()
+        .filter_map(|session| {
+            let id = session_id(&session)?.to_string();
+            Some((id, session))
+        })
+        .collect();
+
+    for session in ordered_sessions.iter() {
+        let Some(parent_id) = parent_session_id(session) else {
+            continue;
+        };
+        let Some(child_id) = session_id(session) else {
+            continue;
+        };
+        child_map
+            .entry(parent_id.to_string())
+            .or_default()
+            .push(child_id.to_string());
+    }
+
+    let mut descendants_by_session_id: HashMap<String, usize> = HashMap::new();
+    let mut root_sessions = Vec::new();
+
+    for session in ordered_sessions.iter() {
+        if parent_session_id(session).is_some() {
+            continue;
+        }
+
+        let Some(current_session_id) = session_id(session) else {
+            continue;
+        };
+        let direct_delegates = child_map
+            .get(current_session_id)
+            .map(|children| children.len())
+            .unwrap_or(0);
+        let descendants = count_descendants(
+            current_session_id,
+            &child_map,
+            &mut descendants_by_session_id,
+            &mut Vec::new(),
+        );
+
+        if has_explicit_team_run_marker(session)
+            || session_role(session)
+                .map(|role| role.eq_ignore_ascii_case("ROUTA"))
+                .unwrap_or(false)
+                && descendants > 0
+        {
+            let mut session_with_counts = session.clone();
+            if let Some(object) = session_with_counts.as_object_mut() {
+                object.insert("directDelegates".to_string(), Value::from(direct_delegates));
+                object.insert("descendants".to_string(), Value::from(descendants));
+            }
+            root_sessions.push(session_with_counts);
+        }
+    }
+
+    root_sessions
+}
+
+fn count_descendants(
+    session_id: &str,
+    child_map: &HashMap<String, Vec<String>>,
+    descendants_by_session_id: &mut HashMap<String, usize>,
+    visiting: &mut Vec<String>,
+) -> usize {
+    if let Some(cached) = descendants_by_session_id.get(session_id) {
+        return *cached;
+    }
+    if visiting.iter().any(|current| current == session_id) {
+        return 0;
+    }
+
+    visiting.push(session_id.to_string());
+    let total = child_map
+        .get(session_id)
+        .map(|children| {
+            children
+                .iter()
+                .map(|child_id| 1 + count_descendants(child_id, child_map, descendants_by_session_id, visiting))
+                .sum()
+        })
+        .unwrap_or(0);
+    visiting.pop();
+    descendants_by_session_id.insert(session_id.to_string(), total);
+    total
 }
 
 /// GET /api/sessions/{session_id} — Get session metadata.
@@ -981,11 +1150,12 @@ fn now_iso() -> String {
 mod tests {
     use crate::application::sessions::consolidate_message_history;
     use routa_core::trace::{Contributor, TraceEventType, TraceRecord};
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     use super::{
-        build_transcript_payload, extract_reposlide_result, history_to_transcript_messages,
-        resolve_reposlide_deck_file, TranscriptMessage,
+        build_transcript_payload, count_descendants, extract_reposlide_result,
+        history_to_transcript_messages, list_team_runs, resolve_reposlide_deck_file,
+        session_is_non_empty, TranscriptMessage, TEAM_LEAD_SPECIALIST_ID,
     };
 
     #[test]
@@ -1180,5 +1350,115 @@ mod tests {
         let artifact = resolve_reposlide_deck_file(session_dir.path(), deck_path.to_str());
 
         assert!(artifact.is_none());
+    }
+
+    #[test]
+    fn list_team_runs_matches_next_backend_contract() {
+        let sessions = vec![
+            json!({
+                "sessionId": "anonymous-team-run",
+                "workspaceId": "default",
+                "role": "ROUTA",
+                "createdAt": "2026-04-18T00:00:00Z",
+                "firstPromptSent": true,
+            }),
+            json!({
+                "sessionId": "anonymous-team-child",
+                "workspaceId": "default",
+                "role": "DEVELOPER",
+                "parentSessionId": "anonymous-team-run",
+                "createdAt": "2026-04-18T00:01:00Z",
+                "firstPromptSent": true,
+            }),
+            json!({
+                "sessionId": "named-team-run",
+                "workspaceId": "default",
+                "name": "Team - Investigate regression",
+                "role": "ROUTA",
+                "createdAt": "2026-04-18T00:02:00Z",
+                "firstPromptSent": true,
+            }),
+            json!({
+                "sessionId": "named-non-routa-run",
+                "workspaceId": "default",
+                "name": "Team - not actually routa",
+                "role": "DEVELOPER",
+                "createdAt": "2026-04-18T00:03:00Z",
+                "firstPromptSent": true,
+            }),
+            json!({
+                "sessionId": "team-specialist-run",
+                "workspaceId": "default",
+                "role": "ROUTA",
+                "specialistId": TEAM_LEAD_SPECIALIST_ID,
+                "createdAt": "2026-04-18T00:04:00Z",
+                "firstPromptSent": true,
+            }),
+        ];
+
+        let runs = list_team_runs(sessions);
+        let ids: Vec<_> = runs
+            .iter()
+            .filter_map(|session| session["sessionId"].as_str())
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "anonymous-team-run",
+                "named-team-run",
+                "team-specialist-run",
+            ]
+        );
+        assert_eq!(runs[0]["directDelegates"], Value::from(1));
+        assert_eq!(runs[0]["descendants"], Value::from(1));
+        assert_eq!(runs[1]["directDelegates"], Value::from(0));
+        assert_eq!(runs[1]["descendants"], Value::from(0));
+    }
+
+    #[test]
+    fn count_descendants_handles_cycles_and_empty_sessions() {
+        let mut descendants_by_session_id = std::collections::HashMap::new();
+        let child_map = std::collections::HashMap::from([
+            ("cycle-root".to_string(), vec!["cycle-child".to_string()]),
+            ("cycle-child".to_string(), vec!["cycle-root".to_string()]),
+        ]);
+
+        let descendants = count_descendants(
+            "cycle-root",
+            &child_map,
+            &mut descendants_by_session_id,
+            &mut Vec::new(),
+        );
+
+        assert_eq!(descendants, 2);
+    }
+
+    #[test]
+    fn session_is_non_empty_filters_placeholder_sessions() {
+        let sessions = vec![
+            json!({
+                "sessionId": "visible-session",
+                "workspaceId": "default",
+                "role": "ROUTA",
+                "createdAt": "2026-04-18T00:00:00Z",
+                "firstPromptSent": true,
+            }),
+            json!({
+                "sessionId": "empty-session",
+                "workspaceId": "default",
+                "role": "ROUTA",
+                "createdAt": "2026-04-18T00:01:00Z",
+                "firstPromptSent": false,
+            }),
+        ];
+
+        let non_empty: Vec<_> = sessions
+            .into_iter()
+            .filter(session_is_non_empty)
+            .collect();
+
+        assert_eq!(non_empty.len(), 1);
+        assert_eq!(non_empty[0]["sessionId"].as_str(), Some("visible-session"));
     }
 }

--- a/crates/routa-server/src/api/sessions.rs
+++ b/crates/routa-server/src/api/sessions.rs
@@ -123,11 +123,12 @@ async fn list_sessions(
     let limit = query.limit;
     let surface = query.surface.clone();
     let parent_session_id = query.parent_session_id.clone();
+    let use_team_surface = should_apply_team_surface(surface.as_deref(), query.parent_session_id.as_deref());
     let mut sessions = service
         .list_sessions(SessionListQuery {
             workspace_id: query.workspace_id,
             parent_session_id,
-            limit: if surface.as_deref() == Some("team") {
+            limit: if use_team_surface {
                 None
             } else {
                 limit
@@ -139,7 +140,7 @@ async fn list_sessions(
         sessions.retain(session_is_non_empty);
     }
 
-    if surface.as_deref() == Some("team") {
+    if use_team_surface {
         sessions = list_team_runs(sessions);
     }
 
@@ -181,6 +182,10 @@ fn normalize_session_name(name: Option<&str>) -> String {
     name.unwrap_or_default().split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
 }
 
+fn should_apply_team_surface(surface: Option<&str>, parent_session_id: Option<&str>) -> bool {
+    surface == Some("team") && parent_session_id.is_none()
+}
+
 fn has_explicit_team_run_marker(session: &Value) -> bool {
     if session_specialist_id(session) == Some(TEAM_LEAD_SPECIALIST_ID) {
         return true;
@@ -206,14 +211,6 @@ fn has_explicit_team_run_marker(session: &Value) -> bool {
 fn list_team_runs(sessions: Vec<Value>) -> Vec<Value> {
     let mut child_map: HashMap<String, Vec<String>> = HashMap::new();
     let ordered_sessions = sessions;
-    let sessions_by_id: HashMap<String, Value> = ordered_sessions
-        .iter()
-        .cloned()
-        .filter_map(|session| {
-            let id = session_id(&session)?.to_string();
-            Some((id, session))
-        })
-        .collect();
 
     for session in ordered_sessions.iter() {
         let Some(parent_id) = parent_session_id(session) else {
@@ -287,7 +284,13 @@ fn count_descendants(
         .map(|children| {
             children
                 .iter()
-                .map(|child_id| 1 + count_descendants(child_id, child_map, descendants_by_session_id, visiting))
+                .map(|child_id| {
+                    if visiting.iter().any(|current| current == child_id) {
+                        0
+                    } else {
+                        1 + count_descendants(child_id, child_map, descendants_by_session_id, visiting)
+                    }
+                })
                 .sum()
         })
         .unwrap_or(0);
@@ -1155,7 +1158,8 @@ mod tests {
     use super::{
         build_transcript_payload, count_descendants, extract_reposlide_result,
         history_to_transcript_messages, list_team_runs, resolve_reposlide_deck_file,
-        session_is_non_empty, TranscriptMessage, TEAM_LEAD_SPECIALIST_ID,
+        session_is_non_empty, should_apply_team_surface, TranscriptMessage,
+        TEAM_LEAD_SPECIALIST_ID,
     };
 
     #[test]
@@ -1431,7 +1435,14 @@ mod tests {
             &mut Vec::new(),
         );
 
-        assert_eq!(descendants, 2);
+        assert_eq!(descendants, 1);
+    }
+
+    #[test]
+    fn team_surface_is_skipped_for_child_queries() {
+        assert!(should_apply_team_surface(Some("team"), None));
+        assert!(!should_apply_team_surface(Some("team"), Some("parent-1")));
+        assert!(!should_apply_team_surface(None, None));
     }
 
     #[test]

--- a/crates/routa-server/src/api/sessions.rs
+++ b/crates/routa-server/src/api/sessions.rs
@@ -124,15 +124,12 @@ async fn list_sessions(
     let surface = query.surface.clone();
     let parent_session_id = query.parent_session_id.clone();
     let use_team_surface = should_apply_team_surface(surface.as_deref(), query.parent_session_id.as_deref());
+    let service_limit = service_limit_for_query(limit, query.parent_session_id.as_deref());
     let mut sessions = service
         .list_sessions(SessionListQuery {
             workspace_id: query.workspace_id,
             parent_session_id,
-            limit: if use_team_surface {
-                None
-            } else {
-                limit
-            },
+            limit: service_limit,
         })
         .await;
 
@@ -184,6 +181,14 @@ fn normalize_session_name(name: Option<&str>) -> String {
 
 fn should_apply_team_surface(surface: Option<&str>, parent_session_id: Option<&str>) -> bool {
     surface == Some("team") && parent_session_id.is_none()
+}
+
+fn service_limit_for_query(limit: Option<usize>, parent_session_id: Option<&str>) -> Option<usize> {
+    if parent_session_id.is_some() {
+        limit
+    } else {
+        None
+    }
 }
 
 fn has_explicit_team_run_marker(session: &Value) -> bool {
@@ -1158,8 +1163,8 @@ mod tests {
     use super::{
         build_transcript_payload, count_descendants, extract_reposlide_result,
         history_to_transcript_messages, list_team_runs, resolve_reposlide_deck_file,
-        session_is_non_empty, should_apply_team_surface, TranscriptMessage,
-        TEAM_LEAD_SPECIALIST_ID,
+        service_limit_for_query, session_is_non_empty, should_apply_team_surface,
+        TranscriptMessage, TEAM_LEAD_SPECIALIST_ID,
     };
 
     #[test]
@@ -1443,6 +1448,13 @@ mod tests {
         assert!(should_apply_team_surface(Some("team"), None));
         assert!(!should_apply_team_surface(Some("team"), Some("parent-1")));
         assert!(!should_apply_team_surface(None, None));
+    }
+
+    #[test]
+    fn top_level_queries_apply_limit_after_filtering() {
+        assert_eq!(service_limit_for_query(Some(5), None), None);
+        assert_eq!(service_limit_for_query(Some(5), Some("parent-1")), Some(5));
+        assert_eq!(service_limit_for_query(None, None), None);
     }
 
     #[test]

--- a/crates/routa-server/src/api/sessions.rs
+++ b/crates/routa-server/src/api/sessions.rs
@@ -182,15 +182,15 @@ fn normalize_session_name(name: Option<&str>) -> String {
 }
 
 fn has_explicit_team_run_marker(session: &Value) -> bool {
+    if session_specialist_id(session) == Some(TEAM_LEAD_SPECIALIST_ID) {
+        return true;
+    }
+
     if !session_role(session)
         .map(|role| role.eq_ignore_ascii_case("ROUTA"))
         .unwrap_or(false)
     {
         return false;
-    }
-
-    if session_specialist_id(session) == Some(TEAM_LEAD_SPECIALIST_ID) {
-        return true;
     }
 
     let normalized_name = normalize_session_name(session_name(session));

--- a/src/app/api/sessions/__tests__/route.test.ts
+++ b/src/app/api/sessions/__tests__/route.test.ts
@@ -134,6 +134,14 @@ describe("/api/sessions GET", () => {
         createdAt: "2026-04-03T10:03:00.000Z",
       },
       {
+        sessionId: "named-non-routa-run",
+        name: "Team - not actually routa",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "DEVELOPER",
+        createdAt: "2026-04-03T10:02:30.000Z",
+      },
+      {
         sessionId: "non-team-routa",
         workspaceId: "workspace-1",
         cwd: "/tmp/project",
@@ -176,6 +184,54 @@ describe("/api/sessions GET", () => {
       sessionId: "named-team-run",
       directDelegates: 0,
       descendants: 0,
+    });
+  });
+
+  it("ignores cyclic descendants and excludes named non-ROUTA sessions from the team surface", async () => {
+    listSessions.mockReturnValue([
+      {
+        sessionId: "cycle-root",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        createdAt: "2026-04-03T10:05:00.000Z",
+      },
+      {
+        sessionId: "cycle-child",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "DEVELOPER",
+        parentSessionId: "cycle-root",
+        createdAt: "2026-04-03T10:04:00.000Z",
+      },
+      {
+        sessionId: "cycle-root",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "DEVELOPER",
+        parentSessionId: "cycle-child",
+        createdAt: "2026-04-03T10:03:00.000Z",
+      },
+      {
+        sessionId: "named-non-routa-run",
+        name: "Team - not actually routa",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "DEVELOPER",
+        createdAt: "2026-04-03T10:02:30.000Z",
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/sessions?workspaceId=workspace-1&surface=team"),
+    );
+    const data = await response.json();
+
+    expect(data.sessions).toHaveLength(1);
+    expect(data.sessions[0]).toMatchObject({
+      sessionId: "cycle-root",
+      directDelegates: 1,
+      descendants: 2,
     });
   });
 });

--- a/src/app/api/sessions/__tests__/route.test.ts
+++ b/src/app/api/sessions/__tests__/route.test.ts
@@ -107,4 +107,75 @@ describe("/api/sessions GET", () => {
       "child-2",
     ]);
   });
+
+  it("returns stable team-run summaries for explicit team runs and anonymous top-level ROUTA runs with descendants", async () => {
+    listSessions.mockReturnValue([
+      {
+        sessionId: "anonymous-team-run",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        createdAt: "2026-04-03T10:05:00.000Z",
+      },
+      {
+        sessionId: "anonymous-team-child",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "DEVELOPER",
+        parentSessionId: "anonymous-team-run",
+        createdAt: "2026-04-03T10:04:00.000Z",
+      },
+      {
+        sessionId: "named-team-run",
+        name: "Team - Investigate regression",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        createdAt: "2026-04-03T10:03:00.000Z",
+      },
+      {
+        sessionId: "non-team-routa",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        createdAt: "2026-04-03T10:02:00.000Z",
+      },
+      {
+        sessionId: "team-specialist-run",
+        workspaceId: "workspace-1",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        specialistId: "team-agent-lead",
+        createdAt: "2026-04-03T10:01:00.000Z",
+      },
+      {
+        sessionId: "session-other-workspace",
+        workspaceId: "workspace-2",
+        cwd: "/tmp/project",
+        role: "ROUTA",
+        createdAt: "2026-04-03T10:00:00.000Z",
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/sessions?workspaceId=workspace-1&surface=team"),
+    );
+    const data = await response.json();
+
+    expect(data.sessions.map((session: { sessionId: string }) => session.sessionId)).toEqual([
+      "anonymous-team-run",
+      "named-team-run",
+      "team-specialist-run",
+    ]);
+    expect(data.sessions[0]).toMatchObject({
+      sessionId: "anonymous-team-run",
+      directDelegates: 1,
+      descendants: 1,
+    });
+    expect(data.sessions[1]).toMatchObject({
+      sessionId: "named-team-run",
+      directDelegates: 0,
+      descendants: 0,
+    });
+  });
 });

--- a/src/app/api/sessions/__tests__/route.test.ts
+++ b/src/app/api/sessions/__tests__/route.test.ts
@@ -152,7 +152,6 @@ describe("/api/sessions GET", () => {
         sessionId: "team-specialist-run",
         workspaceId: "workspace-1",
         cwd: "/tmp/project",
-        role: "ROUTA",
         specialistId: TEAM_LEAD_SPECIALIST_ID,
         createdAt: "2026-04-03T10:01:00.000Z",
       },

--- a/src/app/api/sessions/__tests__/route.test.ts
+++ b/src/app/api/sessions/__tests__/route.test.ts
@@ -230,7 +230,7 @@ describe("/api/sessions GET", () => {
     expect(data.sessions[0]).toMatchObject({
       sessionId: "cycle-root",
       directDelegates: 1,
-      descendants: 2,
+      descendants: 1,
     });
   });
 });

--- a/src/app/api/sessions/__tests__/route.test.ts
+++ b/src/app/api/sessions/__tests__/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/core/acp/http-session-store", () => ({
   }),
 }));
 
-import { GET } from "../route";
+import { GET, TEAM_LEAD_SPECIALIST_ID } from "../route";
 
 describe("/api/sessions GET", () => {
   beforeEach(() => {
@@ -153,7 +153,7 @@ describe("/api/sessions GET", () => {
         workspaceId: "workspace-1",
         cwd: "/tmp/project",
         role: "ROUTA",
-        specialistId: "team-agent-lead",
+        specialistId: TEAM_LEAD_SPECIALIST_ID,
         createdAt: "2026-04-03T10:01:00.000Z",
       },
       {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -74,6 +74,10 @@ function normalizeSessionName(name: string | undefined): string {
 }
 
 function hasExplicitTeamRunMarker(session: RoutaSessionRecord): boolean {
+  if (session.role?.toUpperCase() !== "ROUTA") {
+    return false;
+  }
+
   if (session.specialistId === TEAM_LEAD_SPECIALIST_ID) {
     return true;
   }
@@ -100,12 +104,17 @@ function listTeamRuns(sessions: RoutaSessionRecord[]): TeamRunSummary[] {
   }
 
   const descendantsBySessionId = new Map<string, number>();
-  const countDescendants = (sessionId: string): number => {
+  const countDescendants = (sessionId: string, visiting = new Set<string>()): number => {
     const cached = descendantsBySessionId.get(sessionId);
     if (cached !== undefined) return cached;
+    if (visiting.has(sessionId)) {
+      return 0;
+    }
 
+    visiting.add(sessionId);
     const children = childMap.get(sessionId) ?? [];
-    const total = children.reduce((sum, child) => sum + 1 + countDescendants(child.sessionId), 0);
+    const total = children.reduce((sum, child) => sum + 1 + countDescendants(child.sessionId, visiting), 0);
+    visiting.delete(sessionId);
     descendantsBySessionId.set(sessionId, total);
     return total;
   };

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -113,7 +113,13 @@ function listTeamRuns(sessions: RoutaSessionRecord[]): TeamRunSummary[] {
 
     visiting.add(sessionId);
     const children = childMap.get(sessionId) ?? [];
-    const total = children.reduce((sum, child) => sum + 1 + countDescendants(child.sessionId, visiting), 0);
+    const total = children.reduce((sum, child) => {
+      if (visiting.has(child.sessionId)) {
+        return sum;
+      }
+
+      return sum + 1 + countDescendants(child.sessionId, visiting);
+    }, 0);
     visiting.delete(sessionId);
     descendantsBySessionId.set(sessionId, total);
     return total;

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -14,8 +14,15 @@ export const dynamic = "force-dynamic";
 
 /** Stale threshold: sessions older than 7 days without an active process are considered stale */
 const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+const TEAM_LEAD_SPECIALIST_ID = "team-agent-lead";
 
 export type SessionContinuityStatus = "active" | "interrupted" | "restorable" | "stale";
+
+interface TeamRunSummary {
+  session: RoutaSessionRecord;
+  directDelegates: number;
+  descendants: number;
+}
 
 /**
  * Derive the session continuity status for the session picker UI.
@@ -62,6 +69,63 @@ function toSessionSummary(session: RoutaSessionRecord, hasActiveProcess: boolean
   };
 }
 
+function normalizeSessionName(name: string | undefined): string {
+  return (name ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function hasExplicitTeamRunMarker(session: RoutaSessionRecord): boolean {
+  if (session.specialistId === TEAM_LEAD_SPECIALIST_ID) {
+    return true;
+  }
+
+  const normalizedName = normalizeSessionName(session.name);
+  if (!normalizedName) {
+    return false;
+  }
+
+  return (
+    normalizedName.startsWith("team -")
+    || normalizedName.startsWith("team run")
+    || normalizedName.includes("team lead")
+  );
+}
+
+function listTeamRuns(sessions: RoutaSessionRecord[]): TeamRunSummary[] {
+  const childMap = new Map<string, RoutaSessionRecord[]>();
+  for (const session of sessions) {
+    if (!session.parentSessionId) continue;
+    const existing = childMap.get(session.parentSessionId) ?? [];
+    existing.push(session);
+    childMap.set(session.parentSessionId, existing);
+  }
+
+  const descendantsBySessionId = new Map<string, number>();
+  const countDescendants = (sessionId: string): number => {
+    const cached = descendantsBySessionId.get(sessionId);
+    if (cached !== undefined) return cached;
+
+    const children = childMap.get(sessionId) ?? [];
+    const total = children.reduce((sum, child) => sum + 1 + countDescendants(child.sessionId), 0);
+    descendantsBySessionId.set(sessionId, total);
+    return total;
+  };
+
+  return sessions
+    .filter((session) => !session.parentSessionId)
+    .map((session) => {
+      const directDelegates = (childMap.get(session.sessionId) ?? []).length;
+      const descendants = countDescendants(session.sessionId);
+      return { session, directDelegates, descendants };
+    })
+    .filter(({ session, descendants }) => {
+      if (hasExplicitTeamRunMarker(session)) {
+        return true;
+      }
+
+      return session.role?.toUpperCase() === "ROUTA" && descendants > 0;
+    });
+}
+
 export async function GET(request: NextRequest) {
   const store = getHttpSessionStore();
   const processManager = getAcpProcessManager();
@@ -71,6 +135,7 @@ export async function GET(request: NextRequest) {
 
   const workspaceId = request.nextUrl.searchParams.get("workspaceId");
   const parentSessionId = request.nextUrl.searchParams.get("parentSessionId");
+  const surface = request.nextUrl.searchParams.get("surface");
   const rawLimit = request.nextUrl.searchParams.get("limit");
   const parsedLimit = rawLimit ? Number.parseInt(rawLimit, 10) : Number.NaN;
   const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : null;
@@ -94,6 +159,20 @@ export async function GET(request: NextRequest) {
 
   // Filter out empty sessions that never received a real prompt
   sessions = sessions.filter((s) => s.firstPromptSent !== false);
+
+  if (surface === "team") {
+    const teamRuns = listTeamRuns(sessions);
+    return NextResponse.json(
+      {
+        sessions: (limit ? teamRuns.slice(0, limit) : teamRuns).map(({ session, directDelegates, descendants }) => ({
+          ...summarize(session),
+          directDelegates,
+          descendants,
+        })),
+      },
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  }
 
   return NextResponse.json(
     { sessions: (limit ? sessions.slice(0, limit) : sessions).map(summarize) },

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -74,12 +74,12 @@ function normalizeSessionName(name: string | undefined): string {
 }
 
 function hasExplicitTeamRunMarker(session: RoutaSessionRecord): boolean {
-  if (session.role?.toUpperCase() !== "ROUTA") {
-    return false;
-  }
-
   if (session.specialistId === TEAM_LEAD_SPECIALIST_ID) {
     return true;
+  }
+
+  if (session.role?.toUpperCase() !== "ROUTA") {
+    return false;
   }
 
   const normalizedName = normalizeSessionName(session.name);

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -14,7 +14,7 @@ export const dynamic = "force-dynamic";
 
 /** Stale threshold: sessions older than 7 days without an active process are considered stale */
 const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
-const TEAM_LEAD_SPECIALIST_ID = "team-agent-lead";
+export const TEAM_LEAD_SPECIALIST_ID = "team-agent-lead";
 
 export type SessionContinuityStatus = "active" | "interrupted" | "restorable" | "stale";
 

--- a/src/app/workspace/[workspaceId]/team/[sessionId]/__tests__/team-run-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/team/[sessionId]/__tests__/team-run-page-client.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TeamRunPageClient } from "../team-run-page-client";
+
+const {
+  mockDesktopAwareFetch,
+  mockSelectSession,
+  mockConnect,
+  mockHeaderProps,
+} = vi.hoisted(() => ({
+  mockDesktopAwareFetch: vi.fn(),
+  mockSelectSession: vi.fn(),
+  mockConnect: vi.fn(async () => {}),
+  mockHeaderProps: [] as Array<{ teamRuns: Array<{ sessionId: string; name?: string }> }>,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/i18n", () => ({
+  useTranslation: () => ({
+    t: {
+      common: {
+        back: "Back",
+        refresh: "Refresh",
+      },
+      team: {
+        openSession: "Open session details",
+        active: "ACTIVE",
+        waitingForDelegation: "Waiting for delegation",
+        loadingTeamRun: "Loading team run",
+        teamRuns: "Team Runs",
+      },
+    },
+  }),
+}));
+
+vi.mock("../use-real-team-run-params", () => ({
+  useRealTeamRunParams: () => ({
+    workspaceId: "default",
+    sessionId: "session-1",
+    isResolved: true,
+  }),
+}));
+
+vi.mock("@/client/hooks/use-acp", () => ({
+  useAcp: () => ({
+    connected: true,
+    loading: false,
+    sessionId: "session-1",
+    updates: [],
+    providers: [{ id: "codex", name: "Codex", description: "Codex", command: "codex-acp" }],
+    selectedProvider: "codex",
+    connect: mockConnect,
+    prompt: vi.fn(async () => {}),
+    promptSession: vi.fn(async () => {}),
+    setProvider: vi.fn(),
+    selectSession: mockSelectSession,
+  }),
+}));
+
+vi.mock("@/client/hooks/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    workspaces: [
+      {
+        id: "default",
+        title: "Default Workspace",
+      },
+    ],
+    loading: false,
+    createWorkspace: vi.fn(async () => null),
+  }),
+  useCodebases: () => ({
+    codebases: [],
+  }),
+}));
+
+vi.mock("@/client/hooks/use-notes", () => ({
+  useNotes: () => ({
+    notes: [],
+  }),
+}));
+
+vi.mock("@/client/components/desktop-app-shell", () => ({
+  DesktopAppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/client/components/workspace-switcher", () => ({
+  WorkspaceSwitcher: () => <div data-testid="workspace-switcher" />,
+}));
+
+vi.mock("@/client/components/tiptap-input", () => ({
+  TiptapInput: () => <div data-testid="tiptap-input" />,
+}));
+
+vi.mock("@/client/utils/diagnostics", () => ({
+  desktopAwareFetch: mockDesktopAwareFetch,
+}));
+
+vi.mock("../team-run-page-sections", () => ({
+  ObjectiveSidebarSection: () => <div data-testid="objective-sidebar" />,
+  SessionTimelineSection: () => <div data-testid="session-timeline" />,
+  TeamMembersSection: () => <div data-testid="team-members" />,
+}));
+
+vi.mock("../team-run-session-modal", () => ({
+  TeamRunSessionModal: () => null,
+}));
+
+vi.mock("../team-run-page-header", () => ({
+  TeamRunPageHeader: (props: { teamRuns: Array<{ sessionId: string; name?: string }> }) => {
+    mockHeaderProps.push({ teamRuns: props.teamRuns });
+    return (
+      <div data-testid="team-run-header">
+        {props.teamRuns.map((run) => run.name ?? run.sessionId).join(" | ")}
+      </div>
+    );
+  },
+}));
+
+describe("TeamRunPageClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHeaderProps.length = 0;
+
+    mockDesktopAwareFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/specialists") {
+        return { ok: true, json: async () => ({ specialists: [] }) } as Response;
+      }
+      if (url === "/api/sessions/session-1") {
+        return {
+          ok: true,
+          json: async () => ({
+            session: {
+              sessionId: "session-1",
+              name: "Team - Original run",
+              workspaceId: "default",
+              provider: "codex",
+              role: "ROUTA",
+              createdAt: "2026-04-18T00:00:00.000Z",
+            },
+          }),
+        } as Response;
+      }
+      if (url === "/api/sessions?workspaceId=default") {
+        return {
+          ok: true,
+          json: async () => ({
+            sessions: [
+              {
+                sessionId: "session-1",
+                name: "Team - Original run",
+                workspaceId: "default",
+                role: "ROUTA",
+                createdAt: "2026-04-18T00:00:00.000Z",
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url === "/api/sessions?workspaceId=default&surface=team") {
+        return {
+          ok: true,
+          json: async () => ({
+            sessions: [
+              {
+                sessionId: "session-1",
+                name: "Team - Original run",
+                workspaceId: "default",
+                role: "ROUTA",
+                createdAt: "2026-04-18T00:00:00.000Z",
+              },
+              {
+                sessionId: "session-2",
+                name: "Team - Follow-up",
+                workspaceId: "default",
+                role: "ROUTA",
+                createdAt: "2026-04-17T00:00:00.000Z",
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url === "/api/agents?workspaceId=default") {
+        return { ok: true, json: async () => ({ agents: [] }) } as Response;
+      }
+      if (url === "/api/sessions/session-1/transcript") {
+        return { ok: true, json: async () => ({ history: [], messages: [] }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+  });
+
+  it("loads team run switcher options from the backend team surface", async () => {
+    render(<TeamRunPageClient />);
+
+    await waitFor(() => {
+      expect(mockDesktopAwareFetch).toHaveBeenCalledWith(
+        "/api/sessions?workspaceId=default&surface=team",
+        expect.objectContaining({ cache: "no-store" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("team-run-header").textContent).toContain("Team - Original run");
+      expect(screen.getByTestId("team-run-header").textContent).toContain("Team - Follow-up");
+    });
+
+    expect(mockHeaderProps.at(-1)?.teamRuns.map((run) => run.sessionId)).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+  });
+});

--- a/src/app/workspace/[workspaceId]/team/[sessionId]/team-run-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/team/[sessionId]/team-run-page-client.tsx
@@ -138,21 +138,6 @@ function delegationRoleMatchesSession(targetRosterId: string, child: SessionInfo
   return normalizedRole === "CRAFTER" || normalizedRole === "DEVELOPER";
 }
 
-function isTopLevelTeamRun(session: SessionInfo): boolean {
-  if (session.parentSessionId) return false;
-  if (session.specialistId === TEAM_LEAD_SPECIALIST_ID) return true;
-  if (session.role?.toUpperCase() !== "ROUTA") return false;
-
-  const normalizedName = (session.name ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-  if (!normalizedName) return false;
-
-  return (
-    normalizedName.startsWith("team -")
-    || normalizedName.startsWith("team run")
-    || normalizedName.includes("team lead")
-  );
-}
-
 export function TeamRunPageClient() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -183,6 +168,7 @@ export function TeamRunPageClient() {
   const notesHook = useNotes(workspaceId, sessionId);
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [workspaceSessions, setWorkspaceSessions] = useState<SessionInfo[]>([]);
+  const [teamRuns, setTeamRuns] = useState<SessionInfo[]>([]);
   const [specialists, setSpecialists] = useState<SpecialistSummary[]>([]);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [historiesBySessionId, setHistoriesBySessionId] = useState<Record<string, SessionHistoryEntry[]>>({});
@@ -300,14 +286,16 @@ export function TeamRunPageClient() {
 
   const fetchRunMetadata = useCallback(async () => {
     const contextKey = `${workspaceId}:${sessionId}`;
-    const [sessionRes, sessionsRes, agentsRes] = await Promise.all([
+    const [sessionRes, sessionsRes, teamRunsRes, agentsRes] = await Promise.all([
       desktopAwareFetch(`/api/sessions/${encodeURIComponent(sessionId)}`, { cache: "no-store" }),
-      desktopAwareFetch(`/api/sessions?workspaceId=${encodeURIComponent(workspaceId)}&limit=100`, { cache: "no-store" }),
+      desktopAwareFetch(`/api/sessions?workspaceId=${encodeURIComponent(workspaceId)}`, { cache: "no-store" }),
+      desktopAwareFetch(`/api/sessions?workspaceId=${encodeURIComponent(workspaceId)}&surface=team`, { cache: "no-store" }),
       desktopAwareFetch(`/api/agents?workspaceId=${encodeURIComponent(workspaceId)}`, { cache: "no-store" }),
     ]);
 
     const sessionData = await sessionRes.json().catch(() => ({}));
     const sessionsData = await sessionsRes.json().catch(() => ({}));
+    const teamRunsData = await teamRunsRes.json().catch(() => ({}));
     const agentsData = await agentsRes.json().catch(() => ({}));
 
     if (contextKeyRef.current !== contextKey) return;
@@ -316,6 +304,9 @@ export function TeamRunPageClient() {
     }
     if (Array.isArray(sessionsData?.sessions)) {
       setWorkspaceSessions(sessionsData.sessions);
+    }
+    if (Array.isArray(teamRunsData?.sessions)) {
+      setTeamRuns(teamRunsData.sessions);
     }
     if (Array.isArray(agentsData?.agents)) {
       setAgents(agentsData.agents);
@@ -522,11 +513,6 @@ export function TeamRunPageClient() {
   }, [fetchSpecialists, flushMetadataRefresh, sessionId, workspaceId]);
 
   const workspace = workspacesHook.workspaces.find((item) => item.id === workspaceId);
-  const teamRuns = useMemo(() => (
-    [...workspaceSessions]
-      .filter((entry) => isTopLevelTeamRun(entry))
-      .sort((left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime())
-  ), [workspaceSessions]);
   const specialistsById = useMemo(
     () => new Map(specialists.map((specialist) => [specialist.id, specialist])),
     [specialists],

--- a/src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/i18n", () => ({
         teamRuns: "Team Runs",
         topLevelOnly: "Top-level only",
         noTeamRunsYet: "No team runs yet",
+        unnamedRun: "Unnamed Team run",
         launchAbove: "Launch one above",
       },
       home: {
@@ -127,5 +128,42 @@ describe("TeamPageClient", () => {
     });
 
     expect(await screen.findByText("Team - Investigate regression")).toBeTruthy();
+  });
+
+  it("renders the unnamed team-run fallback from i18n", async () => {
+    mockDesktopAwareFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/sessions?workspaceId=default&surface=team") {
+        return {
+          ok: true,
+          json: async () => ({
+            sessions: [
+              {
+                sessionId: "team-run-1",
+                workspaceId: "default",
+                acpStatus: "ready",
+                createdAt: "2026-04-18T00:00:00.000Z",
+              },
+            ],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/specialists") {
+        return {
+          ok: true,
+          json: async () => ({ specialists: [] }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    render(<TeamPageClient />);
+
+    expect(await screen.findByText("Unnamed Team run")).toBeTruthy();
   });
 });

--- a/src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TeamPageClient } from "../team-page-client";
+
+const { mockPush, mockDesktopAwareFetch } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockDesktopAwareFetch: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ workspaceId: "default" }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/i18n", () => ({
+  useTranslation: () => ({
+    t: {
+      common: {
+        workspace: "Workspace",
+        refresh: "Refresh",
+      },
+      team: {
+        loadingWorkspace: "Loading workspace",
+        launchTeamLead: "Launch Team Lead",
+        reusesInput: "Reuse the same input flow",
+        runs: "Runs",
+        active: "Active",
+        members: "Members",
+        teamBench: "Team Bench",
+        specialists: "specialists",
+        teamRuns: "Team Runs",
+        topLevelOnly: "Top-level only",
+        noTeamRunsYet: "No team runs yet",
+        launchAbove: "Launch one above",
+      },
+      home: {
+        modeTeamTitle: "Team",
+        modeTeamDescription: "Team mode",
+        modeTeamPlaceholder: "Describe the work",
+      },
+    },
+  }),
+}));
+
+vi.mock("@/client/components/desktop-app-shell", () => ({
+  DesktopAppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/client/components/workspace-switcher", () => ({
+  WorkspaceSwitcher: () => <div data-testid="workspace-switcher" />,
+}));
+
+vi.mock("@/client/components/home-input", () => ({
+  HomeInput: () => <div data-testid="home-input" />,
+}));
+
+vi.mock("@/client/hooks/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    workspaces: [
+      {
+        id: "default",
+        title: "Default Workspace",
+      },
+    ],
+    loading: false,
+    createWorkspace: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock("@/client/utils/diagnostics", () => ({
+  desktopAwareFetch: mockDesktopAwareFetch,
+}));
+
+vi.mock("@/client/utils/specialist-categories", () => ({
+  filterSpecialistsByCategory: (specialists: Array<unknown>) => specialists,
+}));
+
+vi.mock("../ui-components", () => ({
+  formatRelativeTime: () => "just now",
+}));
+
+describe("TeamPageClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDesktopAwareFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/sessions?workspaceId=default&surface=team") {
+        return {
+          ok: true,
+          json: async () => ({
+            sessions: [
+              {
+                sessionId: "team-run-1",
+                name: "Team - Investigate regression",
+                workspaceId: "default",
+                acpStatus: "ready",
+                createdAt: "2026-04-18T00:00:00.000Z",
+              },
+            ],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/specialists") {
+        return {
+          ok: true,
+          json: async () => ({ specialists: [] }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+  });
+
+  it("loads and renders team runs from the backend team surface", async () => {
+    render(<TeamPageClient />);
+
+    await waitFor(() => {
+      expect(mockDesktopAwareFetch).toHaveBeenCalledWith(
+        "/api/sessions?workspaceId=default&surface=team",
+        expect.objectContaining({ cache: "no-store" }),
+      );
+    });
+
+    expect(await screen.findByText("Team - Investigate regression")).toBeTruthy();
+  });
+});

--- a/src/app/workspace/[workspaceId]/team/team-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/team/team-page-client.tsx
@@ -370,7 +370,7 @@ export function TeamPageClient() {
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
-                          {run.name ?? "Unnamed Team run"}
+                          {run.name ?? t.team.unnamedRun}
                         </div>
                         <div className="mt-1 flex items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
                           <span>{formatRelativeTime(run.createdAt)}</span>

--- a/src/app/workspace/[workspaceId]/team/team-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/team/team-page-client.tsx
@@ -23,10 +23,9 @@ interface SpecialistSummary {
   role?: string;
 }
 
-interface TeamRunSummary {
-  session: SessionInfo;
-  descendants: number;
-  directDelegates: number;
+interface TeamRunSessionInfo extends SessionInfo {
+  descendants?: number;
+  directDelegates?: number;
 }
 
 const TEAM_MEMBER_DISPLAY_ORDER = [
@@ -56,21 +55,6 @@ function buildTeamRunName(requirement: string): string {
   return normalized.length > 56 ? `Team - ${normalized.slice(0, 53)}...` : `Team - ${normalized}`;
 }
 
-function isTeamLeadRun(session: SessionInfo): boolean {
-  if (session.parentSessionId) return false;
-  if (session.specialistId === TEAM_LEAD_SPECIALIST_ID) return true;
-  if (session.role?.toUpperCase() !== "ROUTA") return false;
-
-  const normalizedName = (session.name ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-  if (!normalizedName) return false;
-
-  return (
-    normalizedName.startsWith("team -")
-    || normalizedName.startsWith("team run")
-    || normalizedName.includes("team lead")
-  );
-}
-
 export function TeamPageClient() {
   const { t } = useTranslation();
   const params = useParams();
@@ -83,7 +67,7 @@ export function TeamPageClient() {
 
   const workspacesHook = useWorkspaces();
 
-  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [teamRuns, setTeamRuns] = useState<TeamRunSessionInfo[]>([]);
   const [specialists, setSpecialists] = useState<SpecialistSummary[]>([]);
   const [refreshKey, setRefreshKey] = useState(0);
   const [isBenchPaused, setIsBenchPaused] = useState(false);
@@ -92,16 +76,16 @@ export function TeamPageClient() {
     const controller = new AbortController();
     (async () => {
       try {
-        const res = await desktopAwareFetch(`/api/sessions?workspaceId=${encodeURIComponent(workspaceId)}&limit=100`, {
+        const res = await desktopAwareFetch(`/api/sessions?workspaceId=${encodeURIComponent(workspaceId)}&surface=team`, {
           cache: "no-store",
           signal: controller.signal,
         });
         const data = await res.json();
         if (controller.signal.aborted) return;
-        setSessions(Array.isArray(data?.sessions) ? data.sessions : []);
+        setTeamRuns(Array.isArray(data?.sessions) ? data.sessions : []);
       } catch {
         if (controller.signal.aborted) return;
-        setSessions([]);
+        setTeamRuns([]);
       }
     })();
     return () => controller.abort();
@@ -133,31 +117,8 @@ export function TeamPageClient() {
   const shouldAutoScrollBench = teamSpecialists.length > 4;
   const benchItems = shouldAutoScrollBench ? [...teamSpecialists, ...teamSpecialists] : teamSpecialists;
 
-  const teamRuns = useMemo<TeamRunSummary[]>(() => {
-    const childMap = new Map<string, SessionInfo[]>();
-    for (const session of sessions) {
-      if (!session.parentSessionId) continue;
-      const existing = childMap.get(session.parentSessionId) ?? [];
-      existing.push(session);
-      childMap.set(session.parentSessionId, existing);
-    }
-
-    const countDescendants = (sessionId: string): number => {
-      const children = childMap.get(sessionId) ?? [];
-      return children.reduce((total, child) => total + 1 + countDescendants(child.sessionId), 0);
-    };
-
-    return sessions
-      .filter((session) => isTeamLeadRun(session))
-      .map((session) => ({
-        session,
-        descendants: countDescendants(session.sessionId),
-        directDelegates: (childMap.get(session.sessionId) ?? []).length,
-      }));
-  }, [sessions]);
-
   const workspace = workspacesHook.workspaces.find((item) => item.id === workspaceId);
-  const activeRuns = teamRuns.filter((run) => run.session.acpStatus === "connecting" || run.session.acpStatus === "ready").length;
+  const activeRuns = teamRuns.filter((run) => run.acpStatus === "connecting" || run.acpStatus === "ready").length;
   const availableMembers = Math.max(teamSpecialists.length - 1, 0);
 
   const handleWorkspaceSelect = useCallback((nextWorkspaceId: string) => {
@@ -181,19 +142,19 @@ export function TeamPageClient() {
     sessionContext?: { cwd?: string; branch?: string; repoName?: string },
   ) => {
     const optimisticName = buildTeamRunName(promptText);
-    setSessions((current) => {
-      if (current.some((session) => session.sessionId === sessionId)) {
-        return current.map((session) => (
-          session.sessionId === sessionId
+    setTeamRuns((current) => {
+      if (current.some((run) => run.sessionId === sessionId)) {
+        return current.map((run) => (
+          run.sessionId === sessionId
             ? {
-              ...session,
+              ...run,
               name: optimisticName,
-              cwd: session.cwd || sessionContext?.cwd || "",
-              branch: session.branch ?? sessionContext?.branch,
-              role: session.role ?? "ROUTA",
-              specialistId: session.specialistId ?? TEAM_LEAD_SPECIALIST_ID,
+              cwd: run.cwd || sessionContext?.cwd || "",
+              branch: run.branch ?? sessionContext?.branch,
+              role: run.role ?? "ROUTA",
+              specialistId: run.specialistId ?? TEAM_LEAD_SPECIALIST_ID,
             }
-            : session
+            : run
         ));
       }
 
@@ -206,6 +167,8 @@ export function TeamPageClient() {
         role: "ROUTA",
         specialistId: TEAM_LEAD_SPECIALIST_ID,
         createdAt: new Date().toISOString(),
+        directDelegates: 0,
+        descendants: 0,
       }, ...current];
     });
 
@@ -399,27 +362,27 @@ export function TeamPageClient() {
               <div className="space-y-2">
                 {teamRuns.slice(0, 8).map((run) => (
                   <button
-                    key={run.session.sessionId}
+                    key={run.sessionId}
                     type="button"
-                    onClick={() => router.push(`/workspace/${workspaceId}/team/${run.session.sessionId}`)}
+                    onClick={() => router.push(`/workspace/${workspaceId}/team/${run.sessionId}`)}
                     className="w-full rounded-[18px] border border-black/6 bg-[#fbfaf7] px-4 py-3 text-left transition-colors hover:bg-white dark:border-white/8 dark:bg-white/4 dark:hover:bg-white/[0.07]"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
-                          {run.session.name ?? "Unnamed Team run"}
+                          {run.name ?? "Unnamed Team run"}
                         </div>
                         <div className="mt-1 flex items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
-                          <span>{formatRelativeTime(run.session.createdAt)}</span>
-                          {run.session.branch ? (
+                          <span>{formatRelativeTime(run.createdAt)}</span>
+                          {run.branch ? (
                             <>
                               <span>·</span>
-                              <span className="truncate">{run.session.branch}</span>
+                              <span className="truncate">{run.branch}</span>
                             </>
                           ) : null}
                         </div>
                       </div>
-                      <StatusPill status={run.session.acpStatus} />
+                      <StatusPill status={run.acpStatus} />
                     </div>
                   </button>
                 ))}

--- a/src/app/workspace/[workspaceId]/team/team-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/team/team-page-client.tsx
@@ -24,8 +24,8 @@ interface SpecialistSummary {
 }
 
 interface TeamRunSessionInfo extends SessionInfo {
-  descendants?: number;
-  directDelegates?: number;
+  descendants: number;
+  directDelegates: number;
 }
 
 const TEAM_MEMBER_DISPLAY_ORDER = [

--- a/src/i18n/locales/en-extended.ts
+++ b/src/i18n/locales/en-extended.ts
@@ -1108,6 +1108,7 @@ export const enExtended: ExtendedTranslationDictionarySections = {
     topLevelOnly: "Top-level lead sessions only.",
     inspectRunDesc: "Open any run to inspect the task tree, coordination feed, and team panel.",
     noTeamRunsYet: "No Team runs yet.",
+    unnamedRun: "Unnamed Team run",
     launchAbove: "Launch a lead session above.",
     directDelegates: "Direct delegates",
     totalSubSessions: "Total sub-sessions",

--- a/src/i18n/locales/zh-extended.ts
+++ b/src/i18n/locales/zh-extended.ts
@@ -1108,6 +1108,7 @@ export const zhExtended: ExtendedTranslationDictionarySections = {
     topLevelOnly: "仅显示顶层引导会话。",
     inspectRunDesc: "打开任意运行以检查任务树、协调流和团队面板。",
     noTeamRunsYet: "暂无团队运行。",
+    unnamedRun: "未命名团队运行",
     launchAbove: "在上方启动一个引导会话。",
     directDelegates: "直接委派",
     totalSubSessions: "总子会话",

--- a/src/i18n/types-extended.ts
+++ b/src/i18n/types-extended.ts
@@ -1119,6 +1119,7 @@ export interface ExtendedTranslationDictionarySections extends TailTranslationDi
     topLevelOnly: string;
     inspectRunDesc: string;
     noTeamRunsYet: string;
+    unnamedRun: string;
     launchAbove: string;
     directDelegates: string;
     totalSubSessions: string;


### PR DESCRIPTION
## Summary

- What changed:
  - Added a `surface=team` query mode to `/api/sessions` so Team run discovery is handled by the backend instead of frontend heuristics over the latest session list.
  - Updated the Team page and Team run page to consume the backend Team surface.
  - Added route coverage for explicit Team lead runs and anonymous top-level `ROUTA` runs that have descendants.
  - Added UI regression coverage for the Team page and Team run page consumers of the backend Team surface.

- Why:
  - The Team UI could hide valid Team runs because it depended on frontend filtering of a generic session list, including a `limit=100` window.
  - Team-run identification is a shared backend concern and should not be reimplemented independently in each consumer.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

Targeted validation completed:
- [x] `./node_modules/.bin/eslint 'src/app/api/sessions/route.ts' 'src/app/api/sessions/__tests__/route.test.ts' 'src/app/workspace/[workspaceId]/team/team-page-client.tsx' 'src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx' 'src/app/workspace/[workspaceId]/team/[sessionId]/team-run-page-client.tsx' 'src/app/workspace/[workspaceId]/team/[sessionId]/__tests__/team-run-page-client.test.tsx'`
- [x] `npm run test:run -- 'src/app/api/sessions/__tests__/route.test.ts' 'src/app/workspace/[workspaceId]/team/__tests__/team-page-client.test.tsx' 'src/app/workspace/[workspaceId]/team/[sessionId]/__tests__/team-run-page-client.test.tsx'`
- [x] `5/5` tests passed across `3` files

## Notes

- Related issue:
  - N/A

- Risks or follow-up work:
  - The Team run detail page still builds its descendant tree from the workspace session list. If workspace session volume grows further, that tree may also need a dedicated backend query.
  - Full repo-wide `npm run lint` currently reports unrelated baseline issues outside this PR’s touched files, so validation here is scoped to changed files and changed behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team sessions feed: new "team" surface returns filtered team runs with stable ordering and cycle-safe direct-delegate/descendant counts; team pages and headers now consume this feed.

* **Tests**
  * Added tests covering the team feed, UI rendering and ordering, unnamed-run fallback, and cycle-safe descendant counting.

* **Documentation**
  * Added localized label for unnamed team runs (English and Chinese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->