### PR TITLE
[codex] Preserve Task-Adaptive tool-call path continuity

### DIFF
--- a/docs/issues/2026-04-23-task-adaptive-tool-continuity-relative-paths.md
+++ b/docs/issues/2026-04-23-task-adaptive-tool-continuity-relative-paths.md
@@ -1,0 +1,54 @@
+---
+title: "Task-Adaptive history relevance should preserve tool-call continuity across nested cwd paths"
+date: "2026-04-23"
+kind: issue
+status: open
+severity: medium
+area: harness
+tags:
+  - task-adaptive
+  - codex-sessions
+  - transcript-analysis
+  - relative-paths
+  - tool-continuity
+reported_by: "user"
+github_issue: 528
+github_state: open
+github_url: "https://github.com/phodal/routa/issues/528"
+---
+
+# Task-Adaptive history relevance should preserve tool-call continuity across nested cwd paths
+
+## What Happened
+
+The original GitHub issue title over-focused on normalizing every file path to repository-relative form. The real intent is narrower and more behavioral: Task-Adaptive history analysis should understand normal local agent workflows from `~/.codex/sessions`, especially tool-call sequences such as:
+
+- search or enumerate files with `rg --files`, `rg`, `grep`, `find`, or `fd`
+- read one of the returned relative paths
+- edit the same path through `apply_patch`
+- use those linked signals to rank the session as relevant
+
+In real Codex transcripts, some sessions run with `cwd` under a nested codebase path such as `.routa/repos/<codebase>`. A path like `packages/app/src/page.tsx` is correct relative to that session `cwd`, but not correct relative to the Routa repo root. If Task-Adaptive keeps the raw token as `packages/app/src/page.tsx`, it cannot match a selected file stored as `.routa/repos/<codebase>/packages/app/src/page.tsx`.
+
+## Expected Behavior
+
+Task-Adaptive transcript analysis should treat file paths as relative to the session `cwd` first when the session runs inside a nested repo path, then convert them back to the current repo root's relative form for matching and ranking.
+
+It should also preserve enough tool-call continuity to count search results as useful discovery/read signals, so a normal `rg -> sed -> apply_patch` sequence improves relevance instead of being split into disconnected events.
+
+## Why This Might Happen
+
+- `normalizeRepoRelative` returned the raw relative token before considering that `sessionCwd/token` may be the real target.
+- Absolute paths were previously checked relative to the session cwd before the current repo root, which could also strip nested repo prefixes.
+- Search-like command outputs were ignored as file discovery evidence.
+- `parsePatchBlock` did not match real `apply_patch` headers like `*** Update File: ...`, so edited files could be missed entirely.
+
+## Relevant Files
+
+- `src/core/harness/task-adaptive.ts`
+- `src/app/api/harness/task-adaptive/__tests__/shared.test.ts`
+
+## Verification
+
+- 2026-04-23: added a regression test for a nested `cwd` transcript with `rg --files -> sed -> apply_patch`.
+- 2026-04-23: `npx vitest run src/app/api/harness/task-adaptive/__tests__/shared.test.ts` passed.

--- a/src/app/api/harness/task-adaptive/__tests__/shared.test.ts
+++ b/src/app/api/harness/task-adaptive/__tests__/shared.test.ts
@@ -320,6 +320,97 @@ describe("assembleTaskAdaptiveHarness", () => {
     expect(pack.selectedFiles).toEqual(["src/explicit.ts"]);
   });
 
