### PR TITLE
feat(desktop): make tray workspace-first and macOS-ready

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -388,7 +388,8 @@ fn api_port() -> u16 {
         .unwrap_or(3210)
 }
 
-const DEFAULT_WORKSPACE_ID: &str = "default";
+pub(crate) const DEFAULT_WORKSPACE_ID: &str = "default";
+pub(crate) const DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY: &str = "routa.desktop.last-workspace-id";
 
 fn escape_html(value: &str) -> String {
     value
@@ -399,17 +400,46 @@ fn escape_html(value: &str) -> String {
         .replace('\'', "&#39;")
 }
 
-fn desktop_workspace_navigation_js(_port: u16, route_suffix: &str) -> String {
+pub(crate) fn desktop_workspace_navigation_js(_port: u16, route_suffix: &str) -> String {
     format!(
         r#"
             (function() {{
                 const match = window.location.pathname.match(/\/workspace\/([^\/]+)/);
-                const workspaceId = match ? match[1] : '{DEFAULT_WORKSPACE_ID}';
+                const query = (() => {{
+                    try {{
+                        const params = new URLSearchParams(window.location.search);
+                        return params.get('workspaceId') || params.get('workspace') || '';
+                    }} catch {{
+                        return '';
+                    }}
+                }})();
+                const persisted = (() => {{
+                    try {{
+                        const value = (window.localStorage.getItem('{DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY}') || '').trim();
+                        return /^[A-Za-z0-9_-]+$/.test(value) ? value : '';
+                    }} catch {{
+                        return '';
+                    }}
+                }})();
+                const workspaceId = match ? match[1] : (query || persisted || '{DEFAULT_WORKSPACE_ID}');
                 window.location.href = `${{window.location.origin}}/workspace/${{workspaceId}}{route_suffix}`;
             }})();
         "#,
     )
 }
+
+#[cfg(target_os = "macos")]
+fn configure_macos_menu_bar_mode(app: &tauri::AppHandle) {
+    if let Err(error) = app.set_activation_policy(tauri::ActivationPolicy::Accessory) {
+        eprintln!("[macos] Failed to set activation policy to Accessory: {error}");
+    }
+    if let Err(error) = app.set_dock_visibility(false) {
+        eprintln!("[macos] Failed to hide Dock icon: {error}");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn configure_macos_menu_bar_mode(_app: &tauri::AppHandle) {}
 
 fn resolve_dual_origin_navigation_js(api_url: &str) -> String {
     format!(
@@ -1057,6 +1087,7 @@ pub fn run() {
             if let Err(e) = tray::setup_tray(app.handle(), &[]) {
                 eprintln!("[tray] Failed to set up system tray: {e}");
             }
+            configure_macos_menu_bar_mode(app.handle());
 
             // Only auto-open devtools in debug builds; use View menu in release builds
             #[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -408,7 +408,8 @@ pub(crate) fn desktop_workspace_navigation_js(_port: u16, route_suffix: &str) ->
                 const query = (() => {{
                     try {{
                         const params = new URLSearchParams(window.location.search);
-                        return params.get('workspaceId') || params.get('workspace') || '';
+                        const raw = params.get('workspaceId') || params.get('workspace') || '';
+                        return /^[A-Za-z0-9_-]+$/.test(raw) ? raw : '';
                     }} catch {{
                         return '';
                     }}
@@ -430,6 +431,9 @@ pub(crate) fn desktop_workspace_navigation_js(_port: u16, route_suffix: &str) ->
 
 #[cfg(target_os = "macos")]
 fn configure_macos_menu_bar_mode(app: &tauri::AppHandle) {
+    if std::env::var("ROUTA_DESKTOP_MENU_BAR_MODE").as_deref() != Ok("1") {
+        return;
+    }
     if let Err(error) = app.set_activation_policy(tauri::ActivationPolicy::Accessory) {
         eprintln!("[macos] Failed to set activation policy to Accessory: {error}");
     }
@@ -1086,8 +1090,9 @@ pub fn run() {
             // `update_tray_github_repos` after loading webhook configs.
             if let Err(e) = tray::setup_tray(app.handle(), &[]) {
                 eprintln!("[tray] Failed to set up system tray: {e}");
+            } else {
+                configure_macos_menu_bar_mode(app.handle());
             }
-            configure_macos_menu_bar_mode(app.handle());
 
             // Only auto-open devtools in debug builds; use View menu in release builds
             #[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -1,8 +1,10 @@
 //! System tray module for Routa Desktop.
 //!
-//! Provides a reusable system tray icon with a dynamic menu that shows
-//! GitHub repository quick-links (Pull Requests, Issues) when webhook
-//! configurations are present.
+//! Provides a reusable system tray icon with workspace-first shortcuts.
+//!
+//! The tray is intentionally optimized for "resume and jump" desktop flows:
+//! sessions, kanban, team runs, and message review stay one click away,
+//! while GitHub repo links remain available as a secondary submenu.
 //!
 //! # Usage
 //!
@@ -15,11 +17,20 @@
 //! ```
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
-use tauri::tray::TrayIconBuilder;
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager};
 
 /// Stable identifier for the single application tray icon.
 pub const TRAY_ID: &str = "routa-tray";
+
+const TRAY_SHOW_HIDE_ID: &str = "tray:show_hide";
+const TRAY_WORKSPACE_SESSIONS_ID: &str = "tray:workspace:sessions";
+const TRAY_WORKSPACE_KANBAN_ID: &str = "tray:workspace:kanban";
+const TRAY_WORKSPACE_TEAM_ID: &str = "tray:workspace:team";
+const TRAY_MESSAGES_ID: &str = "tray:messages";
+const TRAY_SETTINGS_AGENTS_ID: &str = "tray:settings:agents";
+const TRAY_SETTINGS_WEBHOOKS_ID: &str = "tray:settings:webhooks";
+const TRAY_QUIT_ID: &str = "tray:quit";
 
 // ─── Data types ──────────────────────────────────────────────────────────────
 
@@ -69,12 +80,19 @@ impl GitHubRepo {
 /// ```text
 /// Show / Hide Window
 /// ──────────────────
-/// [owner/repo]           (one sub-menu per configured GitHub repo)
-///   ├─ Pull Requests
-///   ├─ Issues
-///   └─ Repository
-/// ──────────────────     (only when repos are present)
-/// Webhook Settings…
+/// Sessions
+/// Kanban Board
+/// Team Runs
+/// Messages
+/// ──────────────────
+/// Settings
+///   ├─ Agent Settings…
+///   └─ Webhook Settings…
+/// GitHub Shortcuts      (optional)
+///   └─ [owner/repo]
+///      ├─ Pull Requests
+///      ├─ Issues
+///      └─ Repository
 /// ──────────────────
 /// Quit Routa
 /// ```
@@ -84,7 +102,7 @@ pub fn build_tray_menu(app: &AppHandle, repos: &[GitHubRepo]) -> tauri::Result<M
     // ── Show / Hide window ──
     let show_hide = MenuItem::with_id(
         app,
-        "tray:show_hide",
+        TRAY_SHOW_HIDE_ID,
         "Show / Hide Window",
         true,
         None::<&str>,
@@ -93,8 +111,52 @@ pub fn build_tray_menu(app: &AppHandle, repos: &[GitHubRepo]) -> tauri::Result<M
 
     menu.append(&PredefinedMenuItem::separator(app)?)?;
 
+    let sessions = MenuItem::with_id(
+        app,
+        TRAY_WORKSPACE_SESSIONS_ID,
+        "Sessions",
+        true,
+        None::<&str>,
+    )?;
+    let kanban = MenuItem::with_id(
+        app,
+        TRAY_WORKSPACE_KANBAN_ID,
+        "Kanban Board",
+        true,
+        None::<&str>,
+    )?;
+    let team_runs =
+        MenuItem::with_id(app, TRAY_WORKSPACE_TEAM_ID, "Team Runs", true, None::<&str>)?;
+    let messages = MenuItem::with_id(app, TRAY_MESSAGES_ID, "Messages", true, None::<&str>)?;
+    menu.append(&sessions)?;
+    menu.append(&kanban)?;
+    menu.append(&team_runs)?;
+    menu.append(&messages)?;
+
+    menu.append(&PredefinedMenuItem::separator(app)?)?;
+
+    let agent_settings = MenuItem::with_id(
+        app,
+        TRAY_SETTINGS_AGENTS_ID,
+        "Agent Settings…",
+        true,
+        None::<&str>,
+    )?;
+    let webhook_settings = MenuItem::with_id(
+        app,
+        TRAY_SETTINGS_WEBHOOKS_ID,
+        "Webhook Settings…",
+        true,
+        None::<&str>,
+    )?;
+    let settings_submenu =
+        Submenu::with_items(app, "Settings", true, &[&agent_settings, &webhook_settings])?;
+    menu.append(&settings_submenu)?;
+
     // ── GitHub repo sub-menus (only when configured) ──
     if !repos.is_empty() {
+        let github_shortcuts = Submenu::new(app, "GitHub Shortcuts", true)?;
+
         for repo in repos {
             let owner_repo = repo.id_prefix();
             let label = if repo.name.is_empty() {
@@ -125,27 +187,17 @@ pub fn build_tray_menu(app: &AppHandle, repos: &[GitHubRepo]) -> tauri::Result<M
                 None::<&str>,
             )?;
 
-            let sub = Submenu::with_items(app, &label, true, &[&pulls, &issues, &repo_link])?;
-            menu.append(&sub)?;
+            let repo_submenu =
+                Submenu::with_items(app, &label, true, &[&pulls, &issues, &repo_link])?;
+            github_shortcuts.append(&repo_submenu)?;
         }
 
+        menu.append(&github_shortcuts)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
     }
 
-    // ── Webhook settings page ──
-    let settings = MenuItem::with_id(
-        app,
-        "tray:settings",
-        "Webhook Settings…",
-        true,
-        None::<&str>,
-    )?;
-    menu.append(&settings)?;
-
-    menu.append(&PredefinedMenuItem::separator(app)?)?;
-
     // ── Quit ──
-    let quit = MenuItem::with_id(app, "tray:quit", "Quit Routa", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, TRAY_QUIT_ID, "Quit Routa", true, None::<&str>)?;
     menu.append(&quit)?;
 
     Ok(menu)
@@ -163,11 +215,25 @@ pub fn setup_tray(app: &AppHandle, repos: &[GitHubRepo]) -> tauri::Result<()> {
     let mut builder = TrayIconBuilder::with_id(TRAY_ID)
         .tooltip("Routa Desktop")
         .menu(&menu)
-        .show_menu_on_left_click(true)
         .on_menu_event(handle_tray_menu_event);
 
     if let Some(icon) = app.default_window_icon() {
         builder = builder.icon(icon.clone());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .icon_as_template(true)
+            .show_menu_on_left_click(false)
+            .on_tray_icon_event(|tray, event| {
+                handle_tray_icon_event(tray.app_handle(), &event);
+            });
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder.show_menu_on_left_click(true);
     }
 
     builder.build(app)?;
@@ -196,10 +262,23 @@ pub fn update_tray_repos(app: &AppHandle, repos: &[GitHubRepo]) -> tauri::Result
 fn handle_tray_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
     let id = event.id().as_ref();
 
+    if id == TRAY_SHOW_HIDE_ID {
+        toggle_main_window(app);
+        return;
+    }
+
+    if let Some(route_suffix) = workspace_route_for_menu_id(id) {
+        navigate_to_workspace_route(app, route_suffix);
+        return;
+    }
+
+    if let Some(path) = absolute_route_for_menu_id(id) {
+        navigate_to_absolute_route(app, path);
+        return;
+    }
+
     match id {
-        "tray:show_hide" => toggle_main_window(app),
-        "tray:settings" => navigate_to(app, "/settings/webhooks"),
-        "tray:quit" => app.exit(0),
+        TRAY_QUIT_ID => app.exit(0),
         id if id.starts_with("tray:gh:") => {
             if let Some(url) = parse_github_menu_id_to_url(id) {
                 open_url_in_browser(app, &url);
@@ -207,6 +286,41 @@ fn handle_tray_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
         }
         _ => {}
     }
+}
+
+fn workspace_route_for_menu_id(id: &str) -> Option<&'static str> {
+    match id {
+        TRAY_WORKSPACE_SESSIONS_ID => Some("/sessions"),
+        TRAY_WORKSPACE_KANBAN_ID => Some("/kanban"),
+        TRAY_WORKSPACE_TEAM_ID => Some("/team"),
+        _ => None,
+    }
+}
+
+fn absolute_route_for_menu_id(id: &str) -> Option<&'static str> {
+    match id {
+        TRAY_MESSAGES_ID => Some("/messages"),
+        TRAY_SETTINGS_AGENTS_ID => Some("/settings/agents"),
+        TRAY_SETTINGS_WEBHOOKS_ID => Some("/settings/webhooks"),
+        _ => None,
+    }
+}
+
+fn handle_tray_icon_event(app: &AppHandle, event: &TrayIconEvent) {
+    if should_open_main_window_for_tray_event(event) {
+        show_main_window(app);
+    }
+}
+
+fn should_open_main_window_for_tray_event(event: &TrayIconEvent) -> bool {
+    matches!(
+        event,
+        TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        }
+    )
 }
 
 /// Parse a `tray:gh:{type}:{owner}/{repo}` menu-event id and return the
@@ -250,14 +364,21 @@ pub fn parse_github_menu_id_to_url(id: &str) -> Option<String> {
 
     Some(url)
 }
+
+fn show_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 /// Toggle the main window's visibility.
 fn toggle_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         if window.is_visible().unwrap_or(false) {
             let _ = window.hide();
         } else {
-            let _ = window.show();
-            let _ = window.set_focus();
+            show_main_window(app);
         }
     }
 }
@@ -267,14 +388,21 @@ fn toggle_main_window(app: &AppHandle) {
 /// # Safety
 /// `path` must be a trusted, internal application path (e.g. `/settings/webhooks`).
 /// It is interpolated directly into JavaScript and must never contain user-controlled data.
-fn navigate_to(app: &AppHandle, path: &str) {
+fn navigate_to_absolute_route(app: &AppHandle, path: &str) {
     if let Some(window) = app.get_webview_window("main") {
         let port = crate::api_port();
         let url = format!("http://127.0.0.1:{port}{path}");
         let js = format!("window.location.href = '{url}';");
         let _ = window.eval(&js);
-        let _ = window.show();
-        let _ = window.set_focus();
+        show_main_window(app);
+    }
+}
+
+fn navigate_to_workspace_route(app: &AppHandle, route_suffix: &str) {
+    if let Some(window) = app.get_webview_window("main") {
+        let js = crate::desktop_workspace_navigation_js(crate::api_port(), route_suffix);
+        let _ = window.eval(&js);
+        show_main_window(app);
     }
 }
 
@@ -291,6 +419,7 @@ fn open_url_in_browser(app: &AppHandle, url: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tauri::{Position, Size};
 
     fn make_repo(name: &str, owner: &str, repo: &str) -> GitHubRepo {
         GitHubRepo {
@@ -369,5 +498,82 @@ mod tests {
             parse_github_menu_id_to_url("tray:gh:pulls:myorg/my-project"),
             Some("https://github.com/myorg/my-project/pulls".to_string())
         );
+    }
+
+    #[test]
+    fn test_workspace_route_for_menu_id() {
+        assert_eq!(
+            workspace_route_for_menu_id(TRAY_WORKSPACE_SESSIONS_ID),
+            Some("/sessions")
+        );
+        assert_eq!(
+            workspace_route_for_menu_id(TRAY_WORKSPACE_KANBAN_ID),
+            Some("/kanban")
+        );
+        assert_eq!(
+            workspace_route_for_menu_id(TRAY_WORKSPACE_TEAM_ID),
+            Some("/team")
+        );
+        assert_eq!(workspace_route_for_menu_id(TRAY_MESSAGES_ID), None);
+    }
+
+    #[test]
+    fn test_absolute_route_for_menu_id() {
+        assert_eq!(
+            absolute_route_for_menu_id(TRAY_MESSAGES_ID),
+            Some("/messages")
+        );
+        assert_eq!(
+            absolute_route_for_menu_id(TRAY_SETTINGS_AGENTS_ID),
+            Some("/settings/agents")
+        );
+        assert_eq!(
+            absolute_route_for_menu_id(TRAY_SETTINGS_WEBHOOKS_ID),
+            Some("/settings/webhooks")
+        );
+        assert_eq!(absolute_route_for_menu_id(TRAY_WORKSPACE_SESSIONS_ID), None);
+    }
+
+    #[test]
+    fn test_should_open_main_window_for_left_click_release() {
+        let event = TrayIconEvent::Click {
+            id: TRAY_ID.into(),
+            position: tauri::PhysicalPosition::new(0.0, 0.0),
+            rect: tauri::Rect {
+                position: Position::Physical(tauri::PhysicalPosition::new(0, 0)),
+                size: Size::Physical(tauri::PhysicalSize::new(12, 12)),
+            },
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+        };
+
+        assert!(should_open_main_window_for_tray_event(&event));
+    }
+
+    #[test]
+    fn test_should_ignore_non_primary_open_clicks() {
+        let right_click = TrayIconEvent::Click {
+            id: TRAY_ID.into(),
+            position: tauri::PhysicalPosition::new(0.0, 0.0),
+            rect: tauri::Rect {
+                position: Position::Physical(tauri::PhysicalPosition::new(0, 0)),
+                size: Size::Physical(tauri::PhysicalSize::new(12, 12)),
+            },
+            button: MouseButton::Right,
+            button_state: MouseButtonState::Up,
+        };
+        let left_down = TrayIconEvent::Click {
+            id: TRAY_ID.into(),
+            position: tauri::PhysicalPosition::new(0.0, 0.0),
+            rect: tauri::Rect {
+                position: Position::Physical(tauri::PhysicalPosition::new(0, 0)),
+                size: Size::Physical(tauri::PhysicalSize::new(12, 12)),
+            },
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Down,
+        };
+
+        assert!(!should_open_main_window_for_tray_event(&right_click));
+        assert!(!should_open_main_window_for_tray_event(&left_down));
     }
 }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -390,9 +390,9 @@ fn toggle_main_window(app: &AppHandle) {
 /// It is interpolated directly into JavaScript and must never contain user-controlled data.
 fn navigate_to_absolute_route(app: &AppHandle, path: &str) {
     if let Some(window) = app.get_webview_window("main") {
-        let port = crate::api_port();
-        let url = format!("http://127.0.0.1:{port}{path}");
-        let js = format!("window.location.href = '{url}';");
+        let js = format!(
+            "window.location.href = `${{window.location.origin}}{path}`;"
+        );
         let _ = window.eval(&js);
         show_main_window(app);
     }

--- a/docs/issues/2026-04-20-desktop-tray-workspace-first-menu-bar-mode.md
+++ b/docs/issues/2026-04-20-desktop-tray-workspace-first-menu-bar-mode.md
@@ -1,0 +1,87 @@
+---
+title: "Desktop tray should expose workspace-first actions and macOS menu bar behavior"
+date: "2026-04-20"
+kind: issue
+status: open
+severity: medium
+area: "desktop"
+tags: ["desktop", "tray", "macos", "tauri", "workspace", "ux"]
+reported_by: "codex"
+related_issues: []
+github_issue: 498
+github_state: open
+github_url: "https://github.com/phodal/routa/issues/498"
+---
+
+# Desktop tray 应该提供 workspace-first 快捷入口和 macOS 菜单栏行为
+
+## What Happened
+
+Routa Desktop 已经有系统托盘实现，但当前菜单结构仍然偏向 webhook / GitHub 快捷链接：一级入口主要是 `Show / Hide Window`、按仓库展开的 `Pull Requests / Issues / Repository`、`Webhook Settings…` 和 `Quit`。
+
+这和产品当前的主工作流不一致。Routa 的核心 surface 已经是 workspace-first，稳定高频能力集中在 `Sessions`、`Kanban`、`Team Runs` 和消息/后台任务，而这些能力没有进入托盘一级入口。
+
+同时，macOS 上的 tray 仍然保持“普通桌面应用 + 托盘菜单”的默认交互：左键会直接弹菜单，没有使用 template icon，也没有切换到 accessory / hidden dock 这类更接近菜单栏应用的运行模式。
+
+结果是：
+
+- Desktop tray 没有成为真正的工作入口，只是一个 GitHub / webhook 附属菜单
+- 用户无法从 tray 快速恢复会话、打开看板、启动 team flow、查看后台消息
+- macOS 上的视觉与交互仍然偏普通 app，而不是 menu bar app
+
+## Expected Behavior
+
+Desktop tray 应该优先暴露 Routa 自己的高频工作流，而不是外部 GitHub 链接。
+
+理想的一阶行为是：
+
+- 一级入口包含 `Sessions`、`Kanban Board`、`Team Runs`、`Messages`
+- `Settings` 保持二级入口，至少包含 `Agent Settings…` 和 `Webhook Settings…`
+- GitHub repo links 保留，但下降为二级 submenu
+- workspace 跳转优先使用当前页面上下文，其次回退到最近活跃 workspace，而不是盲目退回 `default`
+
+macOS 上应进一步增强为菜单栏模式：
+
+- `show_menu_on_left_click(false)`，左键点击图标时直接唤起主窗口
+- tray icon 使用 template 模式，适配深浅色菜单栏
+- application activation policy 切为 `Accessory`
+- Dock icon 隐藏，仅保留菜单栏驻留
+
+## Reproduction Context
+
+- Environment: desktop
+- Platforms:
+  - macOS: tray 存在，但交互和视觉仍然像普通桌面应用
+  - Windows / Linux: tray 存在，但菜单信息架构仍未对齐 workspace-first 主工作流
+- Trigger:
+  1. 启动 Desktop app
+  2. 点击系统托盘图标
+  3. 观察一级菜单仍然偏 GitHub / webhook 快捷链接
+  4. 在 macOS 上左键点击图标，会弹出菜单，而不是唤起主窗口
+
+## Why This Happens
+
+- tray 初始实现围绕 GitHub webhook 配置展开，而不是围绕 workspace/task/session 主流程展开
+- workspace 级导航逻辑主要存在于主窗口内，没有被 tray 复用
+- macOS-specific tray 能力没有在 Rust 侧启用，包括 template icon、left-click custom handling、Accessory activation policy 和 Dock 可见性控制
+
+## Suggested First Slice
+
+- 重构 `apps/desktop/src-tauri/src/tray.rs`，把一级菜单改为 workspace-first actions
+- 保留 GitHub repo links，但移动到 `GitHub Shortcuts` submenu
+- 复用或抽取 workspace-aware 跳转 helper，让 tray 能回到最近活跃 workspace
+- 在 macOS 上启用 `icon_as_template(true)` 和 `show_menu_on_left_click(false)`
+- 为左键点击补一个显式 tray click handler，仅负责唤起主窗口
+- 在 app setup 阶段启用 `ActivationPolicy::Accessory` 和 `set_dock_visibility(false)`
+
+## Relevant Files
+
+- `apps/desktop/src-tauri/src/tray.rs`
+- `apps/desktop/src-tauri/src/lib.rs`
+- `src/client/components/workspace-switcher.tsx`
+- `docs/product-specs/FEATURE_TREE.md`
+
+## Notes
+
+- 这项工作主要是 Desktop surface 的交互和信息架构调整，不改变 Web/Desktop 的领域语义边界
+- Windows / Linux 继续保留 tray 作为系统托盘入口；macOS 再额外增强为更接近 menu bar app 的形态

--- a/src/client/components/workspace-switcher.tsx
+++ b/src/client/components/workspace-switcher.tsx
@@ -3,8 +3,19 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WorkspaceData } from "../hooks/use-workspaces";
 import { useTranslation } from "@/i18n";
+import { normalizeWorkspaceQueryId } from "../utils/workspace-id";
 import { Check, ChevronDown, Folder, Plus, Search } from "lucide-react";
 
+const DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY = "routa.desktop.last-workspace-id";
+
+function hasWorkspaceStorageAccess(): boolean {
+  return (
+    typeof window !== "undefined"
+    && window.localStorage != null
+    && typeof window.localStorage.getItem === "function"
+    && typeof window.localStorage.setItem === "function"
+  );
+}
 
 interface WorkspaceSwitcherProps {
   workspaces: WorkspaceData[];
@@ -70,6 +81,15 @@ export function WorkspaceSwitcher({
     window.addEventListener("keydown", onEscape);
     return () => window.removeEventListener("keydown", onEscape);
   }, [closeDropdown, open]);
+
+  useEffect(() => {
+    const normalizedWorkspaceId = normalizeWorkspaceQueryId(activeWorkspaceId);
+    if (!hasWorkspaceStorageAccess() || !normalizedWorkspaceId) {
+      return;
+    }
+
+    window.localStorage.setItem(DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY, normalizedWorkspaceId);
+  }, [activeWorkspaceId]);
 
   const handleCreate = async () => {
     const title = newTitle.trim();

--- a/src/client/components/workspace-switcher.tsx
+++ b/src/client/components/workspace-switcher.tsx
@@ -83,12 +83,19 @@ export function WorkspaceSwitcher({
   }, [closeDropdown, open]);
 
   useEffect(() => {
-    const normalizedWorkspaceId = normalizeWorkspaceQueryId(activeWorkspaceId);
-    if (!hasWorkspaceStorageAccess() || !normalizedWorkspaceId) {
+    if (!hasWorkspaceStorageAccess()) {
       return;
     }
-
-    window.localStorage.setItem(DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY, normalizedWorkspaceId);
+    const normalizedWorkspaceId = normalizeWorkspaceQueryId(activeWorkspaceId);
+    try {
+      if (normalizedWorkspaceId) {
+        window.localStorage.setItem(DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY, normalizedWorkspaceId);
+      } else {
+        window.localStorage.removeItem(DESKTOP_LAST_WORKSPACE_ID_STORAGE_KEY);
+      }
+    } catch {
+      // localStorage may throw in restricted environments (quota, blocked storage)
+    }
   }, [activeWorkspaceId]);
 
   const handleCreate = async () => {


### PR DESCRIPTION
Closes #498.

## Summary

This PR upgrades the desktop tray from a webhook/GitHub utility menu into a workspace-first Routa entry point.

- promotes `Sessions`, `Kanban Board`, `Team Runs`, and `Messages` into top-level tray actions
- keeps GitHub repo shortcuts, but moves them under a secondary submenu
- persists the last active workspace so tray navigation can recover a meaningful workspace context
- adds macOS-specific tray behavior:
  - `show_menu_on_left_click(false)`
  - left-click focuses the main window instead of opening the menu
  - `icon_as_template(true)` for menu bar icon rendering
  - `ActivationPolicy::Accessory` + hidden Dock mode
- adds a local issue tracker doc at `docs/issues/2026-04-20-desktop-tray-workspace-first-menu-bar-mode.md`

## Validation

- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml tray --lib`
- `npx eslint src/client/components/workspace-switcher.tsx`
- `entrix run --tier fast`
- `entrix run --tier normal`

## Notes

- `entrix run --tier normal` passed with final score `95.0%`.
- The repo-level `ts_test_coverage` check still reports the existing baseline gap (`56.5%` vs required `80%`), but it does not block the overall normal-tier pass in this run.
- No screenshot is attached here because the affected surface is the native tray/menu bar interaction path rather than an in-page web UI capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-first system tray: top-level Sessions, Kanban Board, Team Runs, and Messages; Settings submenu; GitHub links moved to an optional submenu.
  * macOS menu-bar mode: can run as a menu-bar app and hide the Dock icon.
  * App now remembers and restores the last active workspace across launches; storage access is more tolerant of restricted environments.
  * Platform-specific tray left-click behavior for improved window focus/navigation.

* **Documentation**
  * Added issue doc describing workspace-first tray and menu-bar mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->