### PR TITLE
chore(fitness): add harness budget runner

### DIFF
--- a/crates/routa-cli/src/commands/harness.rs
+++ b/crates/routa-cli/src/commands/harness.rs
@@ -6,6 +6,8 @@ use routa_core::harness_template;
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
+use crate::commands::harness_budget::{run_budget, FileBudgetArgs};
+
 use self::engineering::{
     evaluate_harness_engineering, format_harness_engineering_report,
     persist_harness_engineering_report, HarnessEngineeringOptions, DEFAULT_REPORT_RELATIVE_PATH,
@@ -17,6 +19,8 @@ pub enum HarnessAction {
     Detect(HarnessDetectArgs),
     /// Evaluate harness engineering readiness and emit dry-run evolution guidance
     Evolve(HarnessEvolveArgs),
+    /// Enforce long-file budgets and frozen hotspot ceilings
+    Budget(FileBudgetArgs),
     /// Manage harness templates
     Template {
         #[command(subcommand)]
@@ -170,6 +174,10 @@ pub async fn run(db_path: &str, action: HarnessAction) -> Result<(), String> {
     match action {
         HarnessAction::Detect(args) => run_detect(&args),
         HarnessAction::Evolve(args) => run_evolve(db_path, &args).await,
+        HarnessAction::Budget(args) => {
+            let repo_root = resolve_repo_root(args.repo_root.as_deref())?;
+            run_budget(&args, &repo_root)
+        }
         HarnessAction::Template { action } => run_template(action),
     }
 }

--- a/crates/routa-cli/src/commands/harness_budget.rs
+++ b/crates/routa-cli/src/commands/harness_budget.rs
@@ -17,6 +17,7 @@ const DEFAULT_EXCLUDED_PARTS: &[&str] = &[
     "/bundled/",
 ];
 
+/// Evaluate repository files against the configured long-file budgets.
 #[derive(Args, Debug, Clone)]
 pub struct FileBudgetArgs {
     /// Repository root to inspect. Defaults to the current git toplevel.
@@ -81,6 +82,7 @@ enum ViolationKind {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Structured detail for one file that exceeded its allowed budget.
 pub struct FileBudgetViolation {
     relative_path: String,
     line_count: usize,
@@ -93,6 +95,7 @@ pub struct FileBudgetViolation {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Structured output for a complete budget run.
 pub struct FileBudgetReport {
     repo_root: String,
     config_path: String,
@@ -104,6 +107,7 @@ pub struct FileBudgetReport {
     warnings: Vec<String>,
 }
 
+/// Run the long-file budget checker and emit either text or JSON output.
 pub fn run_budget(args: &FileBudgetArgs, repo_root: &Path) -> Result<(), String> {
     let report = build_budget_report(args, repo_root)?;
 
@@ -117,6 +121,13 @@ pub fn run_budget(args: &FileBudgetArgs, repo_root: &Path) -> Result<(), String>
         print_text_report(&report);
     }
 
+    if !report.violations.is_empty() {
+        return Err(format!(
+            "found {} file budget violation(s)",
+            report.violations.len()
+        ));
+    }
+
     Ok(())
 }
 
@@ -124,12 +135,14 @@ fn build_budget_report(
     args: &FileBudgetArgs,
     repo_root: &Path,
 ) -> Result<FileBudgetReport, String> {
-    let mut warnings = Vec::new();
     let config_path = resolve_config_path(repo_root, &args.config);
-    let config = load_config(&config_path, &mut warnings);
+    let config = load_config(&config_path)?;
 
     let mut candidates = if args.changed_only {
         list_changed_files(repo_root, &args.base)?
+            .into_iter()
+            .filter(|path| should_include_file(path, &config))
+            .collect()
     } else {
         list_all_budgeted_files(repo_root, &config)
     };
@@ -153,7 +166,7 @@ fn build_budget_report(
         overrides_only: args.overrides_only,
         candidate_count: candidates.len(),
         violations,
-        warnings,
+        warnings: Vec::new(),
     })
 }
 
@@ -197,28 +210,16 @@ fn resolve_config_path(repo_root: &Path, config: &str) -> PathBuf {
     }
 }
 
-fn load_config(config_path: &Path, warnings: &mut Vec<String>) -> NormalizedFileBudgetConfig {
-    if !config_path.exists() {
-        warnings.push(format!(
-            "Missing {}; using default long-file budget thresholds.",
+fn load_config(config_path: &Path) -> Result<NormalizedFileBudgetConfig, String> {
+    let raw = fs::read_to_string(config_path)
+        .map_err(|error| format!("failed to read {}: {error}", config_path.display()))?;
+    let config = serde_json::from_str::<FileBudgetConfig>(&raw).map_err(|error| {
+        format!(
+            "invalid file budget config {}: {error}",
             config_path.display()
-        ));
-        return default_config();
-    }
-
-    match fs::read_to_string(config_path)
-        .ok()
-        .and_then(|raw| serde_json::from_str::<FileBudgetConfig>(&raw).ok())
-    {
-        Some(config) => normalize_config(config),
-        None => {
-            warnings.push(format!(
-                "Failed to parse {}; using default long-file budget thresholds.",
-                config_path.display()
-            ));
-            default_config()
-        }
-    }
+        )
+    })?;
+    Ok(normalize_config(config))
 }
 
 fn default_config() -> NormalizedFileBudgetConfig {
@@ -252,16 +253,33 @@ fn normalize_config(config: FileBudgetConfig) -> NormalizedFileBudgetConfig {
         normalized.default_max_lines = default_max_lines;
     }
     if let Some(include_roots) = config.include_roots {
-        normalized.include_roots = include_roots;
+        normalized.include_roots = include_roots
+            .into_iter()
+            .map(|value| normalize_root_path(&value))
+            .filter(|value| !value.is_empty())
+            .collect();
     }
     if let Some(extensions) = config.extensions {
-        normalized.extensions = extensions;
+        normalized.extensions = extensions
+            .into_iter()
+            .map(|value| normalize_extension(&value))
+            .filter(|value| !value.is_empty())
+            .collect();
     }
     if let Some(extension_max_lines) = config.extension_max_lines {
-        normalized.extension_max_lines.extend(extension_max_lines);
+        normalized.extension_max_lines.extend(
+            extension_max_lines
+                .into_iter()
+                .map(|(key, value)| (normalize_extension(&key), value))
+                .filter(|(key, _)| !key.is_empty()),
+        );
     }
     if let Some(excluded_parts) = config.excluded_parts {
-        normalized.excluded_parts = excluded_parts;
+        normalized.excluded_parts = excluded_parts
+            .into_iter()
+            .map(|value| normalize_path_sequence(&value))
+            .filter(|value| !value.is_empty())
+            .collect();
     }
     if let Some(overrides) = config.overrides {
         normalized.overrides = overrides;
@@ -272,13 +290,20 @@ fn normalize_config(config: FileBudgetConfig) -> NormalizedFileBudgetConfig {
 fn list_changed_files(repo_root: &Path, base_ref: &str) -> Result<Vec<String>, String> {
     let output = git_output(
         repo_root,
-        ["diff", "--name-only", "--diff-filter=ACMR", base_ref, "--"],
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "--end-of-options",
+            base_ref,
+            "--",
+        ],
     )?;
     Ok(output
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
-        .map(|line| line.replace('\\', "/"))
+        .map(normalize_relative_path)
         .collect())
 }
 
@@ -287,39 +312,44 @@ fn list_all_budgeted_files(repo_root: &Path, config: &NormalizedFileBudgetConfig
     for root in &config.include_roots {
         let absolute_root = repo_root.join(root);
         if absolute_root.is_dir() {
-            walk_files(&absolute_root, &mut collected);
+            walk_files(repo_root, &absolute_root, config, &mut collected);
         }
     }
 
     collected
-        .into_iter()
-        .filter_map(|absolute_path| {
-            absolute_path
-                .strip_prefix(repo_root)
-                .ok()
-                .map(|relative| relative.to_string_lossy().replace('\\', "/"))
-        })
-        .filter(|relative_path| should_include_file(relative_path, config))
-        .collect()
 }
 
-fn walk_files(dir: &Path, collected: &mut Vec<PathBuf>) {
+fn walk_files(
+    repo_root: &Path,
+    dir: &Path,
+    config: &NormalizedFileBudgetConfig,
+    collected: &mut Vec<String>,
+) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
 
     for entry in entries.flatten() {
         let path = entry.path();
+        let Ok(relative_path) = path.strip_prefix(repo_root) else {
+            continue;
+        };
+        let normalized_relative_path =
+            normalize_relative_path(relative_path.to_string_lossy().as_ref());
+        if is_excluded_path(&normalized_relative_path, config) {
+            continue;
+        }
+
         if path.is_dir() {
-            walk_files(&path, collected);
-        } else if path.is_file() {
-            collected.push(path);
+            walk_files(repo_root, &path, config, collected);
+        } else if path.is_file() && should_include_file(&normalized_relative_path, config) {
+            collected.push(normalized_relative_path);
         }
     }
 }
 
 fn should_include_file(relative_path: &str, config: &NormalizedFileBudgetConfig) -> bool {
-    let normalized_path = relative_path.replace('\\', "/");
+    let normalized_path = normalize_relative_path(relative_path);
     let extension = Path::new(&normalized_path)
         .extension()
         .map(|value| format!(".{}", value.to_string_lossy().to_lowercase()))
@@ -341,10 +371,7 @@ fn should_include_file(relative_path: &str, config: &NormalizedFileBudgetConfig)
         return false;
     }
 
-    config
-        .excluded_parts
-        .iter()
-        .all(|excluded| !normalized_path.contains(excluded))
+    !is_excluded_path(&normalized_path, config)
 }
 
 fn evaluate_file(
@@ -424,7 +451,8 @@ fn find_override<'a>(
 }
 
 fn read_tracked_file(repo_root: &Path, base_ref: &str, relative_path: &str) -> Option<String> {
-    git_output(repo_root, ["show", &format!("{base_ref}:{relative_path}")]).ok()
+    let revision = format!("{base_ref}:{relative_path}");
+    git_output(repo_root, ["show", "--end-of-options", &revision]).ok()
 }
 
 fn git_output<const N: usize>(repo_root: &Path, args: [&str; N]) -> Result<String, String> {
@@ -450,9 +478,67 @@ fn count_lines(source: &str) -> usize {
     }
 }
 
+fn normalize_extension(value: &str) -> String {
+    let trimmed = value.trim().to_lowercase();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if trimmed.starts_with('.') {
+        trimmed
+    } else {
+        format!(".{trimmed}")
+    }
+}
+
+fn normalize_root_path(value: &str) -> String {
+    normalize_path_sequence(value)
+}
+
+fn normalize_relative_path(value: &str) -> String {
+    normalize_path_sequence(value)
+}
+
+fn normalize_path_sequence(value: &str) -> String {
+    value
+        .replace('\\', "/")
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn is_excluded_path(relative_path: &str, config: &NormalizedFileBudgetConfig) -> bool {
+    config
+        .excluded_parts
+        .iter()
+        .any(|excluded| path_contains_sequence(relative_path, excluded))
+}
+
+fn path_contains_sequence(path: &str, needle: &str) -> bool {
+    let path_parts = path_segments(path);
+    let needle_segments = path_segments(needle);
+
+    if needle_segments.is_empty() || needle_segments.len() > path_parts.len() {
+        return false;
+    }
+
+    path_parts
+        .windows(needle_segments.len())
+        .any(|window| window == needle_segments.as_slice())
+}
+
+fn path_segments(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{build_budget_report, FileBudgetArgs, ViolationKind, DEFAULT_CONFIG_PATH};
+    use super::{
+        build_budget_report, run_budget, FileBudgetArgs, ViolationKind, DEFAULT_CONFIG_PATH,
+    };
     use serde_json::json;
     use std::fs;
     use std::path::Path;
@@ -504,6 +590,43 @@ mod tests {
     }
 
     #[test]
+    fn changed_only_candidate_count_ignores_non_budget_files() {
+        let repo = init_git_repo();
+        write_budget_config(
+            repo.path(),
+            json!({
+                "default_max_lines": 10,
+                "include_roots": ["src"],
+                "extensions": [".ts"],
+                "extension_max_lines": { ".ts": 10 },
+                "overrides": []
+            }),
+        );
+        write_file(repo.path(), "README.md", 1);
+        write_file(repo.path(), "src/app.ts", 1);
+        commit_all(repo.path(), "baseline");
+
+        write_file(repo.path(), "README.md", 2);
+        write_file(repo.path(), "src/app.ts", 2);
+
+        let report = build_budget_report(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: true,
+                base: "HEAD".to_string(),
+                overrides_only: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("budget report should build");
+
+        assert_eq!(report.candidate_count, 1);
+        assert!(report.violations.is_empty());
+    }
+
+    #[test]
     fn overrides_only_reports_only_configured_hotspots() {
         let repo = init_git_repo();
         write_budget_config(
@@ -547,6 +670,102 @@ mod tests {
             violation.violation_kind,
             ViolationKind::OverrideBudgetExceeded
         );
+    }
+
+    #[test]
+    fn invalid_budget_config_fails_fast() {
+        let repo = init_git_repo();
+        let config_path = repo.path().join(DEFAULT_CONFIG_PATH);
+        fs::create_dir_all(
+            config_path
+                .parent()
+                .expect("budget config should have a parent directory"),
+        )
+        .expect("create config dir");
+        fs::write(&config_path, "{ not-valid-json").expect("write invalid config");
+
+        let error = build_budget_report(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: false,
+                base: "HEAD".to_string(),
+                overrides_only: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect_err("invalid config should fail");
+
+        assert!(error.contains("invalid file budget config"));
+        assert!(error.contains("docs/fitness/file_budgets.json"));
+    }
+
+    #[test]
+    fn run_budget_returns_error_when_violations_exist() {
+        let repo = init_git_repo();
+        write_budget_config(
+            repo.path(),
+            json!({
+                "default_max_lines": 1,
+                "include_roots": ["src"],
+                "extensions": [".ts"],
+                "extension_max_lines": { ".ts": 1 },
+                "overrides": []
+            }),
+        );
+        write_file(repo.path(), "src/app.ts", 2);
+
+        let error = run_budget(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: false,
+                base: "HEAD".to_string(),
+                overrides_only: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect_err("violations should fail the command");
+
+        assert_eq!(error, "found 1 file budget violation(s)");
+    }
+
+    #[test]
+    fn normalize_config_accepts_common_extension_and_path_variants() {
+        let repo = init_git_repo();
+        write_budget_config(
+            repo.path(),
+            json!({
+                "default_max_lines": 10,
+                "include_roots": ["src/"],
+                "extensions": ["TS"],
+                "extension_max_lines": { "ts": 1 },
+                "excluded_parts": ["/generated/"],
+                "overrides": []
+            }),
+        );
+        write_file(repo.path(), "src/Mixed.TS", 2);
+        write_file(repo.path(), "src/generated/skip.TS", 4);
+
+        let report = build_budget_report(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: false,
+                base: "HEAD".to_string(),
+                overrides_only: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("budget report should build");
+
+        assert_eq!(report.candidate_count, 1);
+        assert_eq!(report.violations.len(), 1);
+        assert_eq!(report.violations[0].relative_path, "src/Mixed.TS");
+        assert_eq!(report.violations[0].budget_limit, 1);
     }
 
     fn init_git_repo() -> TempDir {

--- a/crates/routa-cli/src/commands/harness_budget.rs
+++ b/crates/routa-cli/src/commands/harness_budget.rs
@@ -1,0 +1,607 @@
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DEFAULT_CONFIG_PATH: &str = "docs/fitness/file_budgets.json";
+const DEFAULT_MAX_LINES: usize = 1600;
+const DEFAULT_INCLUDE_ROOTS: &[&str] = &["src", "apps", "crates"];
+const DEFAULT_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".rs"];
+const DEFAULT_EXCLUDED_PARTS: &[&str] = &[
+    "/node_modules/",
+    "/target/",
+    "/.next/",
+    "/_next/",
+    "/bundled/",
+];
+
+#[derive(Args, Debug, Clone)]
+pub struct FileBudgetArgs {
+    /// Repository root to inspect. Defaults to the current git toplevel.
+    #[arg(long)]
+    pub repo_root: Option<String>,
+
+    /// Budget config path, relative to repo root unless absolute.
+    #[arg(long, default_value = DEFAULT_CONFIG_PATH)]
+    pub config: String,
+
+    /// Only inspect files changed relative to the given base ref.
+    #[arg(long, default_value_t = false)]
+    pub changed_only: bool,
+
+    /// Git base ref used with --changed-only.
+    #[arg(long, default_value = "HEAD")]
+    pub base: String,
+
+    /// Only inspect files explicitly listed in the config overrides section.
+    #[arg(long, default_value_t = false)]
+    pub overrides_only: bool,
+
+    /// Emit JSON instead of the default text summary.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FileBudgetOverride {
+    path: Option<String>,
+    max_lines: Option<usize>,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FileBudgetConfig {
+    default_max_lines: Option<usize>,
+    include_roots: Option<Vec<String>>,
+    extensions: Option<Vec<String>>,
+    extension_max_lines: Option<HashMap<String, usize>>,
+    excluded_parts: Option<Vec<String>>,
+    overrides: Option<Vec<FileBudgetOverride>>,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedFileBudgetConfig {
+    default_max_lines: usize,
+    include_roots: Vec<String>,
+    extensions: Vec<String>,
+    extension_max_lines: HashMap<String, usize>,
+    excluded_parts: Vec<String>,
+    overrides: Vec<FileBudgetOverride>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ViolationKind {
+    BudgetExceeded,
+    BaselineFrozenGrowth,
+    OverrideBudgetExceeded,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileBudgetViolation {
+    relative_path: String,
+    line_count: usize,
+    budget_limit: usize,
+    allowed_max_lines: usize,
+    baseline_line_count: Option<usize>,
+    reason: Option<String>,
+    violation_kind: ViolationKind,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileBudgetReport {
+    repo_root: String,
+    config_path: String,
+    changed_only: bool,
+    base_ref: String,
+    overrides_only: bool,
+    candidate_count: usize,
+    violations: Vec<FileBudgetViolation>,
+    warnings: Vec<String>,
+}
+
+pub fn run_budget(args: &FileBudgetArgs, repo_root: &Path) -> Result<(), String> {
+    let report = build_budget_report(args, repo_root)?;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .map_err(|error| format!("failed to serialize budget report: {error}"))?
+        );
+    } else {
+        print_text_report(&report);
+    }
+
+    Ok(())
+}
+
+fn build_budget_report(
+    args: &FileBudgetArgs,
+    repo_root: &Path,
+) -> Result<FileBudgetReport, String> {
+    let mut warnings = Vec::new();
+    let config_path = resolve_config_path(repo_root, &args.config);
+    let config = load_config(&config_path, &mut warnings);
+
+    let mut candidates = if args.changed_only {
+        list_changed_files(repo_root, &args.base)?
+    } else {
+        list_all_budgeted_files(repo_root, &config)
+    };
+    candidates.sort();
+
+    let mut violations = candidates
+        .iter()
+        .filter_map(|relative_path| evaluate_file(repo_root, relative_path, &config, args))
+        .collect::<Vec<_>>();
+    violations.sort_by(|left, right| {
+        left.relative_path
+            .cmp(&right.relative_path)
+            .then_with(|| right.line_count.cmp(&left.line_count))
+    });
+
+    Ok(FileBudgetReport {
+        repo_root: repo_root.display().to_string(),
+        config_path: config_path.display().to_string(),
+        changed_only: args.changed_only,
+        base_ref: args.base.clone(),
+        overrides_only: args.overrides_only,
+        candidate_count: candidates.len(),
+        violations,
+        warnings,
+    })
+}
+
+fn print_text_report(report: &FileBudgetReport) {
+    println!("file_budget_candidates: {}", report.candidate_count);
+    println!("file_budget_violations: {}", report.violations.len());
+
+    for warning in &report.warnings {
+        println!("warning: {warning}");
+    }
+
+    for violation in &report.violations {
+        let baseline = violation
+            .baseline_line_count
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "n/a".to_string());
+        let reason = violation
+            .reason
+            .as_ref()
+            .map(|value| format!(" reason={value}"))
+            .unwrap_or_default();
+        println!(
+            "{}: lines={} allowed={} budget={} baseline={} kind={:?}{}",
+            violation.relative_path,
+            violation.line_count,
+            violation.allowed_max_lines,
+            violation.budget_limit,
+            baseline,
+            violation.violation_kind,
+            reason
+        );
+    }
+}
+
+fn resolve_config_path(repo_root: &Path, config: &str) -> PathBuf {
+    let config_path = Path::new(config);
+    if config_path.is_absolute() {
+        config_path.to_path_buf()
+    } else {
+        repo_root.join(config_path)
+    }
+}
+
+fn load_config(config_path: &Path, warnings: &mut Vec<String>) -> NormalizedFileBudgetConfig {
+    if !config_path.exists() {
+        warnings.push(format!(
+            "Missing {}; using default long-file budget thresholds.",
+            config_path.display()
+        ));
+        return default_config();
+    }
+
+    match fs::read_to_string(config_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<FileBudgetConfig>(&raw).ok())
+    {
+        Some(config) => normalize_config(config),
+        None => {
+            warnings.push(format!(
+                "Failed to parse {}; using default long-file budget thresholds.",
+                config_path.display()
+            ));
+            default_config()
+        }
+    }
+}
+
+fn default_config() -> NormalizedFileBudgetConfig {
+    let mut extension_max_lines = HashMap::new();
+    extension_max_lines.insert(".rs".to_string(), DEFAULT_MAX_LINES);
+    extension_max_lines.insert(".ts".to_string(), DEFAULT_MAX_LINES);
+    extension_max_lines.insert(".tsx".to_string(), DEFAULT_MAX_LINES);
+
+    NormalizedFileBudgetConfig {
+        default_max_lines: DEFAULT_MAX_LINES,
+        include_roots: DEFAULT_INCLUDE_ROOTS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        extensions: DEFAULT_EXTENSIONS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        extension_max_lines,
+        excluded_parts: DEFAULT_EXCLUDED_PARTS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        overrides: Vec::new(),
+    }
+}
+
+fn normalize_config(config: FileBudgetConfig) -> NormalizedFileBudgetConfig {
+    let mut normalized = default_config();
+    if let Some(default_max_lines) = config.default_max_lines {
+        normalized.default_max_lines = default_max_lines;
+    }
+    if let Some(include_roots) = config.include_roots {
+        normalized.include_roots = include_roots;
+    }
+    if let Some(extensions) = config.extensions {
+        normalized.extensions = extensions;
+    }
+    if let Some(extension_max_lines) = config.extension_max_lines {
+        normalized.extension_max_lines.extend(extension_max_lines);
+    }
+    if let Some(excluded_parts) = config.excluded_parts {
+        normalized.excluded_parts = excluded_parts;
+    }
+    if let Some(overrides) = config.overrides {
+        normalized.overrides = overrides;
+    }
+    normalized
+}
+
+fn list_changed_files(repo_root: &Path, base_ref: &str) -> Result<Vec<String>, String> {
+    let output = git_output(
+        repo_root,
+        ["diff", "--name-only", "--diff-filter=ACMR", base_ref, "--"],
+    )?;
+    Ok(output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.replace('\\', "/"))
+        .collect())
+}
+
+fn list_all_budgeted_files(repo_root: &Path, config: &NormalizedFileBudgetConfig) -> Vec<String> {
+    let mut collected = Vec::new();
+    for root in &config.include_roots {
+        let absolute_root = repo_root.join(root);
+        if absolute_root.is_dir() {
+            walk_files(&absolute_root, &mut collected);
+        }
+    }
+
+    collected
+        .into_iter()
+        .filter_map(|absolute_path| {
+            absolute_path
+                .strip_prefix(repo_root)
+                .ok()
+                .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        })
+        .filter(|relative_path| should_include_file(relative_path, config))
+        .collect()
+}
+
+fn walk_files(dir: &Path, collected: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_files(&path, collected);
+        } else if path.is_file() {
+            collected.push(path);
+        }
+    }
+}
+
+fn should_include_file(relative_path: &str, config: &NormalizedFileBudgetConfig) -> bool {
+    let normalized_path = relative_path.replace('\\', "/");
+    let extension = Path::new(&normalized_path)
+        .extension()
+        .map(|value| format!(".{}", value.to_string_lossy().to_lowercase()))
+        .unwrap_or_default();
+
+    if !config
+        .extensions
+        .iter()
+        .any(|candidate| candidate == &extension)
+    {
+        return false;
+    }
+
+    if !config
+        .include_roots
+        .iter()
+        .any(|root| normalized_path == *root || normalized_path.starts_with(&format!("{root}/")))
+    {
+        return false;
+    }
+
+    config
+        .excluded_parts
+        .iter()
+        .all(|excluded| !normalized_path.contains(excluded))
+}
+
+fn evaluate_file(
+    repo_root: &Path,
+    relative_path: &str,
+    config: &NormalizedFileBudgetConfig,
+    args: &FileBudgetArgs,
+) -> Option<FileBudgetViolation> {
+    if !should_include_file(relative_path, config) {
+        return None;
+    }
+
+    let override_entry = find_override(relative_path, &config.overrides);
+    if args.overrides_only && override_entry.is_none() {
+        return None;
+    }
+
+    let absolute_path = repo_root.join(relative_path);
+    let source = fs::read_to_string(&absolute_path).ok()?;
+    let line_count = count_lines(&source);
+    let extension = Path::new(relative_path)
+        .extension()
+        .map(|value| format!(".{}", value.to_string_lossy().to_lowercase()))
+        .unwrap_or_default();
+    let budget_limit = override_entry
+        .and_then(|entry| entry.max_lines)
+        .or_else(|| config.extension_max_lines.get(&extension).copied())
+        .unwrap_or(config.default_max_lines);
+
+    let baseline_line_count = if args.changed_only {
+        read_tracked_file(repo_root, &args.base, relative_path).map(|source| count_lines(&source))
+    } else {
+        None
+    };
+
+    let (allowed_max_lines, violation_kind) =
+        if override_entry.and_then(|entry| entry.max_lines).is_some() {
+            (budget_limit, ViolationKind::OverrideBudgetExceeded)
+        } else if let Some(baseline) = baseline_line_count {
+            if baseline > budget_limit {
+                (baseline, ViolationKind::BaselineFrozenGrowth)
+            } else {
+                (budget_limit, ViolationKind::BudgetExceeded)
+            }
+        } else {
+            (budget_limit, ViolationKind::BudgetExceeded)
+        };
+
+    if line_count <= allowed_max_lines {
+        return None;
+    }
+
+    Some(FileBudgetViolation {
+        relative_path: relative_path.to_string(),
+        line_count,
+        budget_limit,
+        allowed_max_lines,
+        baseline_line_count,
+        reason: override_entry.and_then(|entry| entry.reason.clone()),
+        violation_kind,
+    })
+}
+
+fn find_override<'a>(
+    relative_path: &str,
+    overrides: &'a [FileBudgetOverride],
+) -> Option<&'a FileBudgetOverride> {
+    overrides.iter().find(|entry| {
+        entry
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value == relative_path)
+            .unwrap_or(false)
+    })
+}
+
+fn read_tracked_file(repo_root: &Path, base_ref: &str, relative_path: &str) -> Option<String> {
+    git_output(repo_root, ["show", &format!("{base_ref}:{relative_path}")]).ok()
+}
+
+fn git_output<const N: usize>(repo_root: &Path, args: [&str; N]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .map_err(|error| format!("failed to run git {}: {error}", args.join(" ")))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+fn count_lines(source: &str) -> usize {
+    if source.is_empty() {
+        0
+    } else {
+        source.lines().count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_budget_report, FileBudgetArgs, ViolationKind, DEFAULT_CONFIG_PATH};
+    use serde_json::json;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    #[test]
+    fn changed_only_freezes_legacy_hotspots_at_head_baseline() {
+        let repo = init_git_repo();
+        write_budget_config(
+            repo.path(),
+            json!({
+                "default_max_lines": 3,
+                "include_roots": ["src"],
+                "extensions": [".ts"],
+                "extension_max_lines": { ".ts": 3 },
+                "overrides": []
+            }),
+        );
+        write_file(repo.path(), "src/legacy.ts", 5);
+        commit_all(repo.path(), "baseline");
+
+        write_file(repo.path(), "src/legacy.ts", 6);
+
+        let report = build_budget_report(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: true,
+                base: "HEAD".to_string(),
+                overrides_only: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("budget report should build");
+
+        assert_eq!(report.violations.len(), 1);
+        let violation = &report.violations[0];
+        assert_eq!(violation.relative_path, "src/legacy.ts");
+        assert_eq!(violation.line_count, 6);
+        assert_eq!(violation.budget_limit, 3);
+        assert_eq!(violation.allowed_max_lines, 5);
+        assert_eq!(violation.baseline_line_count, Some(5));
+        assert_eq!(
+            violation.violation_kind,
+            ViolationKind::BaselineFrozenGrowth
+        );
+    }
+
+    #[test]
+    fn overrides_only_reports_only_configured_hotspots() {
+        let repo = init_git_repo();
+        write_budget_config(
+            repo.path(),
+            json!({
+                "default_max_lines": 3,
+                "include_roots": ["src"],
+                "extensions": [".ts"],
+                "extension_max_lines": { ".ts": 3 },
+                "overrides": [
+                    {
+                        "path": "src/legacy.ts",
+                        "max_lines": 4,
+                        "reason": "legacy hotspot freeze"
+                    }
+                ]
+            }),
+        );
+        write_file(repo.path(), "src/legacy.ts", 5);
+        write_file(repo.path(), "src/new.ts", 5);
+
+        let report = build_budget_report(
+            &FileBudgetArgs {
+                repo_root: None,
+                config: DEFAULT_CONFIG_PATH.to_string(),
+                changed_only: false,
+                base: "HEAD".to_string(),
+                overrides_only: true,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("budget report should build");
+
+        assert_eq!(report.violations.len(), 1);
+        let violation = &report.violations[0];
+        assert_eq!(violation.relative_path, "src/legacy.ts");
+        assert_eq!(violation.allowed_max_lines, 4);
+        assert_eq!(violation.reason.as_deref(), Some("legacy hotspot freeze"));
+        assert_eq!(
+            violation.violation_kind,
+            ViolationKind::OverrideBudgetExceeded
+        );
+    }
+
+    fn init_git_repo() -> TempDir {
+        let repo = TempDir::new().expect("temp dir");
+        run_git(repo.path(), ["init"]);
+        run_git(repo.path(), ["config", "user.name", "Codex"]);
+        run_git(repo.path(), ["config", "user.email", "codex@openai.com"]);
+        repo
+    }
+
+    fn commit_all(repo_root: &Path, message: &str) {
+        run_git(repo_root, ["add", "."]);
+        run_git(repo_root, ["commit", "-m", message]);
+    }
+
+    fn write_budget_config(repo_root: &Path, value: serde_json::Value) {
+        let path = repo_root.join(DEFAULT_CONFIG_PATH);
+        fs::create_dir_all(
+            path.parent()
+                .expect("budget config should have a parent directory"),
+        )
+        .expect("create config dir");
+        fs::write(
+            path,
+            serde_json::to_string_pretty(&value).expect("serialize config"),
+        )
+        .expect("write config");
+    }
+
+    fn write_file(repo_root: &Path, relative_path: &str, line_count: usize) {
+        let path = repo_root.join(relative_path);
+        fs::create_dir_all(
+            path.parent()
+                .expect("test file should have a parent directory"),
+        )
+        .expect("create test dir");
+        let body = (1..=line_count)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(path, format!("{body}\n")).expect("write test file");
+    }
+
+    fn run_git<const N: usize>(repo_root: &Path, args: [&str; N]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/routa-cli/src/commands/mod.rs
+++ b/crates/routa-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod feature_tree;
 pub mod fitness;
 pub mod graph;
 pub mod harness;
+pub mod harness_budget;
 pub mod kanban;
 pub mod prompt;
 pub mod review;

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -17,8 +17,8 @@ Run these before changing code:
 
 ```bash
 entrix analyze long-file --json
-entrix hook file-length --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}"
-entrix hook file-length --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}" --overrides-only
+cargo run -q -p routa-cli -- harness budget --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}"
+cargo run -q -p routa-cli -- harness budget --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}" --overrides-only
 ```
 
 Triage order:

--- a/docs/fitness/code-quality.md
+++ b/docs/fitness/code-quality.md
@@ -12,14 +12,14 @@ metrics:
   # ══════════════════════════════════════════════════════════════
   
   - name: legacy_hotspot_budget_guard
-    command: entrix hook file-length --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}" --overrides-only
+    command: cargo run -q -p routa-cli -- harness budget --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}" --overrides-only
     pattern: "file_budget_violations: 0"
     hard_gate: true
     tier: fast
     description: "已登记的历史热点文件必须满足冻结预算，只允许缩小不允许继续膨胀"
 
   - name: file_line_limit
-    command: entrix hook file-length --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}"
+    command: cargo run -q -p routa-cli -- harness budget --config docs/fitness/file_budgets.json --changed-only --base "${ROUTA_FITNESS_CHANGED_BASE:-HEAD}"
     pattern: "file_budget_violations: 0"
     hard_gate: false
     tier: fast
@@ -244,8 +244,8 @@ metrics:
 
 | 检测项 | 阈值 | Hard Gate | 工具 |
 |--------|------|-----------|------|
-| 文件行数 | 新文件 ≤1600 行，历史超标文件按 HEAD 基线冻结 | ❌ | `python -m entrix.file_budgets` |
-| 历史热点守护 | 已登记热点只允许缩小不允许继续膨胀 | ✅ | `python -m entrix.file_budgets --overrides-only` |
+| 文件行数 | 新文件 ≤1600 行，历史超标文件按 HEAD 基线冻结 | ❌ | `cargo run -q -p routa-cli -- harness budget` |
+| 历史热点守护 | 已登记热点只允许缩小不允许继续膨胀 | ✅ | `cargo run -q -p routa-cli -- harness budget --overrides-only` |
 | 函数行数 | ≤100 行 | ❌ | grep + 人工 |
 | 重复代码 | 变更文件不新增大块 clone | ❌ | jscpd |
 | 结构坏味道 | 变更文件中结构型包装重复 = 0 | ❌ | ast-grep |


### PR DESCRIPTION
## Summary
- add a routa harness budget entrypoint for long-file budgets and frozen hotspot ceilings
- keep existing harness detect, harness evolve, and harness template flows intact while wiring the new budget subcommand into the CLI
- update fitness and refactor docs to run budget checks through cargo run -q -p routa-cli -- harness budget with the existing docs/fitness/file_budgets.json config

## Validation
- cargo test -q -p routa-cli harness_budget --lib
- cargo test -q -p routa-cli harness --lib
- cargo check -q -p routa-cli
- cargo run -q -p routa-cli -- harness budget --config docs/fitness/file_budgets.json --changed-only --base HEAD
- entrix run --tier fast
- entrix run --tier normal

## Notes
- entrix run --tier normal still reports the existing ts_test_coverage baseline gap: 57.1% lines vs 80.0% threshold, but the overall tier result remains PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a harness budget command to validate repository files against configurable line-count budgets; supports changed-only mode, per-path overrides, extension/default thresholds, JSON or text output, and returns a non-zero result when violations exist.

* **Documentation**
  * Updated development playbooks and fitness docs to reference the new budget-checking command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->