### PR TITLE
[codex] test(harness): cover task-adaptive path signals

### DIFF
--- a/docs/issues/2026-04-23-task-adaptive-tool-continuity-relative-paths.md
+++ b/docs/issues/2026-04-23-task-adaptive-tool-continuity-relative-paths.md
@@ -2,7 +2,7 @@
 title: "Task-Adaptive history relevance should preserve tool-call continuity across nested cwd paths"
 date: "2026-04-23"
 kind: issue
-status: open
+status: resolved
 severity: medium
 area: harness
 tags:
@@ -52,3 +52,7 @@ It should also preserve enough tool-call continuity to count search results as u
 
 - 2026-04-23: added a regression test for a nested `cwd` transcript with `rg --files -> sed -> apply_patch`.
 - 2026-04-23: `npx vitest run src/app/api/harness/task-adaptive/__tests__/shared.test.ts` passed.
+- 2026-04-24: re-verified on `main` that commit `2b52fc46` already covers nested `cwd` path continuity in `src/core/harness/task-adaptive.ts`.
+- 2026-04-24: added direct helper regressions for `parsePatchBlock`, `normalizeRepoRelative`, and search-output discovery in `src/core/harness/__tests__/task-adaptive-path-signals.test.ts`.
+- 2026-04-24: `npx vitest run src/core/harness/__tests__/task-adaptive-path-signals.test.ts src/app/api/harness/task-adaptive/__tests__/shared.test.ts` passed.
+- 2026-04-24: `entrix run --tier fast` passed.

--- a/src/core/harness/__tests__/task-adaptive-path-signals.test.ts
+++ b/src/core/harness/__tests__/task-adaptive-path-signals.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment node
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractSearchOutputPathCandidates,
+  normalizeRepoRelative,
+  parsePatchBlock,
+} from "../task-adaptive-path-signals";
+
+function ensureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+describe("task-adaptive-path-signals", () => {
+  it("parses real apply_patch headers as changed file evidence", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: src/core/harness/task-adaptive.ts",
+      "*** Add File: src/core/harness/task-adaptive-path-signals.ts",
+      "*** Delete File: docs/issues/old-task-adaptive-note.md",
+      "*** Move to: src/core/harness/__tests__/task-adaptive-path-signals.test.ts",
+      "*** End Patch",
+      "",
+    ].join("\n");
+
+    expect(parsePatchBlock(patch)).toEqual([
+      "src/core/harness/task-adaptive.ts",
+      "src/core/harness/task-adaptive-path-signals.ts",
+      "docs/issues/old-task-adaptive-note.md",
+      "src/core/harness/__tests__/task-adaptive-path-signals.test.ts",
+    ]);
+  });
+
+  it("prefers session-cwd relative files when the transcript ran in a nested codebase", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "task-adaptive-path-signals-nested-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const codebaseRoot = path.join(repoRoot, ".routa", "repos", "example-codebase");
+    const sessionRelativeFile = "packages/app/src/page.tsx";
+    const repoRelativeFile = ".routa/repos/example-codebase/packages/app/src/page.tsx";
+    const absoluteFile = path.join(codebaseRoot, sessionRelativeFile);
+
+    ensureFile(absoluteFile, "export const nestedPage = true;\n");
+
+    expect(normalizeRepoRelative(repoRoot, sessionRelativeFile, codebaseRoot)).toBe(repoRelativeFile);
+    expect(normalizeRepoRelative(repoRoot, absoluteFile, codebaseRoot)).toBe(repoRelativeFile);
+  });
+
+  it("keeps repo-root relative paths stable when the transcript already ran at repo root", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "task-adaptive-path-signals-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const repoRelativeFile = "src/app/page.tsx";
+    const absoluteFile = path.join(repoRoot, repoRelativeFile);
+
+    ensureFile(absoluteFile, "export default function Page() { return null; }\n");
+
+    expect(normalizeRepoRelative(repoRoot, repoRelativeFile, repoRoot)).toBe(repoRelativeFile);
+    expect(normalizeRepoRelative(repoRoot, absoluteFile, repoRoot)).toBe(repoRelativeFile);
+  });
+
+  it("extracts discovery paths from git grep and find output", () => {
+    expect(
+      extractSearchOutputPathCandidates(
+        "git grep task-adaptive",
+        [
+          "src/core/harness/task-adaptive.ts:42:const ready = true;",
+          "Binary file assets/logo.png matches",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      "src/core/harness/task-adaptive.ts",
+      "assets/logo.png",
+    ]);
+
+    expect(
+      extractSearchOutputPathCandidates(
+        "find src -type f",
+        [
+          "src",
+          "src/core",
+          "src/core/harness/task-adaptive.ts",
+          "Cargo.toml",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      "src/core/harness/task-adaptive.ts",
+      "Cargo.toml",
+    ]);
+  });
+
+  it("unwraps shell-wrapped search commands before extracting discovery paths", () => {
+    expect(
+      extractSearchOutputPathCandidates(
+        `/bin/zsh -lc "rg --files packages/app/src"`,
+        [
+          "packages/app/src/page.tsx",
+          "packages/app/src/layout.tsx",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      "packages/app/src/page.tsx",
+      "packages/app/src/layout.tsx",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- adds direct regression coverage for task-adaptive path-signal helpers
- verifies repo-root and nested session `cwd` normalization stay aligned
- marks the local issue tracker as resolved after re-validating the existing main-branch implementation

## Why

The main behavioral fix for #528 already landed on `main` in `2b52fc46`, but the low-level path-signal helpers still had no direct unit coverage. This follow-up closes the loop with explicit tests for patch-header parsing, `cwd`-relative normalization, and search-output discovery so future refactors do not regress task-adaptive history relevance.

## Impact

- nested codebase `cwd` sessions now have direct helper coverage
- repo-root sessions keep their existing relative-path behavior under test
- `git grep`, `find`, and shell-wrapped `rg` discovery output are covered explicitly
- real `apply_patch` headers are covered explicitly

## Validation

- `npx vitest run src/core/harness/__tests__/task-adaptive-path-signals.test.ts src/app/api/harness/task-adaptive/__tests__/shared.test.ts`
- `entrix run --tier fast`
- pre-push hook: `eslint_pass`, `ts_typecheck_pass`, `ts_test_pass_full`, `clippy_pass`, `graph_test_mapping_probe`, `rust_test_pass`

Closes #528


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for path handling in adaptive tasks, including patch block analysis, repository-relative path normalization, and search output discovery mechanisms.

* **Documentation**
  * Resolved related issue documentation with updated verification status and extended test coverage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->