+  it("resolves search-to-read-to-edit file signals relative to nested session cwd", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "task-adaptive-harness-nested-cwd-"));
+    process.env.HOME = tempRoot;
+    process.env.CLAUDE_CONFIG_DIR = "";
+
+    const repoRoot = path.join(tempRoot, "repo");
+    const codebaseRoot = path.join(repoRoot, ".routa", "repos", "example-codebase");
+    const sessionRelativeFile = "packages/app/src/page.tsx";
+    const repoRelativeFile = ".routa/repos/example-codebase/packages/app/src/page.tsx";
+    ensureFile(path.join(codebaseRoot, sessionRelativeFile), "export const nestedPage = true;\n");
+    writeFeatureTreeIndex(repoRoot, [
+      {
+        id: "nested-codebase",
+        name: "Nested Codebase",
+        sourceFiles: [repoRelativeFile],
+      },
+    ]);
+
+    writeTranscript(
+      path.join(tempRoot, ".codex", "sessions", "session-nested-cwd.jsonl"),
+      codebaseRoot,
+      "session-nested-cwd",
+      [
+        {
+          timestamp: "2026-04-21T10:01:00.000Z",
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "Update the nested codebase page after finding it with rg.",
+          },
+        },
+        {
+          timestamp: "2026-04-21T10:02:00.000Z",
+          type: "event_msg",
+          payload: {
+            type: "exec_command_end",
+            command: ["/bin/zsh", "-lc", "rg --files packages/app/src"],
+            aggregated_output: `${sessionRelativeFile}\n`,
+            exit_code: 0,
+          },
+        },
+        {
+          timestamp: "2026-04-21T10:03:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            arguments: JSON.stringify({ cmd: `sed -n '1,120p' ${sessionRelativeFile}` }),
+          },
+        },
+        {
+          timestamp: "2026-04-21T10:03:04.000Z",
+          type: "event_msg",
+          payload: {
+            type: "exec_command_end",
+            command: ["/bin/zsh", "-lc", `sed -n '1,120p' ${sessionRelativeFile}`],
+            aggregated_output: "export const nestedPage = true;\n",
+            exit_code: 0,
+          },
+        },
+        {
+          timestamp: "2026-04-21T10:04:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "apply_patch",
+            arguments: `*** Begin Patch\n*** Update File: ${sessionRelativeFile}\n*** End Patch\n`,
+          },
+        },
+      ],
+    );
+
+    const pack = await assembleTaskAdaptiveHarness(repoRoot, {
+      filePaths: [repoRelativeFile],
+      taskType: "analysis",
+      maxSessions: 3,
+    });
+
+    expect(pack.selectedFiles).toEqual([repoRelativeFile]);
+    expect(pack.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: "session-nested-cwd",
+        matchedFiles: [repoRelativeFile],
+        matchedChangedFiles: [repoRelativeFile],
+        matchedReadFiles: [repoRelativeFile],
+        matchedWrittenFiles: [repoRelativeFile],
+      }),
+    ]);
+    expect(pack.repeatedReadFiles).toContain(repoRelativeFile);
+  });
+
   it("infers features and files from context search hints when history and files are absent", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "task-adaptive-harness-hints-"));
     process.env.HOME = tempRoot;

