### PR TITLE
fix(kanban): respect enableAutomaticFallback toggle

### DIFF
--- a/crates/routa-cli/src/commands/fitness.rs
+++ b/crates/routa-cli/src/commands/fitness.rs
@@ -246,22 +246,23 @@ fn resolve_requested_path(requested: &str, cwd: &Path) -> PathBuf {
 
 fn discover_git_toplevel(cwd: &Path) -> Option<PathBuf> {
     // Try `--show-toplevel` first (works in normal repos and worktrees).
-    let output = std::process::Command::new("git")
+    let git_result = std::process::Command::new("git")
         .arg("-C")
         .arg(cwd)
         .arg("rev-parse")
         .arg("--show-toplevel")
-        .output()
-        .ok()?;
+        .output();
 
-    if output.status.success() {
-        let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !raw.is_empty() {
-            return Some(PathBuf::from(raw));
+    if let Ok(output) = git_result {
+        if output.status.success() {
+            let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !raw.is_empty() {
+                return Some(PathBuf::from(raw));
+            }
         }
     }
 
-    // In a bare repo `--show-toplevel` fails. Fall back to walking ancestors
+    // In a bare repo `--show-toplevel` fails or git unavailable. Fall back to walking ancestors
     // of `cwd` looking for a known workspace marker file.
     let mut dir = cwd.to_path_buf();
     loop {

--- a/src/core/kanban/__tests__/effective-task-automation.test.ts
+++ b/src/core/kanban/__tests__/effective-task-automation.test.ts
@@ -347,5 +347,31 @@ describe("resolveEffectiveTaskAutomation", () => {
       expect(resolved.steps).toHaveLength(1);
       expect(resolved.steps[0].id).toBe("card-override");
     });
+
+    it("does not append fallback steps when automatic fallback is disabled", () => {
+      const resolved = resolveEffectiveTaskAutomation(
+        {
+          columnId: "dev",
+          assignedProvider: "claude",
+          assignedRole: "DEVELOPER",
+          fallbackAgentChain: [{ providerId: "codex", role: "DEVELOPER" }],
+          enableAutomaticFallback: false,
+        },
+        [
+          {
+            id: "dev",
+            automation: {
+              enabled: true,
+              providerId: "default",
+              role: "DEVELOPER",
+            },
+          },
+        ],
+      );
+
+      expect(resolved.source).toBe("card");
+      expect(resolved.steps).toHaveLength(1);
+      expect(resolved.steps[0].id).toBe("card-override");
+    });
   });
 });

--- a/src/core/kanban/effective-task-automation.ts
+++ b/src/core/kanban/effective-task-automation.ts
@@ -141,7 +141,9 @@ function buildFallbackSteps(chain?: FallbackAgent[]): KanbanAutomationStep[] {
 }
 
 export function resolveEffectiveTaskAutomation(
-  task: TaskAutomationFields,
+  task: TaskAutomationFields & {
+    enableAutomaticFallback?: boolean;
+  },
   boardColumns: ColumnAutomationFields[] = [],
   resolveSpecialist?: AutomationSpecialistResolver,
   options: ResolveAutomationOptions = {},
@@ -156,6 +158,9 @@ export function resolveEffectiveTaskAutomation(
   const hasCardOverride = hasTaskOverrideFields
     && !resolvedLaneSteps.some((step) => taskAssignmentMatchesStep(task, step));
   const canRun = hasCardOverride || Boolean(enabledLaneAutomation);
+  const fallbackSteps = task.enableAutomaticFallback
+    ? buildFallbackSteps(task.fallbackAgentChain)
+    : [];
   const cardOverrideSteps = hasCardOverride
     ? [{
       id: "card-override",
@@ -164,7 +169,7 @@ export function resolveEffectiveTaskAutomation(
       specialistId: task.assignedSpecialistId,
       specialistName: task.assignedSpecialistName,
     },
-    ...buildFallbackSteps(task.fallbackAgentChain),
+    ...fallbackSteps,
     ]
         .map((step) => resolveKanbanAutomationStep(step, resolveSpecialist, options))
         .filter((step): step is ResolvedKanbanAutomationStep => Boolean(step))


### PR DESCRIPTION
## Summary

Fixes CodeRabbit review comments from PR #497:

1. **effective-task-automation.ts** - Only append fallback steps when `enableAutomaticFallback` is `true`, respecting the user's toggle setting
2. **effective-task-automation.test.ts** - Adds test case for disabled toggle 
3. **fitness.rs** - Uses explicit `Result` handling instead of `.ok()` to allow ancestor fallback when git spawn fails

## Changes

- Add `enableAutomaticFallback` to task type in `resolveEffectiveTaskAutomation`
- Gate fallback steps behind toggle check
- Add test: "does not append fallback steps when automatic fallback is disabled"
- Fix `discover_git_toplevel` to handle git spawn errors gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling when git detection is unavailable, ensuring the system gracefully continues with alternative resolution methods.

* **New Features**
  * Added ability to disable automatic fallback steps in task automation workflows through a new configuration option.

* **Tests**
  * Added test coverage for disabled automatic fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->