### PR TITLE
refactor(feature-tree): route generation through rust cli

### DIFF
--- a/crates/routa-cli/src/commands/feature_tree.rs
+++ b/crates/routa-cli/src/commands/feature_tree.rs
@@ -3,15 +3,11 @@
 //! Uses the shared feature-tree script as an execution backend while exposing
 //! a stable Rust CLI surface for preflight, generate, commit, and inspect.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 
-fn workspace_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
-}
+use routa_server::feature_tree::{
+    ensure_feature_tree_success, run_feature_tree_script, workspace_root,
+};
 
 fn repo_root(repo_path: Option<&str>) -> Result<PathBuf, String> {
     let resolved = repo_path
@@ -28,52 +24,6 @@ fn repo_root(repo_path: Option<&str>) -> Result<PathBuf, String> {
     resolved
         .canonicalize()
         .map_err(|e| format!("Failed to resolve repository path: {e}"))
-}
-
-fn feature_tree_script_path() -> Result<PathBuf, String> {
-    let script = workspace_root().join("scripts/docs/feature-tree-generator.ts");
-    if script.exists() {
-        Ok(script)
-    } else {
-        Err(format!(
-            "Feature tree generator script not found at {}",
-            script.display()
-        ))
-    }
-}
-
-fn run_feature_tree_script(
-    args: &[String],
-    working_dir: &Path,
-) -> Result<std::process::Output, String> {
-    let script = feature_tree_script_path()?;
-    let mut command_args = vec!["--import".to_string(), "tsx".to_string()];
-    command_args.push(script.to_string_lossy().to_string());
-    command_args.extend(args.iter().cloned());
-
-    Command::new("node")
-        .args(&command_args)
-        .current_dir(working_dir)
-        .output()
-        .map_err(|e| format!("Failed to run feature tree generator: {e}"))
-}
-
-fn ensure_success(output: &std::process::Output, context: &str) -> Result<(), String> {
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let details = if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        format!("exit code {}", output.status.code().unwrap_or(-1))
-    };
-
-    Err(format!("{context}: {details}"))
 }
 
 fn print_stdout(output: &std::process::Output) {
@@ -93,7 +43,7 @@ pub fn preflight(repo_path: Option<&str>, json_output: bool) -> Result<(), Strin
     ];
 
     let output = run_feature_tree_script(&args, &workspace_root())?;
-    ensure_success(&output, "Feature tree preflight failed")?;
+    ensure_feature_tree_success(&output, "Feature tree preflight failed")?;
 
     if json_output {
         print_stdout(&output);
@@ -151,7 +101,7 @@ pub fn generate(
     }
 
     let output = run_feature_tree_script(&args, &workspace_root())?;
-    ensure_success(&output, "Feature tree generation failed")?;
+    ensure_feature_tree_success(&output, "Feature tree generation failed")?;
 
     if json_output || dry_run {
         print_stdout(&output);
@@ -194,7 +144,7 @@ pub fn commit(
     }
 
     let output = run_feature_tree_script(&args, &workspace_root())?;
-    ensure_success(&output, "Feature tree commit failed")?;
+    ensure_feature_tree_success(&output, "Feature tree commit failed")?;
 
     if json_output {
         print_stdout(&output);
@@ -267,7 +217,8 @@ pub fn inspect(repo_path: Option<&str>) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{feature_tree_script_path, workspace_root};
+    use super::workspace_root;
+    use routa_server::feature_tree::feature_tree_script_path;
 
     #[test]
     fn resolves_workspace_root_to_repo_root() {

--- a/crates/routa-cli/src/commands/feature_tree.rs
+++ b/crates/routa-cli/src/commands/feature_tree.rs
@@ -1,54 +1,205 @@
 //! `routa feature-tree` command group.
 //!
-//! Wraps the TypeScript feature-tree generator script as a first-class
-//! CLI command instead of a hidden script invocation.
+//! Uses the shared feature-tree script as an execution backend while exposing
+//! a stable Rust CLI surface for preflight, generate, commit, and inspect.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Run `feature-tree generate` — scan the repo and produce
-/// `FEATURE_TREE.md` + `feature-tree.index.json`.
-pub fn generate(
-    repo_path: Option<&str>,
-    dry_run: bool,
-) -> Result<(), String> {
-    let repo_root = repo_path
-        .map(std::path::PathBuf::from)
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+}
+
+fn repo_root(repo_path: Option<&str>) -> Result<PathBuf, String> {
+    let resolved = repo_path
+        .map(PathBuf::from)
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
 
-    let script = repo_root.join("scripts/docs/feature-tree-generator.ts");
-    if !script.exists() {
+    if !resolved.exists() {
         return Err(format!(
+            "Repository path does not exist: {}",
+            resolved.display()
+        ));
+    }
+
+    resolved
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve repository path: {e}"))
+}
+
+fn feature_tree_script_path() -> Result<PathBuf, String> {
+    let script = workspace_root().join("scripts/docs/feature-tree-generator.ts");
+    if script.exists() {
+        Ok(script)
+    } else {
+        Err(format!(
             "Feature tree generator script not found at {}",
             script.display()
-        ));
+        ))
+    }
+}
+
+fn run_feature_tree_script(
+    args: &[String],
+    working_dir: &Path,
+) -> Result<std::process::Output, String> {
+    let script = feature_tree_script_path()?;
+    let mut command_args = vec!["--import".to_string(), "tsx".to_string()];
+    command_args.push(script.to_string_lossy().to_string());
+    command_args.extend(args.iter().cloned());
+
+    Command::new("node")
+        .args(&command_args)
+        .current_dir(working_dir)
+        .output()
+        .map_err(|e| format!("Failed to run feature tree generator: {e}"))
+}
+
+fn ensure_success(output: &std::process::Output, context: &str) -> Result<(), String> {
+    if output.status.success() {
+        return Ok(());
     }
 
-    let mut args: Vec<&str> = vec!["--import", "tsx"];
-    let script_str = script.to_string_lossy();
-    args.push(&script_str);
-
-    if !dry_run {
-        args.push("--save");
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
     } else {
-        args.push("--json");
+        format!("exit code {}", output.status.code().unwrap_or(-1))
+    };
+
+    Err(format!("{context}: {details}"))
+}
+
+fn print_stdout(output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.trim().is_empty() {
+        print!("{stdout}");
+    }
+}
+
+pub fn preflight(repo_path: Option<&str>, json_output: bool) -> Result<(), String> {
+    let repo_root = repo_root(repo_path)?;
+    let args = vec![
+        "--mode".to_string(),
+        "preflight".to_string(),
+        "--repo-root".to_string(),
+        repo_root.to_string_lossy().to_string(),
+    ];
+
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    ensure_success(&output, "Feature tree preflight failed")?;
+
+    if json_output {
+        print_stdout(&output);
+        return Ok(());
     }
 
-    eprintln!("🌳 Generating feature tree…");
-    let status = Command::new("node")
-        .args(&args)
-        .current_dir(&repo_root)
-        .status()
-        .map_err(|e| format!("Failed to run feature tree generator: {e}"))?;
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse preflight JSON: {e}"))?;
+    let selected = parsed["selectedScanRoot"].as_str().unwrap_or("unknown");
+    let frameworks = parsed["frameworksDetected"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_else(|| "generic".to_string());
 
-    if !status.success() {
-        return Err(format!(
-            "Feature tree generator exited with status: {}",
-            status.code().unwrap_or(-1)
-        ));
+    println!("🔎 Feature Tree Preflight");
+    println!("  Repo root:        {}", repo_root.display());
+    println!("  Selected root:    {selected}");
+    println!("  Frameworks:       {frameworks}");
+    Ok(())
+}
+
+pub fn generate(
+    repo_path: Option<&str>,
+    scan_root: Option<&str>,
+    dry_run: bool,
+    json_output: bool,
+) -> Result<(), String> {
+    let repo_root = repo_root(repo_path)?;
+    let mut args = vec![
+        "--mode".to_string(),
+        "generate".to_string(),
+        "--repo-root".to_string(),
+        repo_root.to_string_lossy().to_string(),
+    ];
+
+    if let Some(scan_root) = scan_root {
+        args.push("--scan-root".to_string());
+        args.push(scan_root.to_string());
     }
 
-    if !dry_run {
+    args.push(if dry_run {
+        "--dry-run".to_string()
+    } else {
+        "--write".to_string()
+    });
+
+    if !json_output {
+        eprintln!("🌳 Generating feature tree…");
+    }
+
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    ensure_success(&output, "Feature tree generation failed")?;
+
+    if json_output || dry_run {
+        print_stdout(&output);
+    } else {
         eprintln!("✅ Feature tree generated successfully.");
+    }
+
+    Ok(())
+}
+
+pub fn commit(
+    repo_path: Option<&str>,
+    scan_root: Option<&str>,
+    metadata_file: Option<&str>,
+    json_output: bool,
+) -> Result<(), String> {
+    let repo_root = repo_root(repo_path)?;
+    let mut args = vec![
+        "--mode".to_string(),
+        "commit".to_string(),
+        "--repo-root".to_string(),
+        repo_root.to_string_lossy().to_string(),
+    ];
+
+    if let Some(scan_root) = scan_root {
+        args.push("--scan-root".to_string());
+        args.push(scan_root.to_string());
+    }
+
+    if let Some(metadata_file) = metadata_file {
+        let metadata_path = PathBuf::from(metadata_file);
+        if !metadata_path.exists() {
+            return Err(format!(
+                "Metadata file does not exist: {}",
+                metadata_path.display()
+            ));
+        }
+        args.push("--metadata-file".to_string());
+        args.push(metadata_path.to_string_lossy().to_string());
+    }
+
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    ensure_success(&output, "Feature tree commit failed")?;
+
+    if json_output {
+        print_stdout(&output);
+    } else {
+        eprintln!("✅ Feature tree committed successfully.");
     }
 
     Ok(())
@@ -56,9 +207,7 @@ pub fn generate(
 
 /// Run `feature-tree inspect` — read and display the current feature tree index.
 pub fn inspect(repo_path: Option<&str>) -> Result<(), String> {
-    let repo_root = repo_path
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+    let repo_root = repo_root(repo_path)?;
 
     let json_path = repo_root.join("docs/product-specs/feature-tree.index.json");
     let md_path = repo_root.join("docs/product-specs/FEATURE_TREE.md");
@@ -114,4 +263,22 @@ pub fn inspect(repo_path: Option<&str>) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{feature_tree_script_path, workspace_root};
+
+    #[test]
+    fn resolves_workspace_root_to_repo_root() {
+        let root = workspace_root();
+        assert!(root.join("Cargo.toml").exists());
+        assert!(root.join("scripts/docs/feature-tree-generator.ts").exists());
+    }
+
+    #[test]
+    fn resolves_feature_tree_script_from_workspace_root() {
+        let script = feature_tree_script_path().expect("script path should resolve");
+        assert!(script.ends_with("scripts/docs/feature-tree-generator.ts"));
+    }
 }

--- a/crates/routa-cli/src/main.rs
+++ b/crates/routa-cli/src/main.rs
@@ -798,14 +798,44 @@ enum ReviewAction {
 
 #[derive(Subcommand)]
 enum FeatureTreeAction {
+    /// Run feature-tree preflight and print the selected scan root
+    Preflight {
+        /// Repository path to analyze
+        #[arg(long)]
+        repo_path: Option<String>,
+        /// Print the preflight payload as JSON
+        #[arg(long, default_value_t = false)]
+        json_output: bool,
+    },
     /// Scan the repository and generate FEATURE_TREE.md + feature-tree.index.json
     Generate {
         /// Repository path (defaults to current working directory)
         #[arg(long)]
         repo_path: Option<String>,
+        /// Optional scan root within the repository
+        #[arg(long)]
+        scan_root: Option<String>,
         /// Preview what would be generated without writing files
         #[arg(long, default_value_t = false)]
         dry_run: bool,
+        /// Print the generation result as JSON
+        #[arg(long, default_value_t = false)]
+        json_output: bool,
+    },
+    /// Commit FEATURE_TREE artifacts with optional metadata enrichment
+    Commit {
+        /// Repository path (defaults to current working directory)
+        #[arg(long)]
+        repo_path: Option<String>,
+        /// Optional scan root within the repository
+        #[arg(long)]
+        scan_root: Option<String>,
+        /// Optional JSON file containing feature metadata
+        #[arg(long)]
+        metadata_file: Option<String>,
+        /// Print the commit result as JSON
+        #[arg(long, default_value_t = false)]
+        json_output: bool,
     },
     /// Display a summary of the current feature tree index
     Inspect {
@@ -1539,12 +1569,31 @@ async fn main() {
             }
 
             Commands::FeatureTree { action } => match action {
+                FeatureTreeAction::Preflight {
+                    repo_path,
+                    json_output,
+                } => commands::feature_tree::preflight(repo_path.as_deref(), json_output),
                 FeatureTreeAction::Generate {
                     repo_path,
+                    scan_root,
                     dry_run,
+                    json_output,
                 } => commands::feature_tree::generate(
                     repo_path.as_deref(),
+                    scan_root.as_deref(),
                     dry_run,
+                    json_output,
+                ),
+                FeatureTreeAction::Commit {
+                    repo_path,
+                    scan_root,
+                    metadata_file,
+                    json_output,
+                } => commands::feature_tree::commit(
+                    repo_path.as_deref(),
+                    scan_root.as_deref(),
+                    metadata_file.as_deref(),
+                    json_output,
                 ),
                 FeatureTreeAction::Inspect { repo_path } => {
                     commands::feature_tree::inspect(repo_path.as_deref())

--- a/crates/routa-server/src/api/spec.rs
+++ b/crates/routa-server/src/api/spec.rs
@@ -18,7 +18,9 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/issues", get(list_spec_issues))
         .route("/surface-index", get(get_surface_index))
+        .route("/feature-tree/preflight", get(preflight_feature_tree))
         .route("/feature-tree/generate", post(generate_feature_tree))
+        .route("/feature-tree/commit", post(commit_feature_tree))
 }
 
 const SPEC_STATUSES: [&str; 4] = ["open", "investigating", "resolved", "wontfix"];
@@ -522,6 +524,14 @@ async fn get_surface_index(
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct FeatureTreeContextQuery {
+    workspace_id: Option<String>,
+    codebase_id: Option<String>,
+    repo_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct GenerateFeatureTreeRequest {
     workspace_id: Option<String>,
     codebase_id: Option<String>,
@@ -530,25 +540,155 @@ struct GenerateFeatureTreeRequest {
     dry_run: bool,
 }
 
-async fn generate_feature_tree(
-    State(state): State<AppState>,
-    Json(body): Json<GenerateFeatureTreeRequest>,
-) -> Result<Json<JsonValue>, ServerError> {
-    let repo_root = resolve_repo_root(
-        &state,
-        body.workspace_id.as_deref(),
-        body.codebase_id.as_deref(),
-        body.repo_path.as_deref(),
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CommitFeatureTreeRequest {
+    workspace_id: Option<String>,
+    codebase_id: Option<String>,
+    repo_path: Option<String>,
+    scan_root: Option<String>,
+    metadata: Option<JsonValue>,
+}
+
+async fn resolve_feature_tree_repo_root(
+    state: &AppState,
+    workspace_id: Option<&str>,
+    codebase_id: Option<&str>,
+    repo_path: Option<&str>,
+) -> Result<PathBuf, ServerError> {
+    resolve_repo_root(
+        state,
+        workspace_id,
+        codebase_id,
+        repo_path,
         "Missing context: provide workspaceId, codebaseId, or repoPath",
         ResolveRepoRootOptions {
             prefer_current_repo_for_default_workspace: true,
         },
+    )
+    .await
+}
+
+fn resolve_feature_tree_scan_root(
+    repo_root: &Path,
+    scan_root: Option<&str>,
+) -> Result<Option<PathBuf>, ServerError> {
+    let Some(scan_root) = scan_root else {
+        return Ok(None);
+    };
+
+    let resolved = PathBuf::from(scan_root);
+    if !resolved.exists() {
+        return Err(ServerError::BadRequest(
+            "scanRoot does not exist".to_string(),
+        ));
+    }
+
+    let real_scan_root = resolved
+        .canonicalize()
+        .map_err(|e| ServerError::Internal(format!("Failed to resolve scanRoot: {e}")))?;
+    let real_repo_root = repo_root
+        .canonicalize()
+        .map_err(|e| ServerError::Internal(format!("Failed to resolve repoPath: {e}")))?;
+
+    if real_scan_root != real_repo_root && !real_scan_root.starts_with(&real_repo_root) {
+        return Err(ServerError::BadRequest(
+            "scanRoot must be inside the repository".to_string(),
+        ));
+    }
+
+    Ok(Some(real_scan_root))
+}
+
+fn validate_feature_tree_metadata(
+    metadata: Option<JsonValue>,
+) -> Result<Option<JsonValue>, ServerError> {
+    let Some(metadata) = metadata else {
+        return Ok(None);
+    };
+
+    let has_features = metadata
+        .as_object()
+        .and_then(|object| object.get("features"))
+        .and_then(JsonValue::as_array)
+        .is_some();
+
+    if !has_features {
+        return Err(ServerError::BadRequest(
+            "Invalid metadata: must contain a features array".to_string(),
+        ));
+    }
+
+    Ok(Some(metadata))
+}
+
+async fn preflight_feature_tree(
+    State(state): State<AppState>,
+    Query(query): Query<FeatureTreeContextQuery>,
+) -> Result<Json<JsonValue>, ServerError> {
+    let repo_root = resolve_feature_tree_repo_root(
+        &state,
+        query.workspace_id.as_deref(),
+        query.codebase_id.as_deref(),
+        query.repo_path.as_deref(),
+    )
+    .await?;
+
+    let result = tokio::task::spawn_blocking(move || {
+        crate::feature_tree::preflight_feature_tree_json(&repo_root)
+    })
+    .await
+    .map_err(|e| ServerError::Internal(format!("Task join error: {e}")))?
+    .map_err(ServerError::Internal)?;
+
+    Ok(Json(result))
+}
+
+async fn generate_feature_tree(
+    State(state): State<AppState>,
+    body: Result<Json<GenerateFeatureTreeRequest>, axum::extract::rejection::JsonRejection>,
+) -> Result<Json<JsonValue>, ServerError> {
+    let Json(body) = body.map_err(|_| ServerError::BadRequest("Invalid JSON body".to_string()))?;
+    let repo_root = resolve_feature_tree_repo_root(
+        &state,
+        body.workspace_id.as_deref(),
+        body.codebase_id.as_deref(),
+        body.repo_path.as_deref(),
     )
     .await?;
 
     let dry_run = body.dry_run;
     let result = tokio::task::spawn_blocking(move || {
         crate::feature_tree::generate_feature_tree_json(&repo_root, dry_run)
+    })
+    .await
+    .map_err(|e| ServerError::Internal(format!("Task join error: {e}")))?
+    .map_err(ServerError::Internal)?;
+
+    Ok(Json(result))
+}
+
+async fn commit_feature_tree(
+    State(state): State<AppState>,
+    body: Result<Json<CommitFeatureTreeRequest>, axum::extract::rejection::JsonRejection>,
+) -> Result<Json<JsonValue>, ServerError> {
+    let Json(body) = body.map_err(|_| ServerError::BadRequest("Invalid JSON body".to_string()))?;
+    let repo_root = resolve_feature_tree_repo_root(
+        &state,
+        body.workspace_id.as_deref(),
+        body.codebase_id.as_deref(),
+        body.repo_path.as_deref(),
+    )
+    .await?;
+    let scan_root = resolve_feature_tree_scan_root(&repo_root, body.scan_root.as_deref())?;
+    let metadata = validate_feature_tree_metadata(body.metadata)?;
+
+    let result = tokio::task::spawn_blocking(move || {
+        crate::feature_tree::commit_feature_tree_json(
+            &repo_root,
+            scan_root.as_deref(),
+            metadata.as_ref(),
+        )
     })
     .await
     .map_err(|e| ServerError::Internal(format!("Task join error: {e}")))?

--- a/crates/routa-server/src/api/spec.rs
+++ b/crates/routa-server/src/api/spec.rs
@@ -548,50 +548,13 @@ async fn generate_feature_tree(
 
     let dry_run = body.dry_run;
     let result = tokio::task::spawn_blocking(move || {
-        run_feature_tree_generator(&repo_root, dry_run)
+        crate::feature_tree::generate_feature_tree_json(&repo_root, dry_run)
     })
     .await
     .map_err(|e| ServerError::Internal(format!("Task join error: {e}")))?
     .map_err(ServerError::Internal)?;
 
     Ok(Json(result))
-}
-
-/// Run the TypeScript feature-tree generator via Node and return the
-/// JSON result. This is the same script the CLI wraps.
-fn run_feature_tree_generator(repo_root: &Path, dry_run: bool) -> Result<JsonValue, String> {
-    let script = repo_root.join("scripts/docs/feature-tree-generator.ts");
-    if !script.exists() {
-        return Err(format!(
-            "Feature tree generator script not found at {}",
-            script.display()
-        ));
-    }
-
-    let mut args = vec![
-        "--import".to_string(),
-        "tsx".to_string(),
-        script.to_string_lossy().to_string(),
-        "--json".to_string(),
-    ];
-    if !dry_run {
-        args.push("--save".to_string());
-    }
-
-    let output = std::process::Command::new("node")
-        .args(&args)
-        .current_dir(repo_root)
-        .output()
-        .map_err(|e| format!("Failed to run feature tree generator: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Feature tree generator failed: {stderr}"));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str(stdout.trim())
-        .map_err(|e| format!("Failed to parse generator output: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/routa-server/src/feature_tree.rs
+++ b/crates/routa-server/src/feature_tree.rs
@@ -1,0 +1,101 @@
+//! Shared Rust-side feature-tree execution helpers.
+//!
+//! Both the Axum API and the Rust CLI shell out to the same TypeScript
+//! generator. Keeping that process orchestration here preserves one
+//! workspace-root resolution strategy and one error-normalization path.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value as JsonValue;
+
+pub fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+}
+
+pub fn feature_tree_script_path() -> Result<PathBuf, String> {
+    let script = workspace_root().join("scripts/docs/feature-tree-generator.ts");
+    if script.exists() {
+        Ok(script)
+    } else {
+        Err(format!(
+            "Feature tree generator script not found at {}",
+            script.display()
+        ))
+    }
+}
+
+pub fn run_feature_tree_script(args: &[String], working_dir: &Path) -> Result<Output, String> {
+    let script = feature_tree_script_path()?;
+    let mut command_args = vec!["--import".to_string(), "tsx".to_string()];
+    command_args.push(script.to_string_lossy().to_string());
+    command_args.extend(args.iter().cloned());
+
+    Command::new("node")
+        .args(&command_args)
+        .current_dir(working_dir)
+        .output()
+        .map_err(|e| format!("Failed to run feature tree generator: {e}"))
+}
+
+pub fn ensure_feature_tree_success(output: &Output, context: &str) -> Result<(), String> {
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit code {}", output.status.code().unwrap_or(-1))
+    };
+
+    Err(format!("{context}: {details}"))
+}
+
+pub fn parse_feature_tree_json(output: &Output, context: &str) -> Result<JsonValue, String> {
+    ensure_feature_tree_success(output, context)?;
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("{context}: failed to parse JSON output: {e}"))
+}
+
+pub fn generate_feature_tree_json(repo_root: &Path, dry_run: bool) -> Result<JsonValue, String> {
+    let mut args = vec![
+        "--mode".to_string(),
+        "generate".to_string(),
+        "--repo-root".to_string(),
+        repo_root.to_string_lossy().to_string(),
+    ];
+    args.push(if dry_run {
+        "--dry-run".to_string()
+    } else {
+        "--write".to_string()
+    });
+
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    parse_feature_tree_json(&output, "Feature tree generation failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{feature_tree_script_path, workspace_root};
+
+    #[test]
+    fn resolves_workspace_root_to_repo_root() {
+        let root = workspace_root();
+        assert!(root.join("Cargo.toml").exists());
+        assert!(root.join("scripts/docs/feature-tree-generator.ts").exists());
+    }
+
+    #[test]
+    fn resolves_feature_tree_script_from_workspace_root() {
+        let script = feature_tree_script_path().expect("script path should resolve");
+        assert!(script.ends_with("scripts/docs/feature-tree-generator.ts"));
+    }
+}

--- a/crates/routa-server/src/feature_tree.rs
+++ b/crates/routa-server/src/feature_tree.rs
@@ -65,13 +65,23 @@ pub fn parse_feature_tree_json(output: &Output, context: &str) -> Result<JsonVal
         .map_err(|e| format!("{context}: failed to parse JSON output: {e}"))
 }
 
-pub fn generate_feature_tree_json(repo_root: &Path, dry_run: bool) -> Result<JsonValue, String> {
-    let mut args = vec![
+fn feature_tree_args(mode: &str, repo_root: &Path) -> Vec<String> {
+    vec![
         "--mode".to_string(),
-        "generate".to_string(),
+        mode.to_string(),
         "--repo-root".to_string(),
         repo_root.to_string_lossy().to_string(),
-    ];
+    ]
+}
+
+pub fn preflight_feature_tree_json(repo_root: &Path) -> Result<JsonValue, String> {
+    let args = feature_tree_args("preflight", repo_root);
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    parse_feature_tree_json(&output, "Feature tree preflight failed")
+}
+
+pub fn generate_feature_tree_json(repo_root: &Path, dry_run: bool) -> Result<JsonValue, String> {
+    let mut args = feature_tree_args("generate", repo_root);
     args.push(if dry_run {
         "--dry-run".to_string()
     } else {
@@ -80,6 +90,39 @@ pub fn generate_feature_tree_json(repo_root: &Path, dry_run: bool) -> Result<Jso
 
     let output = run_feature_tree_script(&args, &workspace_root())?;
     parse_feature_tree_json(&output, "Feature tree generation failed")
+}
+
+pub fn commit_feature_tree_json(
+    repo_root: &Path,
+    scan_root: Option<&Path>,
+    metadata: Option<&JsonValue>,
+) -> Result<JsonValue, String> {
+    let mut args = feature_tree_args("commit", repo_root);
+
+    if let Some(scan_root) = scan_root {
+        args.push("--scan-root".to_string());
+        args.push(scan_root.to_string_lossy().to_string());
+    }
+
+    let metadata_dir = if let Some(metadata) = metadata {
+        let dir = tempfile::tempdir()
+            .map_err(|e| format!("Failed to create feature tree metadata tempdir: {e}"))?;
+        let metadata_path = dir.path().join("metadata.json");
+        let metadata_json = serde_json::to_vec(metadata)
+            .map_err(|e| format!("Failed to serialize feature tree metadata: {e}"))?;
+        std::fs::write(&metadata_path, metadata_json)
+            .map_err(|e| format!("Failed to write feature tree metadata: {e}"))?;
+        args.push("--metadata-file".to_string());
+        args.push(metadata_path.to_string_lossy().to_string());
+        Some(dir)
+    } else {
+        None
+    };
+
+    let output = run_feature_tree_script(&args, &workspace_root())?;
+    let result = parse_feature_tree_json(&output, "Feature tree commit failed");
+    drop(metadata_dir);
+    result
 }
 
 #[cfg(test)]

--- a/crates/routa-server/src/lib.rs
+++ b/crates/routa-server/src/lib.rs
@@ -39,6 +39,7 @@ pub use routa_core::{AppState, AppStateInner, Database, ServerError};
 
 pub mod api;
 mod application;
+pub mod feature_tree;
 
 // ── Server bootstrap ────────────────────────────────────────────────────
 

--- a/crates/routa-server/tests/rust_api_end_to_end.rs
+++ b/crates/routa-server/tests/rust_api_end_to_end.rs
@@ -1607,6 +1607,126 @@ async fn api_spec_feature_tree_generate_contract() {
         ])
     );
     assert!(payload["warnings"].as_array().is_some());
-    assert!(payload["pagesCount"].as_u64().is_some_and(|count| count > 0));
+    assert!(payload["pagesCount"]
+        .as_u64()
+        .is_some_and(|count| count > 0));
     assert!(payload["apisCount"].as_u64().is_some_and(|count| count > 0));
+}
+
+#[tokio::test]
+async fn api_spec_feature_tree_preflight_contract() {
+    let fixture = ApiFixture::new().await;
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("workspace root")
+        .to_path_buf();
+
+    let response = fixture
+        .client
+        .get(fixture.endpoint("/api/spec/feature-tree/preflight"))
+        .query(&[("repoPath", repo_root.to_string_lossy().to_string())])
+        .send()
+        .await
+        .expect("preflight feature tree");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let payload: Value = response
+        .json()
+        .await
+        .expect("decode feature tree preflight response");
+
+    assert_eq!(
+        payload["repoRoot"],
+        json!(repo_root.to_string_lossy().to_string())
+    );
+    assert_eq!(
+        payload["selectedScanRoot"],
+        json!(repo_root.to_string_lossy().to_string())
+    );
+    let frameworks = payload["frameworksDetected"]
+        .as_array()
+        .expect("frameworksDetected should be an array");
+    assert!(
+        frameworks.iter().any(|f| f.as_str() == Some("nextjs")),
+        "frameworksDetected should include nextjs, got: {frameworks:?}"
+    );
+    assert!(payload["candidateRoots"].as_array().is_some());
+    assert!(payload["warnings"].as_array().is_some());
+}
+
+#[tokio::test]
+async fn api_spec_feature_tree_commit_contract() {
+    let fixture = ApiFixture::new().await;
+    let repo_root = tempfile::tempdir().expect("temp repo");
+
+    write_file(
+        repo_root.path(),
+        "package.json",
+        r#"{"name":"feature-tree-commit-fixture"}"#,
+    );
+    write_file(
+        repo_root.path(),
+        "pages/index.tsx",
+        "export default function Home() { return null; }\n",
+    );
+
+    let response = fixture
+        .client
+        .post(fixture.endpoint("/api/spec/feature-tree/commit"))
+        .json(&json!({
+            "repoPath": repo_root.path().to_string_lossy().to_string(),
+            "metadata": {
+                "schemaVersion": 1,
+                "capabilityGroups": [],
+                "features": [
+                    {
+                        "id": "home",
+                        "name": "Home",
+                        "description": "Generated in rust contract test",
+                        "route": "/"
+                    }
+                ]
+            }
+        }))
+        .send()
+        .await
+        .expect("commit feature tree");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let payload: Value = response
+        .json()
+        .await
+        .expect("decode feature tree commit response");
+
+    assert!(payload["generatedAt"].as_str().is_some());
+    assert_eq!(payload["pagesCount"], json!(1));
+    assert!(payload["warnings"].as_array().is_some());
+
+    let feature_tree_index_path = repo_root
+        .path()
+        .join("docs")
+        .join("product-specs")
+        .join("feature-tree.index.json");
+    let feature_tree_markdown_path = repo_root
+        .path()
+        .join("docs")
+        .join("product-specs")
+        .join("FEATURE_TREE.md");
+    assert!(feature_tree_index_path.exists());
+    assert!(feature_tree_markdown_path.exists());
+
+    let saved_index: Value = serde_json::from_str(
+        &fs::read_to_string(&feature_tree_index_path).expect("read committed feature tree index"),
+    )
+    .expect("decode committed feature tree index");
+    assert_eq!(saved_index["pages"][0]["route"], json!("/"));
+    assert_eq!(
+        saved_index["metadata"]["features"]
+            .as_array()
+            .map(|items| items.len()),
+        Some(1)
+    );
 }

--- a/scripts/docs/feature-tree-generator.ts
+++ b/scripts/docs/feature-tree-generator.ts
@@ -12,6 +12,8 @@ const { INFERRED_GROUP_ID, buildApiLookupKey, normalizeSurfaceMetadata } = featu
 
 type GenerateFeatureTreeArtifacts = (options: {
   repoRoot: string;
+  scanRoot?: string;
+  metadata?: FeatureMetadata | null;
   dryRun?: boolean;
 }) => Promise<{
   generatedAt: string;
@@ -22,23 +24,63 @@ type GenerateFeatureTreeArtifacts = (options: {
   apisCount: number;
 }>;
 
-async function loadGenerateFeatureTreeArtifacts(): Promise<GenerateFeatureTreeArtifacts> {
+type FeatureTreePreflightResult = {
+  repoRoot: string;
+  selectedScanRoot: string;
+  frameworksDetected: string[];
+  adapters: Array<{
+    id: string;
+    confidence: "high" | "medium";
+    signals: string[];
+  }>;
+  candidateRoots: Array<{
+    path: string;
+    kind: string;
+    score: number;
+    surfaceCounts: {
+      pages: number;
+      appRouterApis: number;
+      pagesApis: number;
+      rustApis: number;
+    };
+    adapters: string[];
+    warnings: string[];
+  }>;
+  warnings: string[];
+};
+
+type PreflightFeatureTree = (repoRoot: string) => FeatureTreePreflightResult;
+
+async function loadFeatureTreeGeneratorModule(): Promise<{
+  generateFeatureTree: GenerateFeatureTreeArtifacts;
+  preflightFeatureTree: PreflightFeatureTree;
+}> {
   const moduleUrl = pathToFileURL(fromRoot("src/core/spec/feature-tree-generator.ts")).href;
   const featureTreeGeneratorModule = await import(moduleUrl) as {
     generateFeatureTree?: GenerateFeatureTreeArtifacts;
+    preflightFeatureTree?: PreflightFeatureTree;
     default?: {
       generateFeatureTree?: GenerateFeatureTreeArtifacts;
+      preflightFeatureTree?: PreflightFeatureTree;
     };
   };
 
   const generateFeatureTreeArtifacts = featureTreeGeneratorModule.generateFeatureTree
     ?? featureTreeGeneratorModule.default?.generateFeatureTree;
+  const preflightFeatureTree = featureTreeGeneratorModule.preflightFeatureTree
+    ?? featureTreeGeneratorModule.default?.preflightFeatureTree;
 
   if (typeof generateFeatureTreeArtifacts !== "function") {
     throw new Error("Unable to resolve generateFeatureTree from src/core/spec/feature-tree-generator.ts");
   }
+  if (typeof preflightFeatureTree !== "function") {
+    throw new Error("Unable to resolve preflightFeatureTree from src/core/spec/feature-tree-generator.ts");
+  }
 
-  return generateFeatureTreeArtifacts;
+  return {
+    generateFeatureTree: generateFeatureTreeArtifacts,
+    preflightFeatureTree,
+  };
 }
 
 type RouteInfo = {
@@ -1189,12 +1231,61 @@ function printTreeTable(tree: FeatureTree): void {
   console.log(`📊 Total features: ${countNodes(tree) - 1}`);
 }
 
+function hasArg(argv: string[], flag: string): boolean {
+  return argv.includes(flag);
+}
+
+function getArgValue(argv: string[], flag: string): string | null {
+  const index = argv.indexOf(flag);
+  if (index === -1) {
+    return null;
+  }
+  return argv[index + 1] ?? null;
+}
+
 async function main(): Promise<void> {
-  const args = new Set(process.argv.slice(2));
-  const generateFeatureTreeArtifacts = await loadGenerateFeatureTreeArtifacts();
+  const argv = process.argv.slice(2);
+  const args = new Set(argv);
+  const { generateFeatureTree, preflightFeatureTree } = await loadFeatureTreeGeneratorModule();
+  const mode = getArgValue(argv, "--mode");
+  const repoRoot = path.resolve(getArgValue(argv, "--repo-root") ?? REPO_ROOT);
+  const scanRoot = getArgValue(argv, "--scan-root");
+  const metadataFile = getArgValue(argv, "--metadata-file");
+
+  if (mode === "preflight") {
+    console.log(JSON.stringify(preflightFeatureTree(repoRoot), null, 2));
+    return;
+  }
+
+  if (mode === "generate") {
+    const result = await generateFeatureTree({
+      repoRoot,
+      ...(scanRoot ? { scanRoot: path.resolve(scanRoot) } : {}),
+      dryRun: hasArg(argv, "--dry-run") || !hasArg(argv, "--write"),
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (mode === "commit") {
+    let metadata: FeatureMetadata | null = null;
+    if (metadataFile) {
+      const raw = fs.readFileSync(path.resolve(metadataFile), "utf8");
+      metadata = normalizeFeatureMetadata(JSON.parse(raw));
+    }
+
+    const result = await generateFeatureTree({
+      repoRoot,
+      ...(scanRoot ? { scanRoot: path.resolve(scanRoot) } : {}),
+      ...(metadata ? { metadata } : {}),
+      dryRun: false,
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
 
   if (args.has("--json")) {
-    const result = await generateFeatureTreeArtifacts({
+    const result = await generateFeatureTree({
       repoRoot: REPO_ROOT,
       dryRun: true,
     });
@@ -1218,7 +1309,7 @@ async function main(): Promise<void> {
     return;
   }
   if (args.has("--save")) {
-    const result = await generateFeatureTreeArtifacts({
+    const result = await generateFeatureTree({
       repoRoot: REPO_ROOT,
       dryRun: false,
     });

--- a/src/app/api/spec/feature-tree/commit/__tests__/route.test.ts
+++ b/src/app/api/spec/feature-tree/commit/__tests__/route.test.ts
@@ -1,11 +1,9 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGenerateFeatureTree = vi.fn();
-const mockPreflightFeatureTree = vi.fn();
-vi.mock("@/core/spec/feature-tree-generator", () => ({
-  generateFeatureTree: (...args: unknown[]) => mockGenerateFeatureTree(...args),
-  preflightFeatureTree: (...args: unknown[]) => mockPreflightFeatureTree(...args),
+const mockCommitFeatureTreeViaCli = vi.fn();
+vi.mock("@/core/spec/feature-tree-cli", () => ({
+  commitFeatureTreeViaCli: (...args: unknown[]) => mockCommitFeatureTreeViaCli(...args),
 }));
 
 const mockResolveFitnessRepoRoot = vi.fn();
@@ -34,9 +32,6 @@ import { POST } from "../route";
 describe("POST /api/spec/feature-tree/commit", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPreflightFeatureTree.mockReturnValue({
-      selectedScanRoot: "/tmp/repo/packages/app",
-    });
   });
 
   it("commits generated result with metadata", async () => {
@@ -55,7 +50,7 @@ describe("POST /api/spec/feature-tree/commit", () => {
     };
 
     mockResolveFitnessRepoRoot.mockResolvedValue("/tmp/repo");
-    mockGenerateFeatureTree.mockResolvedValue(fakeResult);
+    mockCommitFeatureTreeViaCli.mockResolvedValue(fakeResult);
 
     const req = new NextRequest("http://localhost/api/spec/feature-tree/commit", {
       method: "POST",
@@ -67,17 +62,15 @@ describe("POST /api/spec/feature-tree/commit", () => {
 
     expect(res.status).toBe(200);
     expect(body).toEqual(fakeResult);
-    expect(mockGenerateFeatureTree).toHaveBeenCalledWith({
+    expect(mockCommitFeatureTreeViaCli).toHaveBeenCalledWith({
       repoRoot: "/tmp/repo",
-      scanRoot: "/tmp/repo/packages/app",
       metadata,
-      dryRun: false,
     });
   });
 
   it("prefers an explicit scanRoot", async () => {
     mockResolveFitnessRepoRoot.mockResolvedValue("/tmp/repo");
-    mockGenerateFeatureTree.mockResolvedValue({ pagesCount: 0, apisCount: 0 });
+    mockCommitFeatureTreeViaCli.mockResolvedValue({ pagesCount: 0, apisCount: 0 });
 
     const req = new NextRequest("http://localhost/api/spec/feature-tree/commit", {
       method: "POST",
@@ -86,13 +79,11 @@ describe("POST /api/spec/feature-tree/commit", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(mockGenerateFeatureTree).toHaveBeenCalledWith({
+    expect(mockCommitFeatureTreeViaCli).toHaveBeenCalledWith({
       repoRoot: "/tmp/repo",
       scanRoot: "/tmp/repo/custom-root",
       metadata: null,
-      dryRun: false,
     });
-    expect(mockPreflightFeatureTree).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid JSON body", async () => {
@@ -120,7 +111,7 @@ describe("POST /api/spec/feature-tree/commit", () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toBe("scanRoot must be inside the repository");
-    expect(mockGenerateFeatureTree).not.toHaveBeenCalled();
+    expect(mockCommitFeatureTreeViaCli).not.toHaveBeenCalled();
   });
 
   it("rejects scanRoot that resolves outside repo via symlink", async () => {
@@ -141,7 +132,7 @@ describe("POST /api/spec/feature-tree/commit", () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toBe("scanRoot must be inside the repository");
-    expect(mockGenerateFeatureTree).not.toHaveBeenCalled();
+    expect(mockCommitFeatureTreeViaCli).not.toHaveBeenCalled();
   });
 
   it("rejects invalid metadata without features array", async () => {
@@ -157,6 +148,6 @@ describe("POST /api/spec/feature-tree/commit", () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toBe("Invalid metadata: must contain a features array");
-    expect(mockGenerateFeatureTree).not.toHaveBeenCalled();
+    expect(mockCommitFeatureTreeViaCli).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/spec/feature-tree/commit/route.ts
+++ b/src/app/api/spec/feature-tree/commit/route.ts
@@ -9,11 +9,8 @@ import {
   normalizeFitnessContextValue,
   resolveFitnessRepoRoot,
 } from "@/core/fitness/repo-root";
-import {
-  type FeatureTreeMetadata,
-  generateFeatureTree,
-  preflightFeatureTree,
-} from "@/core/spec/feature-tree-generator";
+import type { FeatureTreeMetadata } from "@/core/spec/feature-tree-generator";
+import { commitFeatureTreeViaCli } from "@/core/spec/feature-tree-cli";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -73,7 +70,7 @@ export async function POST(request: NextRequest) {
       }
       scanRoot = realScanRoot;
     } else {
-      scanRoot = preflightFeatureTree(repoRoot).selectedScanRoot;
+      scanRoot = "";
     }
 
     let metadata: FeatureTreeMetadata | null = null;
@@ -87,11 +84,10 @@ export async function POST(request: NextRequest) {
       metadata = body.metadata;
     }
 
-    const result = await generateFeatureTree({
+    const result = await commitFeatureTreeViaCli({
       repoRoot,
-      scanRoot,
+      ...(scanRoot ? { scanRoot } : {}),
       metadata,
-      dryRun: false,
     });
     return NextResponse.json(result);
   } catch (error) {

--- a/src/app/api/spec/feature-tree/generate/__tests__/route.test.ts
+++ b/src/app/api/spec/feature-tree/generate/__tests__/route.test.ts
@@ -3,11 +3,9 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
-const mockGenerateFeatureTree = vi.fn();
-const mockPreflightFeatureTree = vi.fn();
-vi.mock("@/core/spec/feature-tree-generator", () => ({
-  generateFeatureTree: (...args: unknown[]) => mockGenerateFeatureTree(...args),
-  preflightFeatureTree: (...args: unknown[]) => mockPreflightFeatureTree(...args),
+const mockGenerateFeatureTreeViaCli = vi.fn();
+vi.mock("@/core/spec/feature-tree-cli", () => ({
+  generateFeatureTreeViaCli: (...args: unknown[]) => mockGenerateFeatureTreeViaCli(...args),
 }));
 
 const mockResolveFitnessRepoRoot = vi.fn();
@@ -36,8 +34,7 @@ describe("POST /api/spec/feature-tree/generate", () => {
       apisCount: 3,
     };
     mockResolveFitnessRepoRoot.mockResolvedValue("/tmp/repo");
-    mockPreflightFeatureTree.mockReturnValue({ selectedScanRoot: "/tmp/repo" });
-    mockGenerateFeatureTree.mockResolvedValue(fakeResult);
+    mockGenerateFeatureTreeViaCli.mockResolvedValue(fakeResult);
 
     const req = new NextRequest("http://localhost/api/spec/feature-tree/generate", {
       method: "POST",
@@ -49,18 +46,15 @@ describe("POST /api/spec/feature-tree/generate", () => {
 
     expect(res.status).toBe(200);
     expect(body).toEqual(fakeResult);
-    expect(mockPreflightFeatureTree).toHaveBeenCalledWith("/tmp/repo");
-    expect(mockGenerateFeatureTree).toHaveBeenCalledWith({
+    expect(mockGenerateFeatureTreeViaCli).toHaveBeenCalledWith({
       repoRoot: "/tmp/repo",
-      scanRoot: "/tmp/repo",
       dryRun: false,
     });
   });
 
   it("passes dryRun option through", async () => {
     mockResolveFitnessRepoRoot.mockResolvedValue("/tmp/repo");
-    mockPreflightFeatureTree.mockReturnValue({ selectedScanRoot: "/tmp/repo/src" });
-    mockGenerateFeatureTree.mockResolvedValue({ pagesCount: 0, apisCount: 0 });
+    mockGenerateFeatureTreeViaCli.mockResolvedValue({ pagesCount: 0, apisCount: 0 });
 
     const req = new NextRequest("http://localhost/api/spec/feature-tree/generate", {
       method: "POST",
@@ -69,9 +63,8 @@ describe("POST /api/spec/feature-tree/generate", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(200);
-    expect(mockGenerateFeatureTree).toHaveBeenCalledWith({
+    expect(mockGenerateFeatureTreeViaCli).toHaveBeenCalledWith({
       repoRoot: "/tmp/repo",
-      scanRoot: "/tmp/repo/src",
       dryRun: true,
     });
   });
@@ -102,8 +95,7 @@ describe("POST /api/spec/feature-tree/generate", () => {
 
   it("returns 500 when generation throws", async () => {
     mockResolveFitnessRepoRoot.mockResolvedValue("/tmp/repo");
-    mockPreflightFeatureTree.mockReturnValue({ selectedScanRoot: "/tmp/repo" });
-    mockGenerateFeatureTree.mockRejectedValue(new Error("scan failed"));
+    mockGenerateFeatureTreeViaCli.mockRejectedValue(new Error("scan failed"));
 
     const req = new NextRequest("http://localhost/api/spec/feature-tree/generate", {
       method: "POST",

--- a/src/app/api/spec/feature-tree/generate/route.ts
+++ b/src/app/api/spec/feature-tree/generate/route.ts
@@ -5,7 +5,7 @@ import {
   normalizeFitnessContextValue,
   resolveFitnessRepoRoot,
 } from "@/core/fitness/repo-root";
-import { generateFeatureTree, preflightFeatureTree } from "@/core/spec/feature-tree-generator";
+import { generateFeatureTreeViaCli } from "@/core/spec/feature-tree-cli";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -45,10 +45,8 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const preflight = preflightFeatureTree(repoRoot);
-    const result = await generateFeatureTree({
+    const result = await generateFeatureTreeViaCli({
       repoRoot,
-      scanRoot: preflight.selectedScanRoot,
       dryRun: body.dryRun ?? false,
     });
     return NextResponse.json(result);

--- a/src/app/api/spec/feature-tree/preflight/__tests__/route.test.ts
+++ b/src/app/api/spec/feature-tree/preflight/__tests__/route.test.ts
@@ -2,8 +2,8 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPreflightFeatureTree = vi.fn();
-vi.mock("@/core/spec/feature-tree-generator", () => ({
-  preflightFeatureTree: (...args: unknown[]) => mockPreflightFeatureTree(...args),
+vi.mock("@/core/spec/feature-tree-cli", () => ({
+  preflightFeatureTreeViaCli: (...args: unknown[]) => mockPreflightFeatureTree(...args),
 }));
 
 const mockResolveFitnessRepoRoot = vi.fn();

--- a/src/app/api/spec/feature-tree/preflight/route.ts
+++ b/src/app/api/spec/feature-tree/preflight/route.ts
@@ -6,7 +6,7 @@ import {
   normalizeFitnessContextValue,
   resolveFitnessRepoRoot,
 } from "@/core/fitness/repo-root";
-import { preflightFeatureTree } from "@/core/spec/feature-tree-generator";
+import { preflightFeatureTreeViaCli } from "@/core/spec/feature-tree-cli";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    return NextResponse.json(preflightFeatureTree(repoRoot));
+    return NextResponse.json(await preflightFeatureTreeViaCli(repoRoot));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/core/spec/feature-tree-cli.ts
+++ b/src/core/spec/feature-tree-cli.ts
@@ -1,0 +1,133 @@
+import { execFile } from "node:child_process";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import type {
+  FeatureTreeMetadata,
+  FeatureTreePreflightResult,
+  GenerateFeatureTreeResult,
+} from "@/core/spec/feature-tree-generator";
+
+const execFileAsync = promisify(execFile);
+const FEATURE_TREE_CLI_MAX_BUFFER = 10 * 1024 * 1024;
+const WORKSPACE_ROOT = process.cwd();
+
+function resolveRustCliInvocation(): { command: string; args: string[] } {
+  const overridePath = process.env.ROUTA_FEATURE_TREE_CLI_PATH?.trim();
+  if (overridePath) {
+    return {
+      command: path.resolve(overridePath),
+      args: [],
+    };
+  }
+
+  const binaryCandidates = [
+    path.join(WORKSPACE_ROOT, "target", "debug", "routa"),
+    path.join(WORKSPACE_ROOT, "target", "release", "routa"),
+  ];
+
+  for (const candidate of binaryCandidates) {
+    if (path.isAbsolute(candidate)) {
+      try {
+        fsSync.accessSync(candidate);
+        return {
+          command: candidate,
+          args: [],
+        };
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return {
+    command: "cargo",
+    args: ["run", "-q", "-p", "routa-cli", "--"],
+  };
+}
+
+async function runFeatureTreeCliJson<T>(args: string[]): Promise<T> {
+  const invocation = resolveRustCliInvocation();
+  const { stdout, stderr } = await execFileAsync(
+    invocation.command,
+    [...invocation.args, "feature-tree", ...args],
+    {
+      cwd: WORKSPACE_ROOT,
+      maxBuffer: FEATURE_TREE_CLI_MAX_BUFFER,
+    },
+  );
+
+  try {
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    const details = stderr.trim() || stdout.trim() || (error instanceof Error ? error.message : String(error));
+    throw new Error(`Feature tree CLI returned invalid JSON: ${details}`, { cause: error });
+  }
+}
+
+export async function preflightFeatureTreeViaCli(repoRoot: string): Promise<FeatureTreePreflightResult> {
+  return runFeatureTreeCliJson<FeatureTreePreflightResult>([
+    "preflight",
+    "--repo-path",
+    repoRoot,
+    "--json-output",
+  ]);
+}
+
+export async function generateFeatureTreeViaCli(options: {
+  repoRoot: string;
+  scanRoot?: string;
+  dryRun?: boolean;
+}): Promise<GenerateFeatureTreeResult> {
+  const args = [
+    "generate",
+    "--repo-path",
+    options.repoRoot,
+    "--json-output",
+  ];
+
+  if (options.scanRoot) {
+    args.push("--scan-root", options.scanRoot);
+  }
+  if (options.dryRun) {
+    args.push("--dry-run");
+  }
+
+  return runFeatureTreeCliJson<GenerateFeatureTreeResult>(args);
+}
+
+export async function commitFeatureTreeViaCli(options: {
+  repoRoot: string;
+  scanRoot?: string;
+  metadata?: FeatureTreeMetadata | null;
+}): Promise<GenerateFeatureTreeResult> {
+  const args = [
+    "commit",
+    "--repo-path",
+    options.repoRoot,
+    "--json-output",
+  ];
+
+  if (options.scanRoot) {
+    args.push("--scan-root", options.scanRoot);
+  }
+
+  let tempDir: string | null = null;
+  try {
+    if (options.metadata != null) {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "feature-tree-cli-"));
+      const metadataPath = path.join(tempDir, "metadata.json");
+      await fs.writeFile(metadataPath, JSON.stringify(options.metadata), "utf8");
+      args.push("--metadata-file", metadataPath);
+    }
+
+    return await runFeatureTreeCliJson<GenerateFeatureTreeResult>(args);
+  } finally {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }
+}


### PR DESCRIPTION
Closes #496.

## Summary

Moves feature-tree generation off the inline Next.js API path and routes it through the Rust CLI / shared Rust execution backend.

- adds JSON-oriented `routa feature-tree` execution modes for `preflight`, `generate`, and `commit`
- switches the Next.js `/api/spec/feature-tree/*` routes to invoke the Rust CLI helper instead of calling the generator inline
- factors the Rust-side feature-tree launcher into a shared `routa-server` module reused by both the CLI and Axum server
- adds Axum parity endpoints for `/api/spec/feature-tree/preflight`, `/generate`, and `/commit`
- preserves Pages Router scanning support already merged with `#499` and keeps the remaining Rust/API work isolated on this branch

## Validation

- `./node_modules/.bin/vitest run src/app/api/spec/feature-tree/preflight/__tests__/route.test.ts src/app/api/spec/feature-tree/generate/__tests__/route.test.ts src/app/api/spec/feature-tree/commit/__tests__/route.test.ts`
- `cargo test -p routa-cli feature_tree`
- `cargo test -p routa-server api_spec_feature_tree_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature-tree generation now supports optional scan root to define custom analysis scopes
  * Added preflight check to validate setup and detect supported frameworks before generation
  * Added commit operation to save feature-tree metadata and generate documentation
  * JSON output support enables programmatic integration across all feature-tree operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->