--- a/src/core/harness/task-adaptive-path-signals.ts
+++ b/src/core/harness/task-adaptive-path-signals.ts
@@ -1,0 +1,361 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const MAX_SEARCH_OUTPUT_FILE_CANDIDATES = 40;
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function toPosix(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function shellLikeSplit(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+
+  for (const ch of command) {
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+export function parsePatchBlock(text: string): string[] {
+  const out: string[] = [];
+
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const [, value] = trimmed.match(/^\*{3} (?:(?:Update|Add|Delete) File|Move to):\s*(.*)$/) ?? [];
+    if (value) {
+      out.push(value);
+    }
+  }
+
+  return out;
+}
+
+export function parseCommandPaths(command: string): string[] {
+  const tokens = shellLikeSplit(command);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  const separatorIndex = tokens.indexOf("--");
+  if (separatorIndex >= 0) {
+    return tokens
+      .slice(separatorIndex + 1)
+      .filter((token) => token.length > 0 && !token.startsWith("-"));
+  }
+
+  if (tokens[0] === "git" && (tokens[1] === "add" || tokens[1] === "rm")) {
+    return tokens
+      .slice(2)
+      .filter((token) => token.length > 0 && !token.startsWith("-"));
+  }
+
+  return [];
+}
+
+export function collectFileValues(value: unknown, out: Set<string>): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFileValues(item, out);
+    }
+    return;
+  }
+
+  if (typeof value === "string") {
+    for (const candidate of parsePatchBlock(value)) {
+      out.add(candidate);
+    }
+    return;
+  }
+
+  if (typeof value !== "object") {
+    return;
+  }
+
+  const map = value as Record<string, unknown>;
+  const pathKeys = new Set([
+    "path",
+    "paths",
+    "file",
+    "filepath",
+    "file_path",
+    "filename",
+    "target",
+    "source",
+    "target_file",
+    "source_file",
+    "absolute_path",
+    "relative_path",
+  ]);
+
+  for (const [key, child] of Object.entries(map)) {
+    const lower = key.toLowerCase();
+    if (pathKeys.has(lower)) {
+      if (typeof child === "string") {
+        out.add(child);
+      } else if (Array.isArray(child)) {
+        for (const item of child) {
+          if (typeof item === "string") {
+            out.add(item);
+          }
+        }
+      }
+    }
+    collectFileValues(child, out);
+  }
+}
+
+export function unwrapShellCommand(command: string): string {
+  const tokens = shellLikeSplit(command);
+  if (tokens.length < 3) {
+    return command;
+  }
+
+  const executable = path.posix.basename(tokens[0] ?? "");
+  const shellLike = executable === "sh" || executable === "bash" || executable === "zsh";
+  if (!shellLike) {
+    return command;
+  }
+
+  const cFlagIndex = tokens.findIndex((token) => token === "-c" || token === "-lc");
+  if (cFlagIndex >= 0 && tokens[cFlagIndex + 1]) {
+    return tokens.slice(cFlagIndex + 1).join(" ");
+  }
+
+  return command;
+}
+
+export function extractReadCandidatesFromCommand(command: string): string[] {
+  const innerCommand = unwrapShellCommand(command);
+  const tokens = shellLikeSplit(innerCommand);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  const executable = path.posix.basename(tokens[0] ?? "");
+  const readCommands = new Set(["bat", "cat", "head", "less", "more", "nl", "sed", "tail"]);
+  if (!readCommands.has(executable)) {
+    return [];
+  }
+
+  return tokens.slice(1).filter((token) => token !== "--" && !token.startsWith("-"));
+}
+
+function sanitizePathCandidate(candidate: string): string | null {
+  const cleaned = toPosix(candidate)
+    .trim()
+    .replace(/^"+|"+$/g, "")
+    .replace(/^'+|'+$/g, "")
+    .replace(/^`+|`+$/g, "")
+    .replace(/[",;:]+$/g, "");
+
+  if (!cleaned) {
+    return null;
+  }
+
+  const lineQualifiedPath = cleaned.match(/^(.*\.[^:/\s]+):\d+(?::\d+)?$/);
+  if (lineQualifiedPath?.[1]) {
+    return lineQualifiedPath[1];
+  }
+
+  if (!/\s/.test(cleaned)) {
+    return cleaned;
+  }
+
+  const embeddedPath = cleaned.match(
+    /([A-Za-z0-9_@()[\]{}.\-/]+?\.(?:[cm]?[jt]sx?|jsx?|tsx?|rs|md|json|ya?ml|toml|css|scss|html))/,
+  );
+  if (embeddedPath?.[1]) {
+    return embeddedPath[1];
+  }
+
+  return cleaned;
+}
+
+function pathLooksFileLike(candidate: string): boolean {
+  const base = path.posix.basename(candidate);
+  return base.includes(".") || ["Dockerfile", "Makefile", "Cargo.toml"].includes(base);
+}
+
+function isExistingDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function repoRelativeFromResolvedPath(repoRoot: string, resolvedPath: string): string | null {
+  const relative = toPosix(path.relative(repoRoot, resolvedPath));
+  if (!relative || relative === "." || relative.startsWith("../") || path.isAbsolute(relative)) {
+    return null;
+  }
+  return relative;
+}
+
+function isUsableResolvedFileCandidate(resolvedPath: string, relativePath: string): boolean {
+  if (isExistingDirectory(resolvedPath)) {
+    return false;
+  }
+  return isExistingFile(resolvedPath) || pathLooksFileLike(relativePath);
+}
+
+export function normalizeRepoRelative(repoRoot: string, candidate: string, sessionCwd: string): string | null {
+  const cleaned = sanitizePathCandidate(candidate);
+
+  if (!cleaned || cleaned === "/dev/null") {
+    return null;
+  }
+
+  const normalizedRepoRoot = path.resolve(repoRoot);
+  const normalizedSessionCwd = path.resolve(sessionCwd);
+
+  if (!path.isAbsolute(cleaned)) {
+    const relativeCandidate = toPosix(cleaned).replace(/^\.\//, "");
+    if (!relativeCandidate || relativeCandidate === "." || relativeCandidate.startsWith("../")) {
+      return null;
+    }
+    const repoResolved = path.join(repoRoot, relativeCandidate);
+    const sessionResolved = path.join(sessionCwd, relativeCandidate);
+    const sessionRelative = repoRelativeFromResolvedPath(repoRoot, sessionResolved);
+
+    if (
+      sessionRelative
+      && normalizedSessionCwd !== normalizedRepoRoot
+      && isUsableResolvedFileCandidate(sessionResolved, sessionRelative)
+    ) {
+      return sessionRelative;
+    }
+
+    if (isExistingDirectory(repoResolved)) {
+      return null;
+    }
+    if (isExistingFile(repoResolved) || pathLooksFileLike(relativeCandidate)) {
+      return relativeCandidate;
+    }
+
+    if (sessionRelative && isExistingFile(sessionResolved)) {
+      return sessionRelative;
+    }
+
+    if (!pathLooksFileLike(relativeCandidate)) {
+      return null;
+    }
+    return sessionRelative ?? relativeCandidate;
+  }
+
+  if (isExistingDirectory(cleaned)) {
+    return null;
+  }
+
+  const repoRelative = repoRelativeFromResolvedPath(repoRoot, cleaned);
+  if (repoRelative && (isExistingFile(cleaned) || pathLooksFileLike(repoRelative))) {
+    return repoRelative;
+  }
+
+  const sessionRelative = toPosix(path.relative(sessionCwd, cleaned));
+  if (
+    sessionRelative
+    && !sessionRelative.startsWith("../")
+    && !path.isAbsolute(sessionRelative)
+    && (isExistingFile(cleaned) || pathLooksFileLike(sessionRelative))
+  ) {
+    return sessionRelative;
+  }
+
+  return null;
+}
+
+function isSearchLikeCommand(command: string): boolean {
+  const tokens = shellLikeSplit(unwrapShellCommand(command));
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  const executable = path.posix.basename(tokens[0] ?? "");
+  if (executable === "rg" || executable === "grep" || executable === "fd" || executable === "find") {
+    return true;
+  }
+
+  return tokens[0] === "git" && tokens[1] === "grep";
+}
+
+function extractSearchOutputPathCandidate(line: string): string | null {
+  const cleaned = line.replace(ANSI_ESCAPE_PATTERN, "").trim();
+  if (!cleaned) {
+    return null;
+  }
+
+  const binaryMatch = cleaned.match(/^Binary file (.+?) matches$/u);
+  if (binaryMatch?.[1]) {
+    return binaryMatch[1];
+  }
+
+  const locationMatch = cleaned.match(/^(.+?)(?::\d+)?(?::\d+)?:/u);
+  if (locationMatch?.[1] && pathLooksFileLike(locationMatch[1])) {
+    return locationMatch[1];
+  }
+
+  return pathLooksFileLike(cleaned) ? cleaned : null;
+}
+
+export function extractSearchOutputPathCandidates(command: string, output: string): string[] {
+  if (!isSearchLikeCommand(command)) {
+    return [];
+  }
+
+  const candidates: string[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const candidate = extractSearchOutputPathCandidate(line);
+    if (!candidate || candidates.includes(candidate)) {
+      continue;
+    }
+    candidates.push(candidate);
+    if (candidates.length >= MAX_SEARCH_OUTPUT_FILE_CANDIDATES) {
+      break;
+    }
+  }
+
+  return candidates;
+}

--- a/src/core/harness/task-adaptive.ts
+++ b/src/core/harness/task-adaptive.ts
@@ -12,6 +12,15 @@ import {
   commandOutputFromUnknown,
   type TranscriptProvider,
 } from "./transcript-sessions";
+import {
+  collectFileValues,
+  extractReadCandidatesFromCommand,
+  extractSearchOutputPathCandidates,
+  normalizeRepoRelative,
+  parseCommandPaths,
+  parsePatchBlock,
+  unwrapShellCommand,
+} from "./task-adaptive-path-signals";
 
 export type TaskAdaptiveHarnessTaskType = "implementation" | "planning" | "analysis" | "review";
 
@@ -408,10 +417,6 @@ function collectPreferredFeatureFiles(
   return mergePreferredStringGroups(explicitFeatureFiles, inferredFeatureFiles);
 }
 
-function toPosix(value: string): string {
-  return value.replace(/\\/g, "/");
-}
-
 function appendLimitedUnique(target: string[], value: string, limit: number): void {
   if (!value || target.includes(value) || target.length >= limit) {
     return;
@@ -510,136 +515,6 @@ function mergeFeatureTreeFeatures(
   return [...merged.values()];
 }
 
-function shellLikeSplit(command: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: string | null = null;
-
-  for (const ch of command) {
-    if (quote !== null) {
-      if (ch === quote) {
-        quote = null;
-        continue;
-      }
-      current += ch;
-      continue;
-    }
-
-    if (ch === "'" || ch === '"') {
-      quote = ch;
-      continue;
-    }
-
-    if (/\s/.test(ch)) {
-      if (current.length > 0) {
-        tokens.push(current);
-        current = "";
-      }
-      continue;
-    }
-
-    current += ch;
-  }
-
-  if (current.length > 0) {
-    tokens.push(current);
-  }
-
-  return tokens;
-}
-
-function parsePatchBlock(text: string): string[] {
-  const out: string[] = [];
-
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    const [, , value] = trimmed.match(/^(\*{3} (Update|Add|Delete|Move to):)\s*(.*)$/) ?? [];
-    if (value) {
-      out.push(value);
-    }
-  }
-
-  return out;
-}
-
-function parseCommandPaths(command: string): string[] {
-  const tokens = shellLikeSplit(command);
-  if (tokens.length === 0) {
-    return [];
-  }
-
-  const separatorIndex = tokens.indexOf("--");
-  if (separatorIndex >= 0) {
-    return tokens
-      .slice(separatorIndex + 1)
-      .filter((token) => token.length > 0 && !token.startsWith("-"));
-  }
-
-  if (tokens[0] === "git" && (tokens[1] === "add" || tokens[1] === "rm")) {
-    return tokens
-      .slice(2)
-      .filter((token) => token.length > 0 && !token.startsWith("-"));
-  }
-
-  return [];
-}
-
-function collectFileValues(value: unknown, out: Set<string>): void {
-  if (value === null || value === undefined) {
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectFileValues(item, out);
-    }
-    return;
-  }
-
-  if (typeof value === "string") {
-    for (const candidate of parsePatchBlock(value)) {
-      out.add(candidate);
-    }
-    return;
-  }
-
-  if (typeof value !== "object") {
-    return;
-  }
-
-  const map = value as Record<string, unknown>;
-  const pathKeys = new Set([
-    "path",
-    "paths",
-    "file",
-    "filepath",
-    "file_path",
-    "filename",
-    "target",
-    "source",
-    "target_file",
-    "source_file",
-    "absolute_path",
-    "relative_path",
-  ]);
-
-  for (const [key, child] of Object.entries(map)) {
-    const lower = key.toLowerCase();
-    if (pathKeys.has(lower)) {
-      if (typeof child === "string") {
-        out.add(child);
-      } else if (Array.isArray(child)) {
-        for (const item of child) {
-          if (typeof item === "string") {
-            out.add(item);
-          }
-        }
-      }
-    }
-    collectFileValues(child, out);
-  }
-}
-
 function normalizeCommandSignature(command: string): string {
   return command.replace(/\s+/g, " ").trim();
 }
@@ -650,26 +525,6 @@ function truncateDiagnosticText(text: string, maxLength: number = 220): string {
     return normalized;
   }
   return `${normalized.slice(0, maxLength - 3)}...`;
-}
-
-function unwrapShellCommand(command: string): string {
-  const tokens = shellLikeSplit(command);
-  if (tokens.length < 3) {
-    return command;
-  }
-
-  const executable = path.posix.basename(tokens[0] ?? "");
-  const shellLike = executable === "sh" || executable === "bash" || executable === "zsh";
-  if (!shellLike) {
-    return command;
-  }
-
-  const cFlagIndex = tokens.findIndex((token) => token === "-c" || token === "-lc");
-  if (cFlagIndex >= 0 && tokens[cFlagIndex + 1]) {
-    return tokens.slice(cFlagIndex + 1).join(" ");
-  }
-
-  return command;
 }
 
 function toolNameFromFeatureEvent(event: unknown): string | undefined {
@@ -692,117 +547,6 @@ function toolNameFromFeatureEvent(event: unknown): string | undefined {
   return commandFromUnknown(event) ? "exec_command" : undefined;
 }
 
-function extractReadCandidatesFromCommand(command: string): string[] {
-  const innerCommand = unwrapShellCommand(command);
-  const tokens = shellLikeSplit(innerCommand);
-  if (tokens.length === 0) {
-    return [];
-  }
-
-  const executable = path.posix.basename(tokens[0] ?? "");
-  const readCommands = new Set(["bat", "cat", "head", "less", "more", "nl", "sed", "tail"]);
-  if (!readCommands.has(executable)) {
-    return [];
-  }
-
-  return tokens.slice(1).filter((token) => token !== "--" && !token.startsWith("-"));
-}
-
-function sanitizePathCandidate(candidate: string): string | null {
-  const cleaned = toPosix(candidate)
-    .trim()
-    .replace(/^"+|"+$/g, "")
-    .replace(/^'+|'+$/g, "")
-    .replace(/^`+|`+$/g, "")
-    .replace(/[",;:]+$/g, "");
-
-  if (!cleaned) {
-    return null;
-  }
-
-  const lineQualifiedPath = cleaned.match(/^(.*\.[^:/\s]+):\d+(?::\d+)?$/);
-  if (lineQualifiedPath?.[1]) {
-    return lineQualifiedPath[1];
-  }
-
-  if (!/\s/.test(cleaned)) {
-    return cleaned;
-  }
-
-  const embeddedPath = cleaned.match(
-    /([A-Za-z0-9_@()[\]{}.\-/]+?\.(?:[cm]?[jt]sx?|jsx?|tsx?|rs|md|json|ya?ml|toml|css|scss|html))/,
-  );
-  if (embeddedPath?.[1]) {
-    return embeddedPath[1];
-  }
-
-  return cleaned;
-}
-
-function pathLooksFileLike(candidate: string): boolean {
-  const base = path.posix.basename(candidate);
-  return base.includes(".") || ["Dockerfile", "Makefile", "Cargo.toml"].includes(base);
-}
-
-function isExistingDirectory(filePath: string): boolean {
-  try {
-    return fs.statSync(filePath).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-function isExistingFile(filePath: string): boolean {
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function normalizeRepoRelative(repoRoot: string, candidate: string, sessionCwd: string): string | null {
-  const cleaned = sanitizePathCandidate(candidate);
-
-  if (!cleaned || cleaned === "/dev/null") {
-    return null;
-  }
-
-  if (!path.isAbsolute(cleaned)) {
-    const relativeCandidate = toPosix(cleaned).replace(/^\.\//, "");
-    if (!relativeCandidate || relativeCandidate === "." || relativeCandidate.startsWith("../")) {
-      return null;
-    }
-    const repoResolved = path.join(repoRoot, relativeCandidate);
-    const sessionResolved = path.join(sessionCwd, relativeCandidate);
-    if (isExistingDirectory(repoResolved) || isExistingDirectory(sessionResolved)) {
-      return null;
-    }
-    if (!isExistingFile(repoResolved) && !isExistingFile(sessionResolved) && !pathLooksFileLike(relativeCandidate)) {
-      return null;
-    }
-    return relativeCandidate;
-  }
-
-  const candidatePaths = [sessionCwd, repoRoot];
-  for (const basePath of candidatePaths) {
-    if (isExistingDirectory(cleaned)) {
-      return null;
-    }
-    const relative = path.relative(basePath, cleaned);
-    const relativePosix = toPosix(relative);
-    if (
-      relativePosix
-      && !relativePosix.startsWith("../")
-      && !path.isAbsolute(relativePosix)
-      && (isExistingFile(cleaned) || pathLooksFileLike(relativePosix))
-    ) {
-      return relativePosix;
-    }
-  }
-
-  return null;
-}
-
 function collectReadFilesFromToolLike(event: unknown, repoRoot: string, sessionCwd: string): string[] {
   const candidates = new Set<string>();
   const toolName = toolNameFromFeatureEvent(event)?.toLowerCase() ?? "";
@@ -819,6 +563,12 @@ function collectReadFilesFromToolLike(event: unknown, repoRoot: string, sessionC
   if (command) {
     for (const token of extractReadCandidatesFromCommand(command)) {
       candidates.add(token);
+    }
+    const commandOutput = commandOutputFromUnknown(event);
+    if (commandOutput) {
+      for (const token of extractSearchOutputPathCandidates(command, commandOutput)) {
+        candidates.add(token);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix Task-Adaptive transcript path attribution for sessions whose `cwd` is nested under the repo, such as `.routa/repos/<codebase>`.
- Extract conservative path-signal parsing into `task-adaptive-path-signals.ts`, including `apply_patch` headers and search-like command output.
- Add a regression test for a normal `rg --files -> sed -> apply_patch` sequence resolving to the repo-root relative file path.
- Add a local issue tracker for the clarified intent behind #528.

## Why

The original issue title framed this as normalizing every path, but the real failure mode was behavioral: normal local Codex sessions can use paths that are correct relative to the transcript session `cwd`. Without preserving that tool-call continuity, Task-Adaptive loses relevant history signals and ranks those sessions poorly.

Refs #528

## Validation

- `npx vitest run src/app/api/harness/task-adaptive/__tests__/shared.test.ts`
- `npx tsc --noEmit`
- `entrix run --tier fast`
- pre-push hook: eslint, typecheck, full TS tests, clippy, graph mapping probe, Rust tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file path resolution when working in nested project directories
  * Enhanced detection of related operations in multi-step tool workflows

* **Documentation**
  * Added documentation detailing file path resolution and tool-call continuity behavior

* **Tests**
  * Added regression tests validating nested working directory file resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->