### PR TITLE
feat(canvas): render live session canvas artifacts

### DIFF
--- a/.agents/skills/canvas/SKILL.md
+++ b/.agents/skills/canvas/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: canvas
+description: Create or update a Routa Canvas artifact for the current task. Use when the user wants a live visual or interactive canvas generated from a Routa session.
+metadata:
+  short-description: Create a Routa Canvas artifact
+---
+
+Use Routa Canvas for this turn.
+
+Canvas behavior:
+- Create or overwrite exactly one `*.canvas.tsx` file during the tool run.
+- The file content must be the TSX source itself, not markdown.
+- Prefer storing the file under the selected repository when appropriate.
+- Use a short descriptive file name ending in `.canvas.tsx`.
+- After the file is created, mention the created path briefly.
+
+Source contract:
+- Create a Routa browser canvas as TSX source code.
+- Return only the TSX source.
+- Do not include markdown code fences.
+- Do not include explanations, notes, or prose before or after the code.
+- The source must `export default function Canvas()` or `export default Canvas`.
+- Prefer a self-contained component with inline styles.
+- If you import anything, you may only import from `react`, `routa/canvas`, `routa/canvas/*`, `@canvas-sdk`, or `@canvas-sdk/*`.
+- Do not use browser globals or side effects such as `window`, `document`, `fetch`, or `localStorage`.
+- Do not render fake shell chrome such as `browser frames`, `global app shells`, `left sidebars`, or `chat panes` unless the prompt explicitly asks for it.
+- Keep the composition flat, minimal, purposeful; avoid gradients, emojis, box shadows.
+
+Canvas SDK access:
+- Prefer MCP tool `read_canvas_sdk_resource` with uri `resource://routa/canvas-sdk/manifest`.
+- If your provider supports native MCP resource reads, you may read that same URI directly instead.
+- That manifest is the authoritative Canvas SDK index for this session.
+- Then read only the defs resources you actually need from its `definitionResources` list, preferably through `read_canvas_sdk_resource`.
+- Import only from `routa/canvas` or `react`.
+- If a symbol or prop is not present in those resources, do not invent it.
+- Example definition resources:
+- `resource://routa/canvas-sdk/defs/primitives`
+- `resource://routa/canvas-sdk/defs/hooks`
+- `resource://routa/canvas-sdk/defs/data-display`
+- `resource://routa/canvas-sdk/defs/containers`
+- `resource://routa/canvas-sdk/defs/controls`
+- `resource://routa/canvas-sdk/defs/charts`
+- `resource://routa/canvas-sdk/defs/diff-view`
+- `resource://routa/canvas-sdk/defs/dag-layout`
+- If neither direct resource reads nor the helper tool are available, stay conservative and use only the symbols named in the manifest.

--- a/src/app/api/acp/__tests__/route.test.ts
+++ b/src/app/api/acp/__tests__/route.test.ts
@@ -624,6 +624,7 @@ describe("/api/acp POST", () => {
       },
       "codex-thread-1",
       undefined,
+      undefined,
     );
     expect(acpProcessManager.createSession).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({

--- a/src/app/api/acp/acp-session-create.ts
+++ b/src/app/api/acp/acp-session-create.ts
@@ -25,6 +25,7 @@ import {
   buildExecutionBinding,
   refreshExecutionBinding,
 } from "@/core/acp/execution-backend";
+import { buildProviderModelArgs } from "@/core/acp/provider-model-args";
 import type { McpServerProfile } from "@/core/mcp/mcp-server-profiles";
 import { pendingAcpCreations } from "@/core/acp/pending-acp-creations";
 import { buildFeatureTreeSpecPromptSection } from "@/core/spec/feature-tree-spec-resource-contract";
@@ -692,17 +693,14 @@ export async function handleSessionNew({
           },
         );
       } else {
-        const extraArgs: string[] = [];
-        if (model && model.trim()) {
-          extraArgs.push("-m", model.trim());
-        }
+        const extraArgs = buildProviderModelArgs(provider, model);
         acpSessionId = await manager.createSession(
           sessionId,
           cwd,
           forwardSessionUpdate,
           provider,
           modeId,
-          extraArgs.length > 0 ? extraArgs : undefined,
+          extraArgs,
           undefined,
           workspaceId,
           resolvedToolMode,

--- a/src/app/api/acp/route.ts
+++ b/src/app/api/acp/route.ts
@@ -54,6 +54,7 @@ import {
   proxyRequestToRunner,
   runnerUnavailableResponse,
 } from "@/core/acp/runner-routing";
+import { buildProviderModelArgs } from "@/core/acp/provider-model-args";
 import { handleSessionNew, parseRequestedAcpMcpServers } from "./acp-session-create";
 import { getSessionWriteBuffer } from "./acp-session-history";
 import { handleSessionPrompt } from "./acp-session-prompt";
@@ -590,6 +591,7 @@ export async function POST(request: NextRequest) {
       let acpSessionId: string;
       let resumeMode: "native" | "recreated" = "recreated";
       let nativeResumeError: string | undefined;
+      const modelArgs = buildProviderModelArgs(provider, recoveredSession.model);
 
       // Determine whether native resume should be attempted based on provider capabilities
       const preset = getPresetById(provider);
@@ -616,6 +618,7 @@ export async function POST(request: NextRequest) {
             },
             providerSessionId,
             requestedAcpMcpServers.servers,
+            modelArgs,
           );
           resumeMode = "native";
         } else {
@@ -630,7 +633,7 @@ export async function POST(request: NextRequest) {
           forwardSessionUpdate,
           provider,
           recoveredSession.modeId,
-          undefined,
+          modelArgs,
           undefined,
           workspaceId,
           "toolMode" in recoveredSession

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
@@ -338,6 +338,38 @@ describe("SessionPageClient", () => {
     });
   });
 
+  it("keeps the slash skill fallback when structured pending skill context cannot load", async () => {
+    storePendingPrompt("session-1", {
+      text: "build repo slides",
+      skillName: "slide-skill",
+      skillRepoPath: "/tmp/routa/tools/ppt-template",
+    });
+    acpState.updates = [
+      { update: { sessionUpdate: "acp_status", status: "ready" } },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/skills?")) {
+        return {
+          ok: false,
+          json: async () => ({ error: "not found" }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ session: {}, sessions: [], specialists: [], globalMode: "essential" }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SessionPageClient />);
+
+    await waitFor(() => {
+      expect(mockPrompt).toHaveBeenCalledWith("/slide-skill build repo slides", undefined);
+    });
+  });
+
   it("renders RepoSlide session results when launched from RepoSlide", async () => {
     navState.searchParams = new URLSearchParams("source=reposlide&codebaseId=cb-1");
 

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
@@ -126,7 +126,27 @@ vi.mock("@/client/hooks/use-notes", () => ({
 }));
 
 vi.mock("@/client/components/chat-panel", () => ({
-  ChatPanel: () => <div data-testid="chat-panel">chat</div>,
+  ChatPanel: ({
+    canvasPromptLabel,
+    canvasPromptActive,
+    onDecoratePrompt,
+    onPrepareCanvasPrompt,
+  }: {
+    canvasPromptActive?: boolean;
+    canvasPromptLabel?: string;
+    onDecoratePrompt?: (text: string) => string;
+    onPrepareCanvasPrompt?: () => void;
+  }) => (
+    <div data-testid="chat-panel">
+      chat
+      {onPrepareCanvasPrompt && canvasPromptLabel && (
+        <button type="button" aria-pressed={canvasPromptActive} onClick={onPrepareCanvasPrompt}>
+          {canvasPromptLabel}
+        </button>
+      )}
+      {onDecoratePrompt && <div data-testid="decorated-prompt">{onDecoratePrompt("Draw workflow")}</div>}
+    </div>
+  ),
 }));
 
 vi.mock("../left-sidebar", () => ({
@@ -397,7 +417,7 @@ describe("SessionPageClient", () => {
     });
   });
 
-  it("shows the live Canvas prompt entry in the title bar", async () => {
+  it("shows the live Canvas prompt entry in the composer", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/specialists") {
@@ -418,7 +438,10 @@ describe("SessionPageClient", () => {
 
     render(<SessionPageClient />);
 
-    expect(await screen.findByRole("button", { name: "Prepare Canvas prompt" })).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "Use Canvas" }));
+
+    expect(await screen.findByRole("button", { name: "Use Canvas", pressed: true })).toBeTruthy();
+    expect((await screen.findByTestId("decorated-prompt")).textContent).toContain("Draw workflow");
   });
 
   it("shows a Resume action for codex sessions and calls ACP resume", async () => {

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx
@@ -397,6 +397,30 @@ describe("SessionPageClient", () => {
     });
   });
 
+  it("shows the live Canvas prompt entry in the title bar", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/specialists") {
+        return { ok: true, json: async () => ({ specialists: [] }) } as Response;
+      }
+      if (url === "/api/sessions/session-1") {
+        return { ok: true, json: async () => ({ session: {} }) } as Response;
+      }
+      if (url === "/api/sessions?parentSessionId=session-1") {
+        return { ok: true, json: async () => ({ sessions: [] }) } as Response;
+      }
+      if (url === "/api/mcp/tools") {
+        return { ok: true, json: async () => ({ globalMode: "essential" }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SessionPageClient />);
+
+    expect(await screen.findByRole("button", { name: "Prepare Canvas prompt" })).toBeTruthy();
+  });
+
   it("shows a Resume action for codex sessions and calls ACP resume", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AcpSessionNotification } from "@/client/acp-client";
+import { desktopAwareFetch } from "@/client/utils/diagnostics";
+import { useSessionCanvasArtifacts } from "../use-session-canvas-artifacts";
+
+vi.mock("@/client/utils/diagnostics", () => ({
+  desktopAwareFetch: vi.fn(),
+}));
+
+function createdCanvas(id: string) {
+  return {
+    ok: true,
+    json: async () => ({
+      id,
+      title: "Status",
+    }),
+  } as Response;
+}
+
+describe("useSessionCanvasArtifacts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(desktopAwareFetch).mockResolvedValue(createdCanvas("canvas-1"));
+  });
+
+  it("creates a canvas artifact when a tool completes writing a canvas file", async () => {
+    const { result, rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+        repoPath: "/repo",
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    rerender({
+      updates: [
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "tool-1",
+            status: "running",
+            rawInput: {
+              path: "canvases/status.canvas.tsx",
+              content: "export default function Canvas(){ return <div>Status</div>; }",
+            },
+          },
+        },
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+          },
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(desktopAwareFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, init] = vi.mocked(desktopAwareFetch).mock.calls[0] ?? [];
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      renderMode: "dynamic",
+      repoPath: "/repo",
+      source: "export default function Canvas(){ return <div>Status</div>; }",
+      title: "Status",
+      workspaceId: "default",
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeCanvas).toMatchObject({
+        fileName: "status.canvas.tsx",
+        filePath: "canvases/status.canvas.tsx",
+        id: "canvas-1",
+        title: "Status",
+        viewerUrl: "/canvas/canvas-1",
+      });
+    });
+  });
+
+  it("ignores completed canvas writes from other sessions", async () => {
+    const { rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    rerender({
+      updates: [
+        {
+          sessionId: "session-2",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+            rawInput: {
+              path: "canvases/status.canvas.tsx",
+              content: "export default function Canvas(){ return <div>Status</div>; }",
+            },
+          },
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(desktopAwareFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
@@ -136,6 +136,62 @@ describe("useSessionCanvasArtifacts", () => {
     });
   });
 
+  it("releases cached raw input after a tool call settles without rendering", async () => {
+    const { rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    const runningUpdate: AcpSessionNotification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        status: "running",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default () => <div>Status</div>;",
+        },
+      },
+    };
+    const failedUpdate: AcpSessionNotification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "failed",
+      },
+    };
+
+    rerender({ updates: [runningUpdate, failedUpdate] });
+    rerender({
+      updates: [
+        runningUpdate,
+        failedUpdate,
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+          },
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(desktopAwareFetch).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps an in-flight canvas materialization alive across non-canvas update rerenders", async () => {
     const pending = deferred<Response>();
     vi.mocked(desktopAwareFetch).mockReturnValueOnce(pending.promise);

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
@@ -192,6 +192,112 @@ describe("useSessionCanvasArtifacts", () => {
     });
   });
 
+  it("ignores completed OpenCode tool updates that carry error output", async () => {
+    const { rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    const runningUpdate: AcpSessionNotification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        status: "running",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default () => <div>Status</div>;",
+        },
+      },
+    };
+
+    rerender({
+      updates: [
+        runningUpdate,
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+            rawOutput: "Tool execution failed",
+          },
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(desktopAwareFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows a failed canvas materialization to retry the same candidate", async () => {
+    vi.mocked(desktopAwareFetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: "renderer unavailable" }),
+      } as Response)
+      .mockResolvedValueOnce(createdCanvas("canvas-retry"));
+
+    const { result, rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    const completedUpdate: AcpSessionNotification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default () => <div>Status</div>;",
+        },
+      },
+    };
+
+    rerender({ updates: [completedUpdate] });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("renderer unavailable");
+    });
+
+    rerender({
+      updates: [
+        completedUpdate,
+        { ...completedUpdate, update: { ...completedUpdate.update } },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(desktopAwareFetch).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.activeCanvas).toMatchObject({
+        id: "canvas-retry",
+        filePath: "canvases/status.canvas.tsx",
+      });
+    });
+  });
+
   it("keeps an in-flight canvas materialization alive across non-canvas update rerenders", async () => {
     const pending = deferred<Response>();
     vi.mocked(desktopAwareFetch).mockReturnValueOnce(pending.promise);

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AcpSessionNotification } from "@/client/acp-client";
@@ -17,6 +17,16 @@ function createdCanvas(id: string) {
       title: "Status",
     }),
   } as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
 }
 
 describe("useSessionCanvasArtifacts", () => {
@@ -50,7 +60,7 @@ describe("useSessionCanvasArtifacts", () => {
             status: "running",
             rawInput: {
               path: "canvases/status.canvas.tsx",
-              content: "export default function Canvas(){ return <div>Status</div>; }",
+              content: "export default () => <div>Status</div>;",
             },
           },
         },
@@ -74,7 +84,7 @@ describe("useSessionCanvasArtifacts", () => {
     expect(JSON.parse(String(init?.body))).toMatchObject({
       renderMode: "dynamic",
       repoPath: "/repo",
-      source: "export default function Canvas(){ return <div>Status</div>; }",
+      source: "export default () => <div>Status</div>;",
       title: "Status",
       workspaceId: "default",
     });
@@ -114,7 +124,7 @@ describe("useSessionCanvasArtifacts", () => {
             status: "completed",
             rawInput: {
               path: "canvases/status.canvas.tsx",
-              content: "export default function Canvas(){ return <div>Status</div>; }",
+              content: "export default () => <div>Status</div>;",
             },
           },
         },
@@ -123,6 +133,126 @@ describe("useSessionCanvasArtifacts", () => {
 
     await waitFor(() => {
       expect(desktopAwareFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps an in-flight canvas materialization alive across non-canvas update rerenders", async () => {
+    const pending = deferred<Response>();
+    vi.mocked(desktopAwareFetch).mockReturnValueOnce(pending.promise);
+    const canvasUpdates: AcpSessionNotification[] = [
+      {
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          status: "completed",
+          rawInput: {
+            path: "canvases/status.canvas.tsx",
+            content: "export default () => <div>Status</div>;",
+          },
+        },
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    rerender({ updates: canvasUpdates });
+    await waitFor(() => expect(result.current.isMaterializing).toBe(true));
+
+    rerender({
+      updates: [
+        ...canvasUpdates,
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "done" },
+          },
+        },
+      ],
+    });
+
+    await act(async () => {
+      pending.resolve(createdCanvas("canvas-2"));
+      await pending.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        activeCanvas: {
+          id: "canvas-2",
+          filePath: "canvases/status.canvas.tsx",
+        },
+        isMaterializing: false,
+      });
+    });
+  });
+
+  it("dismisses an in-flight canvas materialization when the panel is closed", async () => {
+    const pending = deferred<Response>();
+    vi.mocked(desktopAwareFetch).mockReturnValueOnce(pending.promise);
+    const { result, rerender } = renderHook(
+      ({ updates }) => useSessionCanvasArtifacts({
+        workspaceId: "default",
+        sessionId: "session-1",
+        updates,
+      }),
+      {
+        initialProps: {
+          updates: [] as AcpSessionNotification[],
+        },
+      },
+    );
+
+    rerender({
+      updates: [
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+            rawInput: {
+              path: "canvases/status.canvas.tsx",
+              content: "export default () => <div>Status</div>;",
+            },
+          },
+        },
+      ],
+    });
+
+    await waitFor(() => expect(result.current.isMaterializing).toBe(true));
+
+    act(() => {
+      result.current.clearActiveCanvas();
+    });
+
+    expect(result.current).toMatchObject({
+      activeCanvas: null,
+      error: null,
+      isMaterializing: false,
+    });
+
+    await act(async () => {
+      pending.resolve(createdCanvas("canvas-3"));
+      await pending.promise;
+    });
+
+    expect(result.current).toMatchObject({
+      activeCanvas: null,
+      error: null,
+      isMaterializing: false,
     });
   });
 });

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
@@ -36,7 +36,7 @@ import { useSessionCanvasArtifacts } from "./use-session-canvas-artifacts";
 import { RepoSlideSessionPanel } from "./repo-slide-session-panel";
 import { Select } from "@/client/components/select";
 import { useTranslation } from "@/i18n";
-import { ChevronDown, Columns2, Monitor, ScrollText, X } from "lucide-react";
+import { ChevronDown, Columns2, ScrollText, X } from "lucide-react";
 import { desktopAwareFetch } from "@/client/utils/diagnostics";
 import { buildLiveCanvasAgentPrompt } from "@/core/canvas/session-canvas-prompt";
 
@@ -232,7 +232,7 @@ export function SessionPageClient() {
   const [dockerErrorMessage, setDockerErrorMessage] = useState<string | null>(null);
   // Input text to restore when a docker session fails before prompt was sent
   const [dockerRetryText, setDockerRetryText] = useState<string | null>(null);
-  const [canvasPromptPrefill, setCanvasPromptPrefill] = useState<string | null>(null);
+  const [canvasPromptEnabled, setCanvasPromptEnabled] = useState(false);
   const navigationTargetRef = useRef<string | null>(null);
   const displaySessionId = focusedSessionId ?? sessionId;
 
@@ -828,20 +828,26 @@ export function SessionPageClient() {
   };
   const isPlanningSession = activeSessionRecord?.mcpProfile === "kanban-planning";
   const handlePrepareCanvasPrompt = () => {
-    setCanvasPromptPrefill(buildLiveCanvasAgentPrompt({ repoPath: repoSelection?.path }));
+    setCanvasPromptEnabled((enabled) => !enabled);
+  };
+  const decorateCanvasPrompt = (request: string) => {
+    return buildLiveCanvasAgentPrompt({
+      repoPath: repoSelection?.path,
+      request,
+    });
+  };
+  const handleCanvasPromptSent = () => {
+    setCanvasPromptEnabled(false);
   };
   const activeInputPrefill = dockerRetryText !== null
     ? { source: "docker" as const, text: dockerRetryText }
-    : canvasPromptPrefill !== null
-      ? { source: "canvas" as const, text: canvasPromptPrefill }
-      : null;
+    : null;
   const chatInputPrefill = activeInputPrefill?.text ?? null;
   const handleInputPrefillConsumed = () => {
     if (activeInputPrefill?.source === "docker") {
       setDockerRetryText(null);
       return;
     }
-    if (activeInputPrefill?.source === "canvas") setCanvasPromptPrefill(null);
   };
   const hasSessionCanvasPanel = Boolean(
     sessionCanvas.activeCanvas || sessionCanvas.isMaterializing || sessionCanvas.error,
@@ -872,16 +878,6 @@ export function SessionPageClient() {
   );
   const sessionTitleBarRight = (
     <>
-      <button
-        type="button"
-        onClick={handlePrepareCanvasPrompt}
-        className="inline-flex items-center gap-1.5 rounded-xl border border-desktop-border bg-desktop-bg-secondary px-2.5 py-1.5 text-[11px] font-medium text-desktop-text-primary transition-colors hover:bg-desktop-bg-active"
-        title={t.canvas.liveEntryLabel}
-        aria-label={t.canvas.liveEntryLabel}
-      >
-        <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
-        <span className="hidden lg:inline">{t.canvas.liveEntryLabel}</span>
-      </button>
       {agentSelector}
       {activeSessionRecord?.resumeCapabilities?.supported && activeSessionRecord?.cwd && (
         <button
@@ -1002,6 +998,12 @@ export function SessionPageClient() {
             codebases={codebases}
             inputPrefill={chatInputPrefill}
             onInputPrefillConsumed={handleInputPrefillConsumed}
+            onPrepareCanvasPrompt={handlePrepareCanvasPrompt}
+            canvasPromptActive={canvasPromptEnabled}
+            canvasPromptLabel={t.canvas.liveEntryLabel}
+            canvasPromptShortLabel={t.canvas.liveEntryShortLabel}
+            onDecoratePrompt={canvasPromptEnabled ? decorateCanvasPrompt : undefined}
+            onDecoratedPromptSent={handleCanvasPromptSent}
           />
         </div>
 

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
@@ -830,10 +830,18 @@ export function SessionPageClient() {
   const handlePrepareCanvasPrompt = () => {
     setCanvasPromptPrefill(buildLiveCanvasAgentPrompt({ repoPath: repoSelection?.path }));
   };
-  const chatInputPrefill = dockerRetryText ?? canvasPromptPrefill;
+  const activeInputPrefill = dockerRetryText !== null
+    ? { source: "docker" as const, text: dockerRetryText }
+    : canvasPromptPrefill !== null
+      ? { source: "canvas" as const, text: canvasPromptPrefill }
+      : null;
+  const chatInputPrefill = activeInputPrefill?.text ?? null;
   const handleInputPrefillConsumed = () => {
-    if (dockerRetryText) setDockerRetryText(null);
-    if (canvasPromptPrefill) setCanvasPromptPrefill(null);
+    if (activeInputPrefill?.source === "docker") {
+      setDockerRetryText(null);
+      return;
+    }
+    if (activeInputPrefill?.source === "canvas") setCanvasPromptPrefill(null);
   };
   const hasSessionCanvasPanel = Boolean(
     sessionCanvas.activeCanvas || sessionCanvas.isMaterializing || sessionCanvas.error,
@@ -872,7 +880,7 @@ export function SessionPageClient() {
         aria-label={t.canvas.liveEntryLabel}
       >
         <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
-        <span className="hidden lg:inline">{t.canvas.livePanelTitle}</span>
+        <span className="hidden lg:inline">{t.canvas.liveEntryLabel}</span>
       </button>
       {agentSelector}
       {activeSessionRecord?.resumeCapabilities?.supported && activeSessionRecord?.cwd && (

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/session-page-client.tsx
@@ -19,6 +19,7 @@ import {ChatPanel} from "@/client/components/chat-panel";
 import {SpecialistManager} from "@/client/components/specialist-manager";
 import {CraftersView} from "@/client/components/task-panel";
 import {AgentInstallPanel} from "@/client/components/agent-install-panel";
+import {SessionCanvasPanel} from "@/client/components/session-canvas-panel";
 import {LeftSidebar} from "./left-sidebar";
 import {DesktopAppShell} from "@/client/components/desktop-app-shell";
 import {WorkspaceSwitcher} from "@/client/components/workspace-switcher";
@@ -31,11 +32,13 @@ import {DockerConfigModal, loadDefaultProviders, loadProviderConnectionConfig, g
 import { useRealSessionParams } from "./use-real-session-params";
 import { type AgentRole, type SpecialistOption, useSessionPageBootstrap } from "./use-session-page-bootstrap";
 import { useSessionCrafters } from "./use-session-crafters";
+import { useSessionCanvasArtifacts } from "./use-session-canvas-artifacts";
 import { RepoSlideSessionPanel } from "./repo-slide-session-panel";
 import { Select } from "@/client/components/select";
 import { useTranslation } from "@/i18n";
-import { ChevronDown, Columns2, ScrollText, X } from "lucide-react";
+import { ChevronDown, Columns2, Monitor, ScrollText, X } from "lucide-react";
 import { desktopAwareFetch } from "@/client/utils/diagnostics";
+import { buildLiveCanvasAgentPrompt } from "@/core/canvas/session-canvas-prompt";
 
 
 interface SessionRecord {
@@ -229,6 +232,7 @@ export function SessionPageClient() {
   const [dockerErrorMessage, setDockerErrorMessage] = useState<string | null>(null);
   // Input text to restore when a docker session fails before prompt was sent
   const [dockerRetryText, setDockerRetryText] = useState<string | null>(null);
+  const [canvasPromptPrefill, setCanvasPromptPrefill] = useState<string | null>(null);
   const navigationTargetRef = useRef<string | null>(null);
   const displaySessionId = focusedSessionId ?? sessionId;
 
@@ -764,6 +768,13 @@ export function SessionPageClient() {
     resolveAgentConfig,
   });
 
+  const sessionCanvas = useSessionCanvasArtifacts({
+    workspaceId,
+    sessionId: displaySessionId,
+    updates: acpUpdates,
+    repoPath: repoSelection?.path,
+  });
+
   // Notes are now pre-filtered by useNotes(workspaceId, sessionId)
   // - Task notes: only those with matching sessionId
   // - Spec/general notes: workspace-wide (no sessionId) or matching sessionId
@@ -816,6 +827,18 @@ export function SessionPageClient() {
     updatedAt: new Date().toISOString(),
   };
   const isPlanningSession = activeSessionRecord?.mcpProfile === "kanban-planning";
+  const handlePrepareCanvasPrompt = () => {
+    setCanvasPromptPrefill(buildLiveCanvasAgentPrompt({ repoPath: repoSelection?.path }));
+  };
+  const chatInputPrefill = dockerRetryText ?? canvasPromptPrefill;
+  const handleInputPrefillConsumed = () => {
+    if (dockerRetryText) setDockerRetryText(null);
+    if (canvasPromptPrefill) setCanvasPromptPrefill(null);
+  };
+  const hasSessionCanvasPanel = Boolean(
+    sessionCanvas.activeCanvas || sessionCanvas.isMaterializing || sessionCanvas.error,
+  );
+  const showRightSidebar = !isEmbedMode && (hasSessionCanvasPanel || crafterAgents.length > 0);
   const agentSelector = (
     <div className="relative">
       <Select
@@ -841,6 +864,16 @@ export function SessionPageClient() {
   );
   const sessionTitleBarRight = (
     <>
+      <button
+        type="button"
+        onClick={handlePrepareCanvasPrompt}
+        className="inline-flex items-center gap-1.5 rounded-xl border border-desktop-border bg-desktop-bg-secondary px-2.5 py-1.5 text-[11px] font-medium text-desktop-text-primary transition-colors hover:bg-desktop-bg-active"
+        title={t.canvas.liveEntryLabel}
+        aria-label={t.canvas.liveEntryLabel}
+      >
+        <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
+        <span className="hidden lg:inline">{t.canvas.livePanelTitle}</span>
+      </button>
       {agentSelector}
       {activeSessionRecord?.resumeCapabilities?.supported && activeSessionRecord?.cwd && (
         <button
@@ -959,13 +992,13 @@ export function SessionPageClient() {
             activeWorkspaceId={workspaceId}
             onWorkspaceChange={handleWorkspaceSelect}
             codebases={codebases}
-            inputPrefill={dockerRetryText}
-            onInputPrefillConsumed={() => setDockerRetryText(null)}
+            inputPrefill={chatInputPrefill}
+            onInputPrefillConsumed={handleInputPrefillConsumed}
           />
         </div>
 
-        {/* ─── Right Sidebar: CRAFTERs running status ─────────────── */}
-        {!isEmbedMode && crafterAgents.length > 0 && (
+        {/* ─── Right Sidebar: live Canvas or CRAFTERs running status ─────────────── */}
+        {showRightSidebar && (
           <>
             {/* Right sidebar resize handle */}
             <div
@@ -978,45 +1011,56 @@ export function SessionPageClient() {
               className="hidden md:flex shrink-0 border-l border-[var(--dt-border)] bg-[var(--dt-bg-primary)] flex-col overflow-hidden"
               style={{ width: `${sidebarWidth}px` }}
             >
-              {/* CRAFTER agents header */}
-              <div className="px-3 py-2 border-b border-[var(--dt-border)] flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold text-[var(--dt-text-primary)]">
-                    {t.sessions.craftersLabel}
-                  </span>
-                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-[var(--dt-bg-active)] text-[var(--dt-accent)]">
-                    {crafterAgents.length}
-                  </span>
-                </div>
-                {/* Concurrency control */}
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-medium text-[var(--dt-text-secondary)] uppercase tracking-wider">
-                    {t.sessions.concurrencyLabel}
-                  </span>
-                  <div className="flex items-center rounded-md border border-[var(--dt-border)] overflow-hidden">
-                    {[1, 2].map((n) => (
-                      <button
-                        key={n}
-                        onClick={() => handleConcurrencyChange(n)}
-                        className={`px-2 py-0.5 text-[11px] font-medium transition-colors ${
-                          concurrency === n
-                            ? "bg-[var(--dt-accent)] text-[var(--dt-accent-text)]"
-                            : "bg-[var(--dt-bg-primary)] text-[var(--dt-text-secondary)] hover:bg-[var(--dt-bg-active)]"
-                        }`}
-                      >
-                        {n}
-                      </button>
-                    ))}
+              {hasSessionCanvasPanel ? (
+                <SessionCanvasPanel
+                  activeCanvas={sessionCanvas.activeCanvas}
+                  error={sessionCanvas.error}
+                  isMaterializing={sessionCanvas.isMaterializing}
+                  onClose={sessionCanvas.clearActiveCanvas}
+                />
+              ) : (
+                <>
+                  {/* CRAFTER agents header */}
+                  <div className="px-3 py-2 border-b border-[var(--dt-border)] flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-semibold text-[var(--dt-text-primary)]">
+                        {t.sessions.craftersLabel}
+                      </span>
+                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-[var(--dt-bg-active)] text-[var(--dt-accent)]">
+                        {crafterAgents.length}
+                      </span>
+                    </div>
+                    {/* Concurrency control */}
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-medium text-[var(--dt-text-secondary)] uppercase tracking-wider">
+                        {t.sessions.concurrencyLabel}
+                      </span>
+                      <div className="flex items-center rounded-md border border-[var(--dt-border)] overflow-hidden">
+                        {[1, 2].map((n) => (
+                          <button
+                            key={n}
+                            onClick={() => handleConcurrencyChange(n)}
+                            className={`px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                              concurrency === n
+                                ? "bg-[var(--dt-accent)] text-[var(--dt-accent-text)]"
+                                : "bg-[var(--dt-bg-primary)] text-[var(--dt-text-secondary)] hover:bg-[var(--dt-bg-active)]"
+                            }`}
+                          >
+                            {n}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-              {/* CRAFTERs content */}
-              <CraftersView
-                agents={crafterAgents}
-                activeCrafterId={activeCrafterId}
-                onSelectCrafter={handleSelectCrafter}
-                onUpdateAgentMessages={handleUpdateAgentMessages}
-              />
+                  {/* CRAFTERs content */}
+                  <CraftersView
+                    agents={crafterAgents}
+                    activeCrafterId={activeCrafterId}
+                    onSelectCrafter={handleSelectCrafter}
+                    onUpdateAgentMessages={handleUpdateAgentMessages}
+                  />
+                </>
+              )}
             </aside>
           </>
         )}

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
@@ -71,6 +71,30 @@ function isSettledCanvasToolUpdate(update: Record<string, unknown>): boolean {
   return false;
 }
 
+function isFailedCanvasToolUpdate(update: Record<string, unknown>): boolean {
+  const rawOutput = update.rawOutput;
+  const status = typeof update.status === "string" ? update.status.toLowerCase() : "";
+
+  if (status === "failed" || status === "error" || status === "canceled" || status === "cancelled") {
+    return true;
+  }
+
+  if (update.isError === true || update.error) {
+    return true;
+  }
+
+  if (typeof rawOutput === "string") {
+    return rawOutput.toLowerCase().includes("tool execution failed");
+  }
+
+  if (rawOutput && typeof rawOutput === "object") {
+    const output = rawOutput as Record<string, unknown>;
+    return output.isError === true || Boolean(output.error);
+  }
+
+  return false;
+}
+
 async function createCanvasArtifactFromCandidate(
   candidate: CanvasToolWriteCandidate,
   workspaceId: string,
@@ -159,7 +183,15 @@ export function useSessionCanvasArtifacts({
         rawInputByToolCallIdRef.current.set(toolCallId, mergedInput);
       }
 
-      const isSettledUpdate = isSettledCanvasToolUpdate(update);
+      const isFailedUpdate = isFailedCanvasToolUpdate(update);
+      const isSettledUpdate = isSettledCanvasToolUpdate(update) || isFailedUpdate;
+      if (isFailedUpdate) {
+        if (toolCallId && isSettledUpdate) {
+          rawInputByToolCallIdRef.current.delete(toolCallId);
+        }
+        continue;
+      }
+
       if (!isCompletedCanvasToolUpdate(update)) {
         if (toolCallId && isSettledUpdate) {
           rawInputByToolCallIdRef.current.delete(toolCallId);
@@ -185,6 +217,7 @@ export function useSessionCanvasArtifacts({
 
     if (!latestCandidate) return;
 
+    const latestCandidateKey = getCanvasToolWriteCandidateKey(latestCandidate);
     materializeRequestIdRef.current += 1;
     const requestId = materializeRequestIdRef.current;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- external ACP tool completion starts async artifact materialization.
@@ -198,6 +231,7 @@ export function useSessionCanvasArtifacts({
         }
       })
       .catch((createError: unknown) => {
+        processedCandidateKeysRef.current.delete(latestCandidateKey);
         if (materializeRequestIdRef.current === requestId) {
           setError(createError instanceof Error ? createError.message : "Failed to render canvas");
         }

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
@@ -99,6 +99,7 @@ export function useSessionCanvasArtifacts({
   const updatesLengthRef = useRef(updates.length);
   const processedCandidateKeysRef = useRef<Set<string>>(new Set());
   const rawInputByToolCallIdRef = useRef<Map<string, Record<string, unknown>>>(new Map());
+  const materializeRequestIdRef = useRef(0);
 
   useEffect(() => {
     updatesLengthRef.current = updates.length;
@@ -108,6 +109,7 @@ export function useSessionCanvasArtifacts({
     lastProcessedUpdateIndexRef.current = updatesLengthRef.current;
     processedCandidateKeysRef.current.clear();
     rawInputByToolCallIdRef.current.clear();
+    materializeRequestIdRef.current += 1;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- session switch must clear stale live Canvas panel state.
     setActiveCanvas(null);
     setError(null);
@@ -158,36 +160,35 @@ export function useSessionCanvasArtifacts({
 
     if (!latestCandidate) return;
 
-    let cancelled = false;
+    materializeRequestIdRef.current += 1;
+    const requestId = materializeRequestIdRef.current;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- external ACP tool completion starts async artifact materialization.
     setIsMaterializing(true);
     setError(null);
 
     void createCanvasArtifactFromCandidate(latestCandidate, workspaceId, repoPath)
       .then((created) => {
-        if (!cancelled) {
+        if (materializeRequestIdRef.current === requestId) {
           setActiveCanvas(created);
         }
       })
       .catch((createError: unknown) => {
-        if (!cancelled) {
+        if (materializeRequestIdRef.current === requestId) {
           setError(createError instanceof Error ? createError.message : "Failed to render canvas");
         }
       })
       .finally(() => {
-        if (!cancelled) {
+        if (materializeRequestIdRef.current === requestId) {
           setIsMaterializing(false);
         }
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, [repoPath, sessionId, updates, workspaceId]);
 
   const clearActiveCanvas = useCallback(() => {
+    materializeRequestIdRef.current += 1;
     setActiveCanvas(null);
     setError(null);
+    setIsMaterializing(false);
   }, []);
 
   return {

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { AcpSessionNotification } from "@/client/acp-client";
+import { resolveApiPath } from "@/client/config/backend";
+import { desktopAwareFetch } from "@/client/utils/diagnostics";
+import {
+  extractCanvasToolWriteCandidate,
+  getCanvasToolInputFromUpdate,
+  getCanvasToolWriteCandidateKey,
+  mergeCanvasToolInputs,
+  type CanvasToolWriteCandidate,
+} from "@/core/canvas/session-canvas-detection";
+
+export interface SessionCanvasArtifact {
+  fileName: string;
+  filePath: string;
+  id: string;
+  title: string;
+  viewerUrl: string;
+}
+
+export interface UseSessionCanvasArtifactsOptions {
+  repoPath?: string | null;
+  sessionId: string | null;
+  updates: AcpSessionNotification[];
+  workspaceId: string;
+}
+
+export interface UseSessionCanvasArtifactsResult {
+  activeCanvas: SessionCanvasArtifact | null;
+  clearActiveCanvas: () => void;
+  error: string | null;
+  isMaterializing: boolean;
+}
+
+interface CreateCanvasResponse {
+  id: string;
+  title?: string;
+}
+
+function getNotificationUpdate(notification: AcpSessionNotification): Record<string, unknown> {
+  return (notification.update ?? notification) as Record<string, unknown>;
+}
+
+function isTerminalCanvasToolUpdate(update: Record<string, unknown>): boolean {
+  const kind = typeof update.sessionUpdate === "string" ? update.sessionUpdate : "";
+  const status = typeof update.status === "string" ? update.status.toLowerCase() : "";
+
+  if (kind === "tool_call_update") {
+    return status === "completed" || status === "success" || status === "done";
+  }
+
+  return kind === "tool_call" && status === "completed";
+}
+
+async function createCanvasArtifactFromCandidate(
+  candidate: CanvasToolWriteCandidate,
+  workspaceId: string,
+  repoPath?: string | null,
+): Promise<SessionCanvasArtifact> {
+  const response = await desktopAwareFetch(resolveApiPath("/api/canvas"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      renderMode: "dynamic",
+      title: candidate.title,
+      source: candidate.source,
+      workspaceId,
+      repoPath: repoPath ?? undefined,
+    }),
+  });
+
+  const payload = await response.json().catch(() => null) as CreateCanvasResponse & { error?: string } | null;
+  if (!response.ok || !payload?.id) {
+    throw new Error(payload?.error ?? `Canvas artifact creation failed with HTTP ${response.status}`);
+  }
+
+  return {
+    fileName: candidate.fileName,
+    filePath: candidate.filePath,
+    id: payload.id,
+    title: payload.title ?? candidate.title,
+    viewerUrl: `/canvas/${payload.id}`,
+  };
+}
+
+export function useSessionCanvasArtifacts({
+  repoPath,
+  sessionId,
+  updates,
+  workspaceId,
+}: UseSessionCanvasArtifactsOptions): UseSessionCanvasArtifactsResult {
+  const [activeCanvas, setActiveCanvas] = useState<SessionCanvasArtifact | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isMaterializing, setIsMaterializing] = useState(false);
+  const lastProcessedUpdateIndexRef = useRef(updates.length);
+  const updatesLengthRef = useRef(updates.length);
+  const processedCandidateKeysRef = useRef<Set<string>>(new Set());
+  const rawInputByToolCallIdRef = useRef<Map<string, Record<string, unknown>>>(new Map());
+
+  useEffect(() => {
+    updatesLengthRef.current = updates.length;
+  }, [updates.length]);
+
+  useEffect(() => {
+    lastProcessedUpdateIndexRef.current = updatesLengthRef.current;
+    processedCandidateKeysRef.current.clear();
+    rawInputByToolCallIdRef.current.clear();
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- session switch must clear stale live Canvas panel state.
+    setActiveCanvas(null);
+    setError(null);
+    setIsMaterializing(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId || sessionId === "__placeholder__") return;
+    if (updates.length === 0) return;
+
+    if (lastProcessedUpdateIndexRef.current > updates.length) {
+      lastProcessedUpdateIndexRef.current = 0;
+    }
+    const pending = updates.slice(lastProcessedUpdateIndexRef.current);
+    if (pending.length === 0) return;
+    lastProcessedUpdateIndexRef.current = updates.length;
+
+    let latestCandidate: CanvasToolWriteCandidate | null = null;
+    for (const notification of pending) {
+      if (notification.sessionId !== sessionId) continue;
+
+      const update = getNotificationUpdate(notification);
+      const toolCallId = typeof update.toolCallId === "string" ? update.toolCallId : undefined;
+      const currentInput = getCanvasToolInputFromUpdate(update);
+      const previousInput = toolCallId
+        ? rawInputByToolCallIdRef.current.get(toolCallId)
+        : undefined;
+      const mergedInput = mergeCanvasToolInputs(previousInput, currentInput);
+
+      if (toolCallId && mergedInput) {
+        rawInputByToolCallIdRef.current.set(toolCallId, mergedInput);
+      }
+
+      if (!isTerminalCanvasToolUpdate(update)) continue;
+
+      const candidate = extractCanvasToolWriteCandidate({
+        previousRawInput: mergedInput,
+        sessionId,
+        update,
+      });
+      if (!candidate) continue;
+
+      const key = getCanvasToolWriteCandidateKey(candidate);
+      if (processedCandidateKeysRef.current.has(key)) continue;
+      processedCandidateKeysRef.current.add(key);
+      latestCandidate = candidate;
+    }
+
+    if (!latestCandidate) return;
+
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- external ACP tool completion starts async artifact materialization.
+    setIsMaterializing(true);
+    setError(null);
+
+    void createCanvasArtifactFromCandidate(latestCandidate, workspaceId, repoPath)
+      .then((created) => {
+        if (!cancelled) {
+          setActiveCanvas(created);
+        }
+      })
+      .catch((createError: unknown) => {
+        if (!cancelled) {
+          setError(createError instanceof Error ? createError.message : "Failed to render canvas");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsMaterializing(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath, sessionId, updates, workspaceId]);
+
+  const clearActiveCanvas = useCallback(() => {
+    setActiveCanvas(null);
+    setError(null);
+  }, []);
+
+  return {
+    activeCanvas,
+    clearActiveCanvas,
+    error,
+    isMaterializing,
+  };
+}

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-canvas-artifacts.ts
@@ -40,19 +40,35 @@ interface CreateCanvasResponse {
   title?: string;
 }
 
+const COMPLETED_TOOL_STATUSES = new Set(["completed", "success", "done"]);
+const SETTLED_TOOL_STATUSES = new Set([
+  ...COMPLETED_TOOL_STATUSES,
+  "canceled",
+  "cancelled",
+  "error",
+  "failed",
+]);
+
 function getNotificationUpdate(notification: AcpSessionNotification): Record<string, unknown> {
   return (notification.update ?? notification) as Record<string, unknown>;
 }
 
-function isTerminalCanvasToolUpdate(update: Record<string, unknown>): boolean {
+function isCompletedCanvasToolUpdate(update: Record<string, unknown>): boolean {
   const kind = typeof update.sessionUpdate === "string" ? update.sessionUpdate : "";
   const status = typeof update.status === "string" ? update.status.toLowerCase() : "";
 
-  if (kind === "tool_call_update") {
-    return status === "completed" || status === "success" || status === "done";
-  }
+  if (kind === "tool_call" || kind === "tool_call_update") return COMPLETED_TOOL_STATUSES.has(status);
 
-  return kind === "tool_call" && status === "completed";
+  return false;
+}
+
+function isSettledCanvasToolUpdate(update: Record<string, unknown>): boolean {
+  const kind = typeof update.sessionUpdate === "string" ? update.sessionUpdate : "";
+  const status = typeof update.status === "string" ? update.status.toLowerCase() : "";
+
+  if (kind === "tool_call" || kind === "tool_call_update") return SETTLED_TOOL_STATUSES.has(status);
+
+  return false;
 }
 
 async function createCanvasArtifactFromCandidate(
@@ -143,13 +159,22 @@ export function useSessionCanvasArtifacts({
         rawInputByToolCallIdRef.current.set(toolCallId, mergedInput);
       }
 
-      if (!isTerminalCanvasToolUpdate(update)) continue;
+      const isSettledUpdate = isSettledCanvasToolUpdate(update);
+      if (!isCompletedCanvasToolUpdate(update)) {
+        if (toolCallId && isSettledUpdate) {
+          rawInputByToolCallIdRef.current.delete(toolCallId);
+        }
+        continue;
+      }
 
       const candidate = extractCanvasToolWriteCandidate({
         previousRawInput: mergedInput,
         sessionId,
         update,
       });
+      if (toolCallId && isSettledUpdate) {
+        rawInputByToolCallIdRef.current.delete(toolCallId);
+      }
       if (!candidate) continue;
 
       const key = getCanvasToolWriteCandidateKey(candidate);

--- a/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-page-bootstrap.ts
+++ b/src/app/workspace/[workspaceId]/sessions/[sessionId]/use-session-page-bootstrap.ts
@@ -202,8 +202,11 @@ export function useSessionPageBootstrap(params: UseSessionPageBootstrapParams) {
       const skillContext = promptToSend.skillName
         ? await loadSkillContext(promptToSend.skillName, promptToSend.skillRepoPath)
         : undefined;
+      const promptText = promptToSend.skillName && !skillContext
+        ? `/${promptToSend.skillName} ${promptToSend.text}`
+        : promptToSend.text;
 
-      await acpPrompt(promptToSend.text, skillContext);
+      await acpPrompt(promptText, skillContext);
     };
 
     if (acpReady) {

--- a/src/app/workspace/[workspaceId]/sessions/sessions-page-client.tsx
+++ b/src/app/workspace/[workspaceId]/sessions/sessions-page-client.tsx
@@ -187,6 +187,10 @@ export function SessionsPageClient() {
               <HomeInput
                 workspaceId={workspaceId}
                 variant="default"
+                displaySkills={[{
+                  name: "canvas",
+                  description: t.canvas.liveEntryLabel,
+                }]}
                 launchModes={[{
                   id: "session",
                   label: t.home.modeSessionTitle,

--- a/src/client/components/__tests__/home-input.test.tsx
+++ b/src/client/components/__tests__/home-input.test.tsx
@@ -281,7 +281,11 @@ describe("HomeInput", () => {
     expect(args[11]).toBe("main");
 
     await waitFor(() => {
-      expect(storePendingPromptMock).toHaveBeenCalledWith("session-1", "/fix-tests Ship it");
+      expect(storePendingPromptMock).toHaveBeenCalledWith("session-1", {
+        text: "Ship it",
+        skillName: "fix-tests",
+        skillRepoPath: "/repo/main",
+      });
     });
     expect(promptSessionMock).not.toHaveBeenCalled();
     expect(onSessionCreated).toHaveBeenCalledWith(

--- a/src/client/components/__tests__/session-canvas-panel.test.tsx
+++ b/src/client/components/__tests__/session-canvas-panel.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SessionCanvasPanel } from "../session-canvas-panel";
+
+vi.mock("@/client/components/canvas-viewer", () => ({
+  CanvasViewer: ({ canvasId }: { canvasId: string }) => (
+    <div data-testid="canvas-viewer">{canvasId}</div>
+  ),
+}));
+
+describe("SessionCanvasPanel", () => {
+  it("renders the active canvas preview and detected file metadata", () => {
+    render(
+      <SessionCanvasPanel
+        activeCanvas={{
+          fileName: "status.canvas.tsx",
+          filePath: "/repo/canvases/status.canvas.tsx",
+          id: "canvas-1",
+          title: "Status",
+          viewerUrl: "/canvas/canvas-1",
+        }}
+        error={null}
+        isMaterializing={false}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("session-canvas-panel")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+    expect(screen.getByText("Detected file: status.canvas.tsx")).toBeTruthy();
+    expect(screen.getByTestId("canvas-viewer").textContent).toBe("canvas-1");
+    expect(screen.getByRole("link", { name: "Open canvas" }).getAttribute("href")).toBe("/canvas/canvas-1");
+  });
+
+  it("renders materializing and error states", () => {
+    const { rerender } = render(
+      <SessionCanvasPanel
+        activeCanvas={null}
+        error={null}
+        isMaterializing
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Rendering canvas...")).toBeTruthy();
+
+    rerender(
+      <SessionCanvasPanel
+        activeCanvas={null}
+        error="bad source"
+        isMaterializing={false}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Canvas render setup failed: bad source")).toBeTruthy();
+  });
+});

--- a/src/client/components/chat-panel.tsx
+++ b/src/client/components/chat-panel.tsx
@@ -28,7 +28,7 @@ import {
 import {TracePanel} from "@/client/components/trace-panel";
 import type {WorkspaceData, CodebaseData} from "../hooks/use-workspaces";
 import {getFileChangesSummary} from "../utils/file-changes-tracker";
-import { TriangleAlert, X, KeyRound, Copy, Check } from "lucide-react";
+import { TriangleAlert, X, KeyRound, Copy, Check, Monitor } from "lucide-react";
 import { useTranslation } from "@/i18n";
 
 
@@ -101,6 +101,13 @@ interface ChatPanelProps {
   inputPrefill?: string | null;
   /** Called after inputPrefill has been consumed */
   onInputPrefillConsumed?: () => void;
+  /** Optional composer tool action that enables Canvas prompt handling for the next turn. */
+  onPrepareCanvasPrompt?: () => void;
+  canvasPromptActive?: boolean;
+  canvasPromptLabel?: string;
+  canvasPromptShortLabel?: string;
+  onDecoratePrompt?: (text: string) => string;
+  onDecoratedPromptSent?: () => void;
   /** Optional recovery action for a selected historical session. */
   onResumeActiveSession?: () => Promise<void>;
 }
@@ -129,6 +136,12 @@ export function ChatPanel({
   codebases: _codebases = [],
   inputPrefill,
   onInputPrefillConsumed,
+  onPrepareCanvasPrompt,
+  canvasPromptActive,
+  canvasPromptLabel,
+  canvasPromptShortLabel,
+  onDecoratePrompt,
+  onDecoratedPromptSent,
   onResumeActiveSession,
 }: ChatPanelProps) {
   const { t } = useTranslation();
@@ -399,13 +412,28 @@ export function ChatPanel({
       return next;
     });
 
-    await promptSession(sid, finalPrompt, skillContext);
+    const decoratedPrompt = onDecoratePrompt ? onDecoratePrompt(finalPrompt) : finalPrompt;
+
+    await promptSession(sid, decoratedPrompt, skillContext);
+    if (onDecoratePrompt) onDecoratedPromptSent?.();
 
     // Reset streaming refs after sending
     resetStreamingRefs(sid);
 
     // Task extraction is now handled by the useEffect that watches messagesBySession
-  }, [activeSessionId, onEnsureSession, onSelectSession, promptSession, repoSelection, onLoadSkill, acp, resetStreamingRefs, setMessagesBySession]);
+  }, [
+    activeSessionId,
+    onEnsureSession,
+    onSelectSession,
+    promptSession,
+    repoSelection,
+    onLoadSkill,
+    acp,
+    resetStreamingRefs,
+    setMessagesBySession,
+    onDecoratePrompt,
+    onDecoratedPromptSent,
+  ]);
 
   // ── Setup State ──────────────────────────────────────────────────────
 
@@ -670,6 +698,23 @@ export function ChatPanel({
                 <TaskProgressBar tasks={taskInfos} fileChanges={fileChangesSummary} />
               )}
               <div className="flex gap-2 items-end">
+                {onPrepareCanvasPrompt && canvasPromptLabel && canvasPromptShortLabel && (
+                  <button
+                    type="button"
+                    onClick={onPrepareCanvasPrompt}
+                    className={`mb-[1px] flex h-10 shrink-0 items-center gap-2 rounded-xl border px-3 text-xs font-medium transition-colors ${
+                      canvasPromptActive
+                        ? "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-200"
+                        : "border-slate-200 bg-slate-50 text-slate-500 hover:border-blue-200 hover:bg-blue-50 hover:text-blue-700 dark:border-slate-700 dark:bg-[#161922] dark:text-slate-400 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-300"
+                    }`}
+                    title={canvasPromptLabel}
+                    aria-label={canvasPromptLabel}
+                    aria-pressed={canvasPromptActive}
+                  >
+                    <Monitor className="h-4 w-4" aria-hidden="true" />
+                    <span>{canvasPromptShortLabel}</span>
+                  </button>
+                )}
                 <TiptapInput
                   onSend={handleSend}
                   onStop={() => {

--- a/src/client/components/home-input.tsx
+++ b/src/client/components/home-input.tsx
@@ -414,6 +414,13 @@ export function HomeInput({
 
         if (result?.sessionId) {
           const promptText = context.skill ? `/${context.skill} ${text}` : text;
+          const pendingPrompt = context.skill
+            ? {
+                text,
+                skillName: context.skill,
+                skillRepoPath: effectiveCwd,
+              }
+            : text;
           const url = effectiveBuildSessionUrl
             ? effectiveBuildSessionUrl(wsId ?? null, result.sessionId)
             : wsId
@@ -424,7 +431,7 @@ export function HomeInput({
               console.error("[HomeInput] Failed to send direct prompt:", error);
             });
           } else {
-            storePendingPrompt(result.sessionId, promptText);
+            storePendingPrompt(result.sessionId, pendingPrompt);
           }
           onSessionCreated?.(result.sessionId, promptText, {
             cwd: effectiveCwd,

--- a/src/client/components/session-canvas-panel.tsx
+++ b/src/client/components/session-canvas-panel.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Component, Suspense, type ErrorInfo, type ReactNode } from "react";
+import { ExternalLink, Monitor, X } from "lucide-react";
+
+import { CanvasViewer } from "@/client/components/canvas-viewer";
+import { useTranslation } from "@/i18n";
+
+export interface SessionCanvasPanelArtifact {
+  fileName: string;
+  filePath: string;
+  id: string;
+  title: string;
+  viewerUrl: string;
+}
+
+export interface SessionCanvasPanelProps {
+  activeCanvas: SessionCanvasPanelArtifact | null;
+  error: string | null;
+  isMaterializing: boolean;
+  onClose: () => void;
+}
+
+interface CanvasPanelBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+  resetKey: string | null;
+}
+
+interface CanvasPanelBoundaryState {
+  hasError: boolean;
+}
+
+class CanvasPanelBoundary extends Component<CanvasPanelBoundaryProps, CanvasPanelBoundaryState> {
+  state: CanvasPanelBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): CanvasPanelBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(_error: Error, _errorInfo: ErrorInfo): void {
+    // The panel fallback is enough here; the underlying CanvasViewer already
+    // reports compilation errors inside the artifact preview.
+  }
+
+  componentDidUpdate(previousProps: CanvasPanelBoundaryProps): void {
+    if (previousProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) return this.props.fallback;
+    return this.props.children;
+  }
+}
+
+function CanvasPanelState({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "danger";
+}) {
+  return (
+    <div className="flex h-full items-center justify-center px-5 text-center">
+      <div
+        className={
+          tone === "danger"
+            ? "max-w-sm text-[12px] leading-5 text-red-600 dark:text-red-300"
+            : "max-w-sm text-[12px] leading-5 text-[var(--dt-text-secondary)]"
+        }
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function SessionCanvasPanel({
+  activeCanvas,
+  error,
+  isMaterializing,
+  onClose,
+}: SessionCanvasPanelProps) {
+  const { t } = useTranslation();
+  const fallback = (
+    <CanvasPanelState tone="danger">
+      {t.canvas.livePanelError}
+    </CanvasPanelState>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="session-canvas-panel">
+      <div className="flex min-h-10 items-center justify-between gap-2 border-b border-[var(--dt-border)] px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Monitor className="h-3.5 w-3.5 shrink-0 text-[var(--dt-accent)]" aria-hidden="true" />
+          <div className="min-w-0">
+            <div className="truncate text-xs font-semibold text-[var(--dt-text-primary)]">
+              {activeCanvas?.title ?? t.canvas.livePanelTitle}
+            </div>
+            {activeCanvas ? (
+              <div className="truncate text-[10px] text-[var(--dt-text-secondary)]" title={activeCanvas.filePath}>
+                {t.canvas.livePanelDetectedFile}: {activeCanvas.fileName}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {activeCanvas ? (
+            <a
+              href={activeCanvas.viewerUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--dt-text-secondary)] transition-colors hover:bg-[var(--dt-bg-active)] hover:text-[var(--dt-text-primary)]"
+              title={t.canvas.livePanelOpen}
+              aria-label={t.canvas.livePanelOpen}
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          ) : null}
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--dt-text-secondary)] transition-colors hover:bg-[var(--dt-bg-active)] hover:text-[var(--dt-text-primary)]"
+            title={t.canvas.livePanelClose}
+            aria-label={t.canvas.livePanelClose}
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto bg-[var(--dt-bg-primary)]">
+        {error ? (
+          <CanvasPanelState tone="danger">
+            {t.canvas.livePanelError}: {error}
+          </CanvasPanelState>
+        ) : activeCanvas ? (
+          <CanvasPanelBoundary resetKey={activeCanvas.id} fallback={fallback}>
+            <Suspense
+              fallback={(
+                <CanvasPanelState>
+                  {t.canvas.livePanelMaterializing}
+                </CanvasPanelState>
+              )}
+            >
+              <CanvasViewer canvasId={activeCanvas.id} />
+            </Suspense>
+          </CanvasPanelBoundary>
+        ) : (
+          <CanvasPanelState>
+            {isMaterializing ? t.canvas.livePanelMaterializing : t.canvas.livePanelPending}
+          </CanvasPanelState>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/core/acp/__tests__/acp-process.test.ts
+++ b/src/core/acp/__tests__/acp-process.test.ts
@@ -357,6 +357,56 @@ describe("AcpProcess codex permission handling", () => {
     vi.useRealTimers();
   });
 
+  it("uses structured stderr details for generic acp_status internal errors", async () => {
+    vi.useFakeTimers();
+    const onNotification = vi.fn();
+    const fakeProcess = new FakeProcess();
+    spawnMock.mockReturnValue(fakeProcess);
+
+    const process = createProcess(onNotification);
+    const startPromise = process.start();
+    await vi.advanceTimersByTimeAsync(500);
+    await startPromise;
+
+    fakeProcess.stderr.emit(
+      "data",
+      Buffer.from(
+        'ERROR codex_acp::thread: Unhandled error during turn: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The model requires a newer version of Codex."}} Some(Other)\n',
+        "utf-8",
+      ),
+    );
+    fakeProcess.stdout.emit(
+      "data",
+      Buffer.from(JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "codex-session",
+          update: {
+            sessionUpdate: "acp_status",
+            status: "error",
+            error: "Internal error",
+          },
+        },
+      }) + "\n", "utf-8"),
+    );
+
+    expect(onNotification).toHaveBeenLastCalledWith({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "codex-session",
+        update: {
+          sessionUpdate: "acp_status",
+          status: "error",
+          error: "The model requires a newer version of Codex.",
+        },
+      },
+    });
+
+    vi.useRealTimers();
+  });
+
   it("rejects pending requests when the process exits", async () => {
     vi.useFakeTimers();
     const fakeProcess = new FakeProcess();

--- a/src/core/acp/__tests__/acp-process.test.ts
+++ b/src/core/acp/__tests__/acp-process.test.ts
@@ -404,6 +404,35 @@ describe("AcpProcess codex permission handling", () => {
       },
     });
 
+    fakeProcess.stdout.emit(
+      "data",
+      Buffer.from(JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "codex-session",
+          update: {
+            sessionUpdate: "acp_status",
+            status: "error",
+            error: "Internal error",
+          },
+        },
+      }) + "\n", "utf-8"),
+    );
+
+    expect(onNotification).toHaveBeenLastCalledWith({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "codex-session",
+        update: {
+          sessionUpdate: "acp_status",
+          status: "error",
+          error: "Internal error",
+        },
+      },
+    });
+
     vi.useRealTimers();
   });
 

--- a/src/core/acp/__tests__/provider-model-args.test.ts
+++ b/src/core/acp/__tests__/provider-model-args.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProviderModelArgs } from "../provider-model-args";
+
+describe("buildProviderModelArgs", () => {
+  it("uses Codex ACP config overrides for Codex models", () => {
+    expect(buildProviderModelArgs("codex", "gpt-5.4")).toEqual([
+      "-c",
+      'model="gpt-5.4"',
+    ]);
+  });
+
+  it("uses generic model flags for providers that support -m", () => {
+    expect(buildProviderModelArgs("opencode", "anthropic/claude-sonnet-4-5")).toEqual([
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+    ]);
+  });
+
+  it("omits blank model overrides", () => {
+    expect(buildProviderModelArgs("codex", "  ")).toBeUndefined();
+  });
+});

--- a/src/core/acp/acp-process-manager.ts
+++ b/src/core/acp/acp-process-manager.ts
@@ -312,6 +312,7 @@ export class AcpProcessManager {
         sessionContext?: Omit<AcpSessionContext, "sessionId">,
         providerSessionId?: string,
         requestedAcpMcpServers?: Array<Record<string, unknown>>,
+        extraArgs?: string[],
     ): Promise<string> {
         try {
             const mcpSetup = await this.prepareMcpForSession(
@@ -326,7 +327,7 @@ export class AcpProcessManager {
             const config = await buildConfigFromPreset(
                 presetId,
                 cwd,
-                this.combineProviderArgs(mcpSetup?.providerArgs),
+                this.combineProviderArgs(mcpSetup?.providerArgs, extraArgs),
                 undefined,
                 mcpSetup?.mcpConfigs,
             );

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -79,6 +79,7 @@ export class AcpProcess {
     private _initResult: AcpInitResult | null = null;
     private _sessionContext: AcpSessionContext | null = null;
     private lastSyntheticTurnStopReason: string | null = null;
+    private lastStderrErrorMessage: string | null = null;
 
     constructor(config: AcpProcessConfig, onNotification: NotificationHandler) {
         this._config = config;
@@ -168,6 +169,7 @@ export class AcpProcess {
         this.process.stderr?.on("data", (chunk: Buffer) => {
             const text = chunk.toString("utf-8").trim();
             if (text) {
+                this.rememberStderrError(text);
                 console.error(`[AcpProcess:${displayName} stderr] ${text}`);
                 // Forward stderr to frontend as process_output notification
                 // This allows xterm.js to display agent process output
@@ -590,14 +592,15 @@ export class AcpProcess {
 
         // Notification (no id, has method) - e.g. session/update
         if (msg.method) {
-            const updateType = (msg.params as Record<string, unknown>)?.update;
+            const enrichedMsg = this.enrichAcpStatusError(msg);
+            const updateType = (enrichedMsg.params as Record<string, unknown>)?.update;
             const sessionUpdate = updateType
                 ? (updateType as Record<string, unknown>)?.sessionUpdate
-                : (msg.params as Record<string, unknown>)?.sessionUpdate;
+                : (enrichedMsg.params as Record<string, unknown>)?.sessionUpdate;
             console.log(
-                `[AcpProcess:${this._config.displayName}] Notification: ${msg.method} (${sessionUpdate ?? "unknown"})`
+                `[AcpProcess:${this._config.displayName}] Notification: ${enrichedMsg.method} (${sessionUpdate ?? "unknown"})`
             );
-            this.onNotification(msg);
+            this.onNotification(enrichedMsg);
             return;
         }
 
@@ -637,6 +640,60 @@ export class AcpProcess {
             },
         });
         return true;
+    }
+
+    private rememberStderrError(text: string): void {
+        const firstBrace = text.indexOf("{");
+        const lastBrace = text.lastIndexOf("}");
+        if (firstBrace < 0 || lastBrace <= firstBrace) {
+            return;
+        }
+
+        try {
+            const payload = JSON.parse(text.slice(firstBrace, lastBrace + 1)) as Record<string, unknown>;
+            const errorRecord = payload.error && typeof payload.error === "object"
+                ? payload.error as Record<string, unknown>
+                : undefined;
+            const message = typeof errorRecord?.message === "string"
+                ? errorRecord.message
+                : typeof payload.message === "string"
+                    ? payload.message
+                    : undefined;
+            if (message?.trim()) {
+                this.lastStderrErrorMessage = message.trim();
+            }
+        } catch {
+            // Stderr is not structured for many providers.
+        }
+    }
+
+    private enrichAcpStatusError(msg: JsonRpcMessage): JsonRpcMessage {
+        const params = msg.params && typeof msg.params === "object"
+            ? msg.params as Record<string, unknown>
+            : undefined;
+        const update = params?.update && typeof params.update === "object"
+            ? params.update as Record<string, unknown>
+            : undefined;
+
+        if (
+            update?.sessionUpdate !== "acp_status" ||
+            update.status !== "error" ||
+            update.error !== "Internal error" ||
+            !this.lastStderrErrorMessage
+        ) {
+            return msg;
+        }
+
+        return {
+            ...msg,
+            params: {
+                ...params,
+                update: {
+                    ...update,
+                    error: this.lastStderrErrorMessage,
+                },
+            },
+        };
     }
 
     /**

--- a/src/core/acp/acp-process.ts
+++ b/src/core/acp/acp-process.ts
@@ -684,13 +684,16 @@ export class AcpProcess {
             return msg;
         }
 
+        const enrichedError = this.lastStderrErrorMessage;
+        this.lastStderrErrorMessage = null;
+
         return {
             ...msg,
             params: {
                 ...params,
                 update: {
                     ...update,
-                    error: this.lastStderrErrorMessage,
+                    error: enrichedError,
                 },
             },
         };

--- a/src/core/acp/opencode-sdk-adapter.ts
+++ b/src/core/acp/opencode-sdk-adapter.ts
@@ -714,7 +714,7 @@ export class OpencodeSdkAdapter {
                 sessionUpdate: "tool_call_update",
                 title: toolName !== "unknown" ? toolName : (state.title ?? toolName),
                 toolCallId,
-                status: "completed",
+                status: "failed",
                 rawOutput: state.error ?? "Tool execution failed",
               },
             });

--- a/src/core/acp/provider-model-args.ts
+++ b/src/core/acp/provider-model-args.ts
@@ -1,0 +1,12 @@
+export function buildProviderModelArgs(provider: string, model: string | undefined): string[] | undefined {
+  const trimmedModel = model?.trim();
+  if (!trimmedModel) {
+    return undefined;
+  }
+
+  if (provider === "codex" || provider === "codex-acp") {
+    return ["-c", `model=${JSON.stringify(trimmedModel)}`];
+  }
+
+  return ["-m", trimmedModel];
+}

--- a/src/core/acp/session-prompt.ts
+++ b/src/core/acp/session-prompt.ts
@@ -27,6 +27,7 @@ import {
 import type { McpServerProfile } from "@/core/mcp/mcp-server-profiles";
 import { pendingAcpCreations } from "@/core/acp/pending-acp-creations";
 import { persistSessionHistorySnapshot } from "@/core/acp/session-history";
+import { buildProviderModelArgs } from "@/core/acp/provider-model-args";
 
 type JsonRpcResponseFactory = (
   id: string | number | null,
@@ -356,6 +357,7 @@ async function ensurePromptSessionExists(args: {
   const specialistId = recoveredSession?.specialistId;
   const specialistSystemPrompt = storedSession?.specialistSystemPrompt;
   const providerSessionId = recoveredSession?.routaAgentId ?? sessionId;
+  const modelArgs = buildProviderModelArgs(provider, recoveredSession?.model ?? storedSession?.model);
 
   try {
     const preset = getPresetById(provider);
@@ -450,6 +452,8 @@ async function ensurePromptSessionExists(args: {
             role,
           },
           providerSessionId,
+          undefined,
+          modelArgs,
         );
         console.log(`[ACP Route] Native Codex resume succeeded for session ${sessionId}`);
       } catch (resumeError) {
@@ -460,7 +464,7 @@ async function ensurePromptSessionExists(args: {
           forwardSessionUpdate,
           provider,
           undefined,
-          undefined,
+          modelArgs,
           undefined,
           workspaceId,
           toolMode,
@@ -470,6 +474,7 @@ async function ensurePromptSessionExists(args: {
             provider,
             role,
           },
+          undefined,
         );
       }
     } else {
@@ -479,7 +484,7 @@ async function ensurePromptSessionExists(args: {
         forwardSessionUpdate,
         provider,
         undefined,
-        undefined,
+        modelArgs,
         undefined,
         workspaceId,
         toolMode,
@@ -489,6 +494,7 @@ async function ensurePromptSessionExists(args: {
           provider,
           role,
         },
+        undefined,
       );
     }
 

--- a/src/core/canvas/__tests__/session-canvas-detection.test.ts
+++ b/src/core/canvas/__tests__/session-canvas-detection.test.ts
@@ -16,7 +16,7 @@ describe("session canvas detection", () => {
         status: "completed",
         rawInput: {
           path: "canvases/status.canvas.tsx",
-          content: "export default function Canvas(){ return <div>Status</div>; }",
+          content: "export default () => <div>Status</div>;",
         },
       },
     });
@@ -28,7 +28,7 @@ describe("session canvas detection", () => {
       title: "Status",
       toolCallId: "tool-1",
     });
-    expect(candidate?.source).toContain("export default function Canvas");
+    expect(candidate?.source).toContain("export default");
   });
 
   it("extracts a canvas from an apply_patch add-file hunk", () => {
@@ -44,9 +44,9 @@ describe("session canvas detection", () => {
             "*** Add File: canvases/agent-flow.canvas.tsx",
             "+import { Card } from \"routa/canvas\";",
             "+",
-            "+export default function Canvas(){",
-            "+  return <Card title=\"Flow\">Ready</Card>;",
-            "+}",
+            "+export default () => (",
+            "+  <Card title=\"Flow\">Ready</Card>",
+            "+);",
             "*** End Patch",
           ].join("\n"),
         },
@@ -58,7 +58,7 @@ describe("session canvas detection", () => {
       filePath: "canvases/agent-flow.canvas.tsx",
       title: "Agent Flow",
     });
-    expect(candidate?.source).toContain("export default function Canvas");
+    expect(candidate?.source).toContain("export default");
   });
 
   it("ignores non-canvas paths and non-renderable source", () => {
@@ -68,7 +68,7 @@ describe("session canvas detection", () => {
         sessionUpdate: "tool_call_update",
         rawInput: {
           path: "src/status.tsx",
-          content: "export default function Canvas(){ return <div />; }",
+          content: "export default () => <div />;",
         },
       },
     })).toBeNull();
@@ -93,14 +93,42 @@ describe("session canvas detection", () => {
         toolCallId: "tool-1",
         rawInput: {
           path: "canvases/status.canvas.tsx",
-          content: "export default function Canvas(){ return <div>Status</div>; }",
+          content: "export default () => <div>Status</div>;",
         },
       },
     });
 
-    expect(candidate ? getCanvasToolWriteCandidateKey(candidate) : "").toBe(
-      "session-1:tool-1:canvases/status.canvas.tsx:61",
-    );
+    const key = candidate ? getCanvasToolWriteCandidateKey(candidate) : "";
+    expect(key).toMatch(/^session-1:tool-1:canvases\/status\.canvas\.tsx:[a-z0-9]+$/);
+    expect(key).not.toBe("session-1:tool-1:canvases/status.canvas.tsx:61");
+  });
+
+  it("does not collide for same-length canvas source without a tool call id", () => {
+    const first = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default () => <div>AB</div>;",
+        },
+      },
+    });
+    const second = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default () => <div>CD</div>;",
+        },
+      },
+    });
+
+    expect(first?.source).toHaveLength(second?.source.length ?? -1);
+    expect(first && second
+      ? getCanvasToolWriteCandidateKey(first) === getCanvasToolWriteCandidateKey(second)
+      : true).toBe(false);
   });
 });
 

--- a/src/core/canvas/__tests__/session-canvas-detection.test.ts
+++ b/src/core/canvas/__tests__/session-canvas-detection.test.ts
@@ -61,6 +61,44 @@ describe("session canvas detection", () => {
     expect(candidate?.source).toContain("export default");
   });
 
+  it("extracts a canvas from an apply_patch update-file overwrite hunk", () => {
+    const candidate = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-3",
+        status: "completed",
+        rawInput: {
+          patch: [
+            "*** Begin Patch",
+            "*** Update File: canvases/agent-flow.canvas.tsx",
+            "@@",
+            "-import { Card } from \"routa/canvas\";",
+            "-",
+            "-export default () => (",
+            "-  <Card title=\"Flow\">Old</Card>",
+            "-);",
+            "+import { Card } from \"routa/canvas\";",
+            "+",
+            "+export default () => (",
+            "+  <Card title=\"Flow\">Ready</Card>",
+            "+);",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      },
+    });
+
+    expect(candidate).toMatchObject({
+      fileName: "agent-flow.canvas.tsx",
+      filePath: "canvases/agent-flow.canvas.tsx",
+      title: "Agent Flow",
+      toolCallId: "tool-3",
+    });
+    expect(candidate?.source).toContain("Ready");
+    expect(candidate?.source).not.toContain("Old");
+  });
+
   it("ignores non-canvas paths and non-renderable source", () => {
     expect(extractCanvasToolWriteCandidate({
       sessionId: "session-1",

--- a/src/core/canvas/__tests__/session-canvas-detection.test.ts
+++ b/src/core/canvas/__tests__/session-canvas-detection.test.ts
@@ -99,6 +99,31 @@ describe("session canvas detection", () => {
     expect(candidate?.source).not.toContain("Old");
   });
 
+  it("ignores partial apply_patch update-file hunks without a full canvas module", () => {
+    const candidate = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-3",
+        status: "completed",
+        rawInput: {
+          patch: [
+            "*** Begin Patch",
+            "*** Update File: canvases/agent-flow.canvas.tsx",
+            "@@",
+            "   <Card title=\"Flow\">",
+            "-    Old",
+            "+    Ready",
+            "   </Card>",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      },
+    });
+
+    expect(candidate).toBeNull();
+  });
+
   it("ignores non-canvas paths and non-renderable source", () => {
     expect(extractCanvasToolWriteCandidate({
       sessionId: "session-1",

--- a/src/core/canvas/__tests__/session-canvas-detection.test.ts
+++ b/src/core/canvas/__tests__/session-canvas-detection.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractCanvasToolWriteCandidate,
+  getCanvasToolWriteCandidateKey,
+} from "../session-canvas-detection";
+import { buildLiveCanvasAgentPrompt } from "../session-canvas-prompt";
+
+describe("session canvas detection", () => {
+  it("extracts a direct Write tool candidate for a canvas file", () => {
+    const candidate = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default function Canvas(){ return <div>Status</div>; }",
+        },
+      },
+    });
+
+    expect(candidate).toMatchObject({
+      fileName: "status.canvas.tsx",
+      filePath: "canvases/status.canvas.tsx",
+      sessionId: "session-1",
+      title: "Status",
+      toolCallId: "tool-1",
+    });
+    expect(candidate?.source).toContain("export default function Canvas");
+  });
+
+  it("extracts a canvas from an apply_patch add-file hunk", () => {
+    const candidate = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-2",
+        status: "completed",
+        rawInput: {
+          patch: [
+            "*** Begin Patch",
+            "*** Add File: canvases/agent-flow.canvas.tsx",
+            "+import { Card } from \"routa/canvas\";",
+            "+",
+            "+export default function Canvas(){",
+            "+  return <Card title=\"Flow\">Ready</Card>;",
+            "+}",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      },
+    });
+
+    expect(candidate).toMatchObject({
+      fileName: "agent-flow.canvas.tsx",
+      filePath: "canvases/agent-flow.canvas.tsx",
+      title: "Agent Flow",
+    });
+    expect(candidate?.source).toContain("export default function Canvas");
+  });
+
+  it("ignores non-canvas paths and non-renderable source", () => {
+    expect(extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        rawInput: {
+          path: "src/status.tsx",
+          content: "export default function Canvas(){ return <div />; }",
+        },
+      },
+    })).toBeNull();
+
+    expect(extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "not a component",
+        },
+      },
+    })).toBeNull();
+  });
+
+  it("builds a stable candidate key", () => {
+    const candidate = extractCanvasToolWriteCandidate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        rawInput: {
+          path: "canvases/status.canvas.tsx",
+          content: "export default function Canvas(){ return <div>Status</div>; }",
+        },
+      },
+    });
+
+    expect(candidate ? getCanvasToolWriteCandidateKey(candidate) : "").toBe(
+      "session-1:tool-1:canvases/status.canvas.tsx:61",
+    );
+  });
+});
+
+describe("live canvas prompt", () => {
+  it("adapts the canvas skill into a Routa agent prompt", () => {
+    const prompt = buildLiveCanvasAgentPrompt({
+      repoPath: "/Users/phodal/ai/routa-js",
+      request: "Render the latest tool result.",
+    });
+
+    expect(prompt).toContain("Create or overwrite exactly one `*.canvas.tsx` file");
+    expect(prompt).toContain("read_canvas_sdk_resource");
+    expect(prompt).toContain("Import only from `routa/canvas` or `react`.");
+    expect(prompt).toContain("/Users/phodal/ai/routa-js");
+    expect(prompt).toContain("Render the latest tool result.");
+  });
+});

--- a/src/core/canvas/session-canvas-detection.ts
+++ b/src/core/canvas/session-canvas-detection.ts
@@ -122,6 +122,8 @@ function extractApplyPatchCandidate(
       const line = lines[lineIndex] ?? "";
       if (line.startsWith("*** ")) break;
       if (line.startsWith("@@")) continue;
+      // Update patches only contain the changed hunk, so extraction is best-effort:
+      // it only materializes when the hunk includes enough context to form a full Canvas module.
       if (line.startsWith("+") || (operation === "update" && line.startsWith(" "))) {
         sourceLines.push(line.slice(1));
       }

--- a/src/core/canvas/session-canvas-detection.ts
+++ b/src/core/canvas/session-canvas-detection.ts
@@ -105,7 +105,7 @@ function buildCandidate(
   };
 }
 
-function extractAddFilePatchCandidate(
+function extractApplyPatchCandidate(
   sessionId: string,
   patch: string,
   toolCallId?: string,
@@ -113,19 +113,21 @@ function extractAddFilePatchCandidate(
   const lines = patch.replace(/\r\n/g, "\n").split("\n");
 
   for (let index = 0; index < lines.length; index += 1) {
-    const match = lines[index]?.match(/^\*\*\* Add File:\s+(.+\.canvas\.tsx)\s*$/i);
+    const match = lines[index]?.match(/^\*\*\* (Add|Update) File:\s+(.+\.canvas\.tsx)\s*$/i);
     if (!match) continue;
 
+    const operation = match[1]?.toLowerCase();
     const sourceLines: string[] = [];
     for (let lineIndex = index + 1; lineIndex < lines.length; lineIndex += 1) {
       const line = lines[lineIndex] ?? "";
       if (line.startsWith("*** ")) break;
-      if (line.startsWith("+")) {
+      if (line.startsWith("@@")) continue;
+      if (line.startsWith("+") || (operation === "update" && line.startsWith(" "))) {
         sourceLines.push(line.slice(1));
       }
     }
 
-    const candidate = buildCandidate(sessionId, match[1].trim(), sourceLines.join("\n"), toolCallId);
+    const candidate = buildCandidate(sessionId, match[2].trim(), sourceLines.join("\n"), toolCallId);
     if (candidate) return candidate;
   }
 
@@ -192,8 +194,8 @@ export function extractCanvasToolWriteCandidate({
 
   const patch = readString(rawInput, ["patch", "diff"]);
   if (patch) {
-    const addFileCandidate = extractAddFilePatchCandidate(sessionId, patch, toolCallId);
-    if (addFileCandidate) return addFileCandidate;
+    const applyPatchCandidate = extractApplyPatchCandidate(sessionId, patch, toolCallId);
+    if (applyPatchCandidate) return applyPatchCandidate;
 
     const gitDiffCandidate = extractGitDiffNewFileCandidate(sessionId, patch, toolCallId);
     if (gitDiffCandidate) return gitDiffCandidate;

--- a/src/core/canvas/session-canvas-detection.ts
+++ b/src/core/canvas/session-canvas-detection.ts
@@ -1,0 +1,216 @@
+import { extractCanvasSourceFromSpecialistOutput } from "./specialist-source";
+
+const CANVAS_FILE_SUFFIX = ".canvas.tsx";
+
+const PATH_KEYS = [
+  "path",
+  "file_path",
+  "filePath",
+  "filepath",
+  "absolute_path",
+  "target_file",
+  "filename",
+];
+
+const SOURCE_KEYS = [
+  "content",
+  "new_string",
+  "text",
+  "source",
+  "file_content",
+  "code",
+];
+
+const TOOL_UPDATE_KINDS = new Set([
+  "tool_call",
+  "tool_call_update",
+  "tool_call_params_delta",
+]);
+
+export interface CanvasToolWriteCandidate {
+  fileName: string;
+  filePath: string;
+  sessionId: string;
+  source: string;
+  title: string;
+  toolCallId?: string;
+}
+
+export interface CanvasToolWriteCandidateInput {
+  previousRawInput?: Record<string, unknown>;
+  sessionId: string;
+  update: Record<string, unknown>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function isCanvasFilePath(value: string): boolean {
+  return value.trim().toLowerCase().endsWith(CANVAS_FILE_SUFFIX);
+}
+
+function getFileName(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).at(-1) ?? filePath;
+}
+
+function toTitle(filePath: string): string {
+  const fileName = getFileName(filePath);
+  const stem = fileName.slice(0, -CANVAS_FILE_SUFFIX.length);
+  const words = stem
+    .split(/[-_\s.]+/)
+    .map((word) => word.trim())
+    .filter(Boolean);
+
+  if (words.length === 0) return "Canvas";
+
+  return words
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+function normalizeCanvasSource(source: string): string | null {
+  return extractCanvasSourceFromSpecialistOutput(source);
+}
+
+function buildCandidate(
+  sessionId: string,
+  filePath: string,
+  rawSource: string,
+  toolCallId?: string,
+): CanvasToolWriteCandidate | null {
+  if (!isCanvasFilePath(filePath)) return null;
+
+  const source = normalizeCanvasSource(rawSource);
+  if (!source) return null;
+
+  return {
+    fileName: getFileName(filePath),
+    filePath,
+    sessionId,
+    source,
+    title: toTitle(filePath),
+    toolCallId,
+  };
+}
+
+function extractAddFilePatchCandidate(
+  sessionId: string,
+  patch: string,
+  toolCallId?: string,
+): CanvasToolWriteCandidate | null {
+  const lines = patch.replace(/\r\n/g, "\n").split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index]?.match(/^\*\*\* Add File:\s+(.+\.canvas\.tsx)\s*$/i);
+    if (!match) continue;
+
+    const sourceLines: string[] = [];
+    for (let lineIndex = index + 1; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex] ?? "";
+      if (line.startsWith("*** ")) break;
+      if (line.startsWith("+")) {
+        sourceLines.push(line.slice(1));
+      }
+    }
+
+    const candidate = buildCandidate(sessionId, match[1].trim(), sourceLines.join("\n"), toolCallId);
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
+function extractGitDiffNewFileCandidate(
+  sessionId: string,
+  patch: string,
+  toolCallId?: string,
+): CanvasToolWriteCandidate | null {
+  const sections = patch.replace(/\r\n/g, "\n").split(/^diff --git /gm);
+
+  for (const section of sections) {
+    const filePath = section.match(/^\+\+\+\s+b\/(.+\.canvas\.tsx)\s*$/im)?.[1]?.trim();
+    if (!filePath) continue;
+    if (!/new file mode/im.test(section)) continue;
+
+    const source = section
+      .split("\n")
+      .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+      .map((line) => line.slice(1))
+      .join("\n");
+
+    const candidate = buildCandidate(sessionId, filePath, source, toolCallId);
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
+export function getCanvasToolInputFromUpdate(
+  update: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const rawInput = update.rawInput;
+  if (isPlainObject(rawInput)) return rawInput;
+
+  const parsedInput = update.parsedInput;
+  if (isPlainObject(parsedInput)) return parsedInput;
+
+  return undefined;
+}
+
+export function mergeCanvasToolInputs(
+  previous: Record<string, unknown> | undefined,
+  next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!previous) return next;
+  if (!next) return previous;
+  return { ...previous, ...next };
+}
+
+export function extractCanvasToolWriteCandidate({
+  previousRawInput,
+  sessionId,
+  update,
+}: CanvasToolWriteCandidateInput): CanvasToolWriteCandidate | null {
+  const sessionUpdate = typeof update.sessionUpdate === "string" ? update.sessionUpdate : "";
+  if (!TOOL_UPDATE_KINDS.has(sessionUpdate)) return null;
+
+  const toolCallId = typeof update.toolCallId === "string" ? update.toolCallId : undefined;
+  const rawInput = mergeCanvasToolInputs(previousRawInput, getCanvasToolInputFromUpdate(update));
+  if (!rawInput) return null;
+
+  const patch = readString(rawInput, ["patch", "diff"]);
+  if (patch) {
+    const addFileCandidate = extractAddFilePatchCandidate(sessionId, patch, toolCallId);
+    if (addFileCandidate) return addFileCandidate;
+
+    const gitDiffCandidate = extractGitDiffNewFileCandidate(sessionId, patch, toolCallId);
+    if (gitDiffCandidate) return gitDiffCandidate;
+  }
+
+  const filePath = readString(rawInput, PATH_KEYS);
+  const rawSource = readString(rawInput, SOURCE_KEYS);
+  if (!filePath || !rawSource) return null;
+
+  return buildCandidate(sessionId, filePath, rawSource, toolCallId);
+}
+
+export function getCanvasToolWriteCandidateKey(candidate: CanvasToolWriteCandidate): string {
+  return [
+    candidate.sessionId,
+    candidate.toolCallId ?? "",
+    candidate.filePath,
+    candidate.source.length,
+  ].join(":");
+}

--- a/src/core/canvas/session-canvas-detection.ts
+++ b/src/core/canvas/session-canvas-detection.ts
@@ -206,11 +206,21 @@ export function extractCanvasToolWriteCandidate({
   return buildCandidate(sessionId, filePath, rawSource, toolCallId);
 }
 
+function hashCanvasSource(source: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
 export function getCanvasToolWriteCandidateKey(candidate: CanvasToolWriteCandidate): string {
   return [
     candidate.sessionId,
     candidate.toolCallId ?? "",
     candidate.filePath,
-    candidate.source.length,
+    hashCanvasSource(candidate.source),
   ].join(":");
 }

--- a/src/core/canvas/session-canvas-prompt.ts
+++ b/src/core/canvas/session-canvas-prompt.ts
@@ -1,0 +1,33 @@
+import { buildCanvasSpecialistContractLines } from "./generation-contract";
+import { buildCanvasSdkPromptSection } from "./sdk-manifest";
+
+export interface LiveCanvasPromptInput {
+  repoPath?: string | null;
+  request?: string | null;
+}
+
+export function buildLiveCanvasAgentPrompt(input: LiveCanvasPromptInput = {}): string {
+  const repoPath = input.repoPath?.trim();
+  const request = input.request?.trim() || "Create a Routa Canvas for the current work.";
+
+  return [
+    "Use Routa Canvas for this turn.",
+    "",
+    "Canvas behavior:",
+    "- Create or overwrite exactly one `*.canvas.tsx` file during the tool run.",
+    "- The file content must be the TSX source itself, not markdown.",
+    repoPath
+      ? `- Prefer storing the file under this repository when appropriate: \`${repoPath}\`.`
+      : "- Prefer storing the file under the selected repository when appropriate.",
+    "- Use a short descriptive file name ending in `.canvas.tsx`.",
+    "- After the file is created, mention the created path briefly.",
+    "",
+    "Source contract:",
+    ...buildCanvasSpecialistContractLines().map((line) => `- ${line}`),
+    "",
+    buildCanvasSdkPromptSection(),
+    "",
+    "User request:",
+    request,
+  ].join("\n");
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -196,7 +196,8 @@ const en: TranslationDictionary = {
     viewerCannotRender:
       "Cannot render canvas: missing source for dynamic mode or canvasType for prebuilt mode.",
     viewerCompilationError: "Canvas compilation error:",
-    liveEntryLabel: "Prepare Canvas prompt",
+    liveEntryLabel: "Use Canvas",
+    liveEntryShortLabel: "Canvas",
     livePanelTitle: "Canvas",
     livePanelPending: "Waiting for a canvas file.",
     livePanelMaterializing: "Rendering canvas...",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -196,6 +196,14 @@ const en: TranslationDictionary = {
     viewerCannotRender:
       "Cannot render canvas: missing source for dynamic mode or canvasType for prebuilt mode.",
     viewerCompilationError: "Canvas compilation error:",
+    liveEntryLabel: "Prepare Canvas prompt",
+    livePanelTitle: "Canvas",
+    livePanelPending: "Waiting for a canvas file.",
+    livePanelMaterializing: "Rendering canvas...",
+    livePanelOpen: "Open canvas",
+    livePanelClose: "Close canvas panel",
+    livePanelDetectedFile: "Detected file",
+    livePanelError: "Canvas render setup failed",
   },
 
   featureExplorer: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -195,6 +195,14 @@ const zh: TranslationDictionary = {
     viewerCannotRender:
       "无法渲染画布：动态模式缺少 source，或预置模式缺少 canvasType。",
     viewerCompilationError: "Canvas 编译错误：",
+    liveEntryLabel: "准备 Canvas 提示词",
+    livePanelTitle: "Canvas",
+    livePanelPending: "等待 Canvas 文件。",
+    livePanelMaterializing: "正在渲染 Canvas...",
+    livePanelOpen: "打开 Canvas",
+    livePanelClose: "关闭 Canvas 面板",
+    livePanelDetectedFile: "检测到文件",
+    livePanelError: "Canvas 渲染准备失败",
   },
 
   featureExplorer: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -195,7 +195,8 @@ const zh: TranslationDictionary = {
     viewerCannotRender:
       "无法渲染画布：动态模式缺少 source，或预置模式缺少 canvasType。",
     viewerCompilationError: "Canvas 编译错误：",
-    liveEntryLabel: "准备 Canvas 提示词",
+    liveEntryLabel: "使用 Canvas",
+    liveEntryShortLabel: "Canvas",
     livePanelTitle: "Canvas",
     livePanelPending: "等待 Canvas 文件。",
     livePanelMaterializing: "正在渲染 Canvas...",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -201,6 +201,14 @@ export interface TranslationDictionary extends ExtendedTranslationDictionarySect
     viewerToggleDarkTheme: string;
     viewerCannotRender: string;
     viewerCompilationError: string;
+    liveEntryLabel: string;
+    livePanelTitle: string;
+    livePanelPending: string;
+    livePanelMaterializing: string;
+    livePanelOpen: string;
+    livePanelClose: string;
+    livePanelDetectedFile: string;
+    livePanelError: string;
   };
 
   featureExplorer: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -202,6 +202,7 @@ export interface TranslationDictionary extends ExtendedTranslationDictionarySect
     viewerCannotRender: string;
     viewerCompilationError: string;
     liveEntryLabel: string;
+    liveEntryShortLabel: string;
     livePanelTitle: string;
     livePanelPending: string;
     livePanelMaterializing: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
     exclude: ["**/node_modules/**", "**/dist/**", "**/.next/**", "src/client/utils/__tests__/**", "**/.routa/**", "**/.worktrees/**"], // Exclude old test files and .routa cache
     css: true,
+    maxWorkers: 2,
+    testTimeout: 30_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Add a Routa live Canvas prompt adapted from the cursor-canvas skill contract.
- Detect completed ACP tool writes for `*.canvas.tsx` from direct write/edit payloads and `apply_patch` add-file hunks.
- Add a session title-bar Canvas entry and right-side live Canvas preview panel that materializes detected source through `/api/canvas`.
- Add i18n strings and focused coverage for detection, hook behavior, panel rendering, and the session entry.

## Validation
- `npx vitest run src/core/canvas/__tests__/session-canvas-detection.test.ts 'src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/use-session-canvas-artifacts.test.tsx' src/client/components/__tests__/session-canvas-panel.test.tsx 'src/app/workspace/[workspaceId]/sessions/[sessionId]/__tests__/session-page-client.test.tsx'`
- `npx tsc --noEmit`
- targeted `npx eslint ...`
- `entrix run --tier fast`
- push hook: eslint, ts typecheck, TS full tests, clippy, graph test mapping probe, Rust tests

## UI Evidence
- Playwright smoke opened `/workspace/default/sessions/session-1`, found the `Prepare Canvas prompt` button, clicked it, verified `Use Routa Canvas for this turn.` was inserted, and observed no page errors.
- Local screenshot artifact: `/tmp/routa-session-canvas-smoke.png`

## Notes
- Auto-render currently requires the ACP tool event to expose the canvas path and source, or an `apply_patch` add-file hunk. Shell commands that create `*.canvas.tsx` without exposing source in the event still need a file watcher or backend read endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Canvas experience: "Prepare Canvas" control in chat, decorated canvas prompts, computed chat prefill behavior, right‑sidebar Canvas panel with viewer/open and close actions, and clear/materializing/error states.

* **Tests**
  * Added comprehensive tests covering the Canvas UI, materialization hook, panel states, detection logic, and prompt generation.

* **Chores**
  * Added English and Chinese localization strings for the Live Canvas UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->