### PR TITLE
feat(settings): add inline spec file preview to spec-sources panel

### DIFF
--- a/src/app/api/harness/spec-sources/__tests__/file-route.test.ts
+++ b/src/app/api/harness/spec-sources/__tests__/file-route.test.ts
@@ -1,0 +1,99 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const system = {
+  codebaseStore: {
+    get: vi.fn(),
+    listByWorkspace: vi.fn(),
+  },
+};
+
+const getCurrentRoutaRepoRootMock = vi.fn();
+
+vi.mock("@/core/routa-system", () => ({
+  getRoutaSystem: () => system,
+}));
+
+vi.mock("@/core/fitness/repo-root", () => ({
+  getCurrentRoutaRepoRoot: () => getCurrentRoutaRepoRootMock(),
+}));
+
+// Lazy import after mocks
+let GET: (req: import("next/server").NextRequest) => Promise<Response>;
+beforeEach(async () => {
+  vi.resetModules();
+  ({ GET } = await import("../file/route"));
+});
+
+function makeRequest(params: Record<string, string>): import("next/server").NextRequest {
+  const url = new URL("http://localhost/api/harness/spec-sources/file");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return { nextUrl: url } as unknown as import("next/server").NextRequest;
+}
+
+describe("GET /api/harness/spec-sources/file", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "routa-spec-file-"));
+    system.codebaseStore.get.mockResolvedValue(undefined);
+    system.codebaseStore.listByWorkspace.mockResolvedValue([]);
+    getCurrentRoutaRepoRootMock.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns file content when the file exists within the repo root", async () => {
+    const filePath = "docs/spec.md";
+    const absoluteFilePath = path.join(tempDir, filePath);
+    fs.mkdirSync(path.dirname(absoluteFilePath), { recursive: true });
+    fs.writeFileSync(absoluteFilePath, "# Spec content");
+
+    const req = makeRequest({ repoPath: tempDir, filePath });
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.content).toBe("# Spec content");
+    expect(body.filePath).toBe(filePath);
+  });
+
+  it("returns 404 when the file does not exist", async () => {
+    const req = makeRequest({ repoPath: tempDir, filePath: "missing.md" });
+    const res = await GET(req);
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found|找不到|未找到/i);
+  });
+
+  it("returns 400 for invalid context (no workspaceId/codebaseId/repoPath)", async () => {
+    const req = makeRequest({ filePath: "docs/spec.md" });
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when filePath is missing", async () => {
+    const req = makeRequest({ repoPath: tempDir });
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/filePath/i);
+  });
+
+  it("returns 400 when filePath attempts path traversal outside repoRoot", async () => {
+    const req = makeRequest({ repoPath: tempDir, filePath: "../../etc/passwd" });
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/path traversal|invalid path|范围/i);
+  });
+});

--- a/src/app/api/harness/spec-sources/file/route.ts
+++ b/src/app/api/harness/spec-sources/file/route.ts
@@ -1,0 +1,63 @@
+import { promises as fsp } from "fs";
+import * as path from "path";
+import { NextRequest, NextResponse } from "next/server";
+import { isContextError, normalizeContextValue, parseContext, resolveRepoRoot } from "../../hooks/shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const filePath = normalizeContextValue(request.nextUrl.searchParams.get("filePath"));
+    if (!filePath) {
+      return NextResponse.json(
+        { error: "filePath 参数是必填项" },
+        { status: 400 },
+      );
+    }
+
+    const context = parseContext(request.nextUrl.searchParams);
+    const repoRoot = await resolveRepoRoot(context);
+
+    // Resolve and validate no path traversal outside repoRoot
+    const resolvedFilePath = path.resolve(/* turbopackIgnore: true */ repoRoot, filePath);
+    if (!resolvedFilePath.startsWith(repoRoot + path.sep) && resolvedFilePath !== repoRoot) {
+      return NextResponse.json(
+        { error: "文件路径超出仓库根目录范围，不允许访问" },
+        { status: 400 },
+      );
+    }
+
+    let content: string;
+    try {
+      content = await fsp.readFile(resolvedFilePath, "utf-8");
+    } catch (readError) {
+      const msg = toMessage(readError);
+      if (msg.includes("ENOENT") || msg.includes("no such file")) {
+        return NextResponse.json(
+          { error: "文件未找到", details: filePath },
+          { status: 404 },
+        );
+      }
+      throw readError;
+    }
+
+    return NextResponse.json({ content, filePath });
+  } catch (error) {
+    const message = toMessage(error);
+    if (isContextError(message)) {
+      return NextResponse.json(
+        { error: "Spec 文件读取上下文无效", details: message },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "读取 spec 文件失败", details: message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/settings/harness/harness-console-page.tsx
+++ b/src/app/settings/harness/harness-console-page.tsx
@@ -476,7 +476,7 @@ export default function HarnessConsolePage() {
     const props = { repoLabel: selectedRepoLabel, unsupportedMessage: unsupportedRepoMessage };
     switch (selectedGovernanceNodeId) {
       case "thinking":
-        return <HarnessSpecSourcesPanel {...props} data={specSourcesState.data} loading={specSourcesState.loading} error={specSourcesState.error} variant="compact" />;
+        return <HarnessSpecSourcesPanel workspaceId={workspaceId} codebaseId={activeRepoCodebaseId} repoPath={activeRepoPath} {...props} data={specSourcesState.data} loading={specSourcesState.loading} error={specSourcesState.error} variant="compact" />;
       case "coding":
         return <HarnessDesignDecisionPanel {...props} data={designDecisionsState.data} loading={designDecisionsState.loading} error={designDecisionsState.error} variant="compact" />;
       case "build":
@@ -871,7 +871,7 @@ export default function HarnessConsolePage() {
           />
         );
       case "spec-sources":
-        return <HarnessSpecSourcesPanel {...sharedProps} data={specSourcesState.data} loading={specSourcesState.loading} error={specSourcesState.error} hideHeader />;
+        return <HarnessSpecSourcesPanel workspaceId={workspaceId} codebaseId={activeRepoCodebaseId} repoPath={activeRepoPath} {...sharedProps} data={specSourcesState.data} loading={specSourcesState.loading} error={specSourcesState.error} hideHeader />;
       case "agent-instructions":
         return <HarnessAgentInstructionsPanel workspaceId={workspaceId} codebaseId={activeRepoCodebaseId} repoPath={activeRepoPath} {...sharedProps} data={instructionsState.data} loading={instructionsState.loading} error={instructionsState.error} onAuditRerun={reloadInstructions} hideHeader />;
       case "design-decisions":

--- a/src/client/components/__tests__/harness-spec-sources-panel.test.tsx
+++ b/src/client/components/__tests__/harness-spec-sources-panel.test.tsx
@@ -1,7 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { HarnessSpecSourcesPanel } from "../harness-spec-sources-panel";
+
+vi.mock("@/client/utils/diagnostics", () => ({
+  desktopAwareFetch: vi.fn(),
+}));
+
+import { desktopAwareFetch } from "@/client/utils/diagnostics";
+const mockFetch = desktopAwareFetch as ReturnType<typeof vi.fn>;
 
 const sampleData = {
   generatedAt: "2026-03-30T00:00:00.000Z",
@@ -36,6 +44,9 @@ const sampleData = {
 };
 
 describe("HarnessSpecSourcesPanel", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
   it("hides stale compact source cards while loading", () => {
     render(
       <HarnessSpecSourcesPanel
@@ -76,5 +87,67 @@ describe("HarnessSpecSourcesPanel", () => {
     expect(screen.getByText("Feature Tree")).not.toBeNull();
     expect(screen.queryByText(".kiro/specs/feature/requirements.md")).toBeNull();
     expect(screen.getByText("docs/prd.md")).not.toBeNull();
+  });
+
+  it("renders a preview button for each flat spec file when context props are provided", () => {
+    render(
+      <HarnessSpecSourcesPanel
+        repoLabel="repo"
+        data={sampleData}
+        repoPath="/tmp/repo"
+      />,
+    );
+
+    // bmad source has children (prd.md) — should have a preview button
+    const previewButtons = screen.getAllByRole("button", { name: /preview|预览/i });
+    expect(previewButtons.length).toBeGreaterThan(0);
+  });
+
+  it("shows file content after clicking preview button", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: "# PRD Content\nThis is the spec.", filePath: "docs/prd.md" }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <HarnessSpecSourcesPanel
+        repoLabel="repo"
+        data={sampleData}
+        repoPath="/tmp/repo"
+      />,
+    );
+
+    const previewButtons = screen.getAllByRole("button", { name: /preview|预览/i });
+    await user.click(previewButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/# PRD Content/)).not.toBeNull();
+    });
+  });
+
+  it("shows error message when file fetch fails", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "文件未找到", details: "docs/prd.md" }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <HarnessSpecSourcesPanel
+        repoLabel="repo"
+        data={sampleData}
+        repoPath="/tmp/repo"
+      />,
+    );
+
+    const previewButtons = screen.getAllByRole("button", { name: /preview|预览/i });
+    await user.click(previewButtons[0]);
+
+    await waitFor(() => {
+      // Should show a friendly error, not throw
+      const errorMsg = screen.queryByText(/failed|error|失败|找不到|未找到|not found/i);
+      expect(errorMsg).not.toBeNull();
+    });
   });
 });

--- a/src/client/components/harness-spec-sources-panel.tsx
+++ b/src/client/components/harness-spec-sources-panel.tsx
@@ -12,6 +12,8 @@ import type {
 import { HarnessSectionCard, HarnessSectionStateFrame } from "@/client/components/harness-section-card";
 import { useTranslation } from "@/i18n";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { desktopAwareFetch } from "@/client/utils/diagnostics";
+import { resolveApiPath } from "@/client/config/backend";
 
 
 type SpecSourcesPanelProps = {
@@ -22,6 +24,9 @@ type SpecSourcesPanelProps = {
   error?: string | null;
   variant?: "full" | "compact";
   hideHeader?: boolean;
+  workspaceId?: string;
+  codebaseId?: string;
+  repoPath?: string;
 };
 
 type SpecSourceI18nLabels = {
@@ -32,6 +37,17 @@ type SpecSourceI18nLabels = {
   specCount: (count: number) => string;
   qoderIntegration: string;
   integrationDetected: (system: string) => string;
+  previewFile: string;
+  previewLoading: string;
+  previewClose: string;
+  previewError: string;
+  previewNotFound: string;
+};
+
+type FilePreviewContext = {
+  workspaceId?: string;
+  codebaseId?: string;
+  repoPath?: string;
 };
 
 const CONFIDENCE_STYLES: Record<SpecConfidence, { bg: string; text: string }> = {
@@ -128,7 +144,83 @@ function ChevronIcon({ expanded, className }: { expanded: boolean; className?: s
   );
 }
 
-function KiroFeatureTree({ features, labels }: { features: SpecFeature[]; labels: SpecSourceI18nLabels }) {
+type PreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; content: string }
+  | { status: "error"; message: string };
+
+function SpecFilePreviewButton({
+  filePath,
+  context,
+  labels,
+}: {
+  filePath: string;
+  context: FilePreviewContext;
+  labels: Pick<SpecSourceI18nLabels, "previewFile" | "previewLoading" | "previewClose" | "previewError" | "previewNotFound">;
+}) {
+  const [preview, setPreview] = useState<PreviewState>({ status: "idle" });
+
+  const togglePreview = async () => {
+    if (preview.status === "ready" || preview.status === "error") {
+      setPreview({ status: "idle" });
+      return;
+    }
+
+    setPreview({ status: "loading" });
+    try {
+      const params = new URLSearchParams({ filePath });
+      if (context.workspaceId) params.set("workspaceId", context.workspaceId);
+      if (context.codebaseId) params.set("codebaseId", context.codebaseId);
+      if (context.repoPath) params.set("repoPath", context.repoPath);
+
+      const response = await desktopAwareFetch(resolveApiPath(`/api/harness/spec-sources/file?${params.toString()}`));
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const errorMsg = typeof payload?.error === "string" ? payload.error : labels.previewError;
+        if (response.status === 404) {
+          setPreview({ status: "error", message: labels.previewNotFound });
+        } else {
+          setPreview({ status: "error", message: errorMsg });
+        }
+        return;
+      }
+      setPreview({ status: "ready", content: typeof payload.content === "string" ? payload.content : "" });
+    } catch {
+      setPreview({ status: "error", message: labels.previewError });
+    }
+  };
+
+  const isOpen = preview.status === "ready" || preview.status === "error";
+  const buttonLabel = isOpen ? labels.previewClose : labels.previewFile;
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-label={buttonLabel}
+        className="ml-1 rounded px-1.5 py-0.5 text-[9px] font-medium text-desktop-text-secondary hover:bg-desktop-bg-secondary hover:text-desktop-text-primary"
+        onClick={togglePreview}
+      >
+        {preview.status === "loading" ? labels.previewLoading : buttonLabel}
+      </button>
+
+      {preview.status === "ready" && (
+        <pre className="mt-1 max-h-48 overflow-y-auto rounded border border-desktop-border bg-desktop-bg-secondary px-2 py-1.5 text-[9px] font-mono text-desktop-text-primary whitespace-pre-wrap break-all">
+          {preview.content}
+        </pre>
+      )}
+
+      {preview.status === "error" && (
+        <div className="mt-1 rounded border border-red-200 bg-red-50/50 px-2 py-1 text-[9px] text-red-600">
+          {preview.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KiroFeatureTree({ features, labels, context }: { features: SpecFeature[]; labels: SpecSourceI18nLabels; context?: FilePreviewContext }) {
   const [expandedFeatures, setExpandedFeatures] = useState<Set<string> | null>(null);
   const activeExpandedFeatures = expandedFeatures ?? new Set<string>();
 
@@ -160,9 +252,14 @@ function KiroFeatureTree({ features, labels }: { features: SpecFeature[]; labels
             </button>
 
             {isExpanded && feature.documents.map((doc) => (
-              <div key={doc.path} className="ml-5 flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[10px]">
-                <SpecTypeTag label={labels.typeLabels[doc.type] ?? doc.type} />
-                <span className="min-w-0 truncate font-mono text-desktop-text-primary">{doc.path}</span>
+              <div key={doc.path} className="ml-5 rounded px-1.5 py-0.5 text-[10px]">
+                <div className="flex items-center gap-1.5">
+                  <SpecTypeTag label={labels.typeLabels[doc.type] ?? doc.type} />
+                  <span className="min-w-0 truncate font-mono text-desktop-text-primary">{doc.path}</span>
+                  {context && (
+                    <SpecFilePreviewButton filePath={doc.path} context={context} labels={labels} />
+                  )}
+                </div>
               </div>
             ))}
           </div>
@@ -172,20 +269,25 @@ function KiroFeatureTree({ features, labels }: { features: SpecFeature[]; labels
   );
 }
 
-function FlatSpecList({ specs, labels }: { specs: SpecSource["children"]; labels: SpecSourceI18nLabels }) {
+function FlatSpecList({ specs, labels, context }: { specs: SpecSource["children"]; labels: SpecSourceI18nLabels; context?: FilePreviewContext }) {
   return (
     <div className="space-y-0.5">
       {specs.map((spec) => (
-        <div key={spec.path} className="flex items-center gap-2 rounded px-1.5 py-0.5 text-[10px] hover:bg-desktop-bg-secondary/60">
-          <SpecTypeTag label={labels.typeLabels[spec.type] ?? spec.type} />
-          <span className="min-w-0 truncate font-mono text-desktop-text-primary">{spec.path}</span>
+        <div key={spec.path} className="rounded px-1.5 py-0.5 text-[10px] hover:bg-desktop-bg-secondary/60">
+          <div className="flex items-center gap-2">
+            <SpecTypeTag label={labels.typeLabels[spec.type] ?? spec.type} />
+            <span className="min-w-0 truncate font-mono text-desktop-text-primary">{spec.path}</span>
+            {context && (
+              <SpecFilePreviewButton filePath={spec.path} context={context} labels={labels} />
+            )}
+          </div>
         </div>
       ))}
     </div>
   );
 }
 
-function SpecSourceCard({ source, expanded, onToggle, labels }: { source: SpecSource; expanded: boolean; onToggle: () => void; labels: SpecSourceI18nLabels }) {
+function SpecSourceCard({ source, expanded, onToggle, labels, context }: { source: SpecSource; expanded: boolean; onToggle: () => void; labels: SpecSourceI18nLabels; context?: FilePreviewContext }) {
   const icon = SYSTEM_ICONS[source.system] ?? source.system.charAt(0).toUpperCase();
   const hasFeatures = source.features && source.features.length > 0;
   const specCount = hasFeatures ? source.features!.length : source.children.length;
@@ -228,9 +330,9 @@ function SpecSourceCard({ source, expanded, onToggle, labels }: { source: SpecSo
       {expanded && (
         <div className="max-h-80 overflow-y-auto border-t border-desktop-border px-3 py-2">
           {hasFeatures ? (
-            <KiroFeatureTree features={source.features!} labels={labels} />
+            <KiroFeatureTree features={source.features!} labels={labels} context={context} />
           ) : source.children.length > 0 ? (
-            <FlatSpecList specs={source.children} labels={labels} />
+            <FlatSpecList specs={source.children} labels={labels} context={context} />
           ) : source.status === "installed-only" ? (
             <div className="rounded-sm border border-sky-200 bg-sky-50/50 px-2.5 py-2 text-[10px] text-sky-700">
               {source.system === "qoder"
@@ -244,12 +346,13 @@ function SpecSourceCard({ source, expanded, onToggle, labels }: { source: SpecSo
   );
 }
 
-function SourceGroup({ title, sources, expandedKeys, onToggle, labels }: {
+function SourceGroup({ title, sources, expandedKeys, onToggle, labels, context }: {
   title: string;
   sources: SpecSource[];
   expandedKeys: Set<string>;
   onToggle: (key: string) => void;
   labels: SpecSourceI18nLabels;
+  context?: FilePreviewContext;
 }) {
   if (sources.length === 0) return null;
 
@@ -268,6 +371,7 @@ function SourceGroup({ title, sources, expandedKeys, onToggle, labels }: {
               expanded={expandedKeys.has(key)}
               onToggle={() => onToggle(key)}
               labels={labels}
+              context={context}
             />
           );
         })}
@@ -284,6 +388,9 @@ export function HarnessSpecSourcesPanel({
   error,
   variant = "full",
   hideHeader = false,
+  workspaceId,
+  codebaseId,
+  repoPath,
 }: SpecSourcesPanelProps) {
   const { t } = useTranslation();
   const sources = useMemo(
@@ -342,7 +449,17 @@ export function HarnessSpecSourcesPanel({
       : t.harness.specSources.specCount.replace('{count}', `${count}`),
     qoderIntegration: t.harness.specSources.qoderIntegration,
     integrationDetected: (system: string) => t.harness.specSources.integrationDetected.replace('{system}', system),
+    previewFile: t.harness.specSources.previewFile,
+    previewLoading: t.harness.specSources.previewLoading,
+    previewClose: t.harness.specSources.previewClose,
+    previewError: t.harness.specSources.previewError,
+    previewNotFound: t.harness.specSources.previewNotFound,
   }), [t]);
+
+  // Only provide file preview context when at least one context param is available
+  const filePreviewContext: FilePreviewContext | undefined = (workspaceId || codebaseId || repoPath)
+    ? { workspaceId, codebaseId, repoPath }
+    : undefined;
 
   const isCompact = variant === "compact";
 
@@ -382,6 +499,7 @@ export function HarnessSpecSourcesPanel({
               expanded={activeExpandedKeys.has(key)}
               onToggle={() => toggleKey(key)}
               labels={labels}
+              context={filePreviewContext}
             />
           );
         }) : null}
@@ -414,10 +532,10 @@ export function HarnessSpecSourcesPanel({
 
       {!loading && !unsupportedMessage && sources.length > 0 ? (
         <div className="mt-3 space-y-3" data-testid="spec-sources-full">
-          <SourceGroup title={t.harness.specSources.nativeTools} sources={nativeTools} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} />
-          <SourceGroup title={t.harness.specSources.frameworks} sources={frameworks} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} />
-          <SourceGroup title={t.harness.specSources.integrations} sources={integrations} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} />
-          <SourceGroup title={t.harness.specSources.legacy} sources={legacy} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} />
+          <SourceGroup title={t.harness.specSources.nativeTools} sources={nativeTools} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} context={filePreviewContext} />
+          <SourceGroup title={t.harness.specSources.frameworks} sources={frameworks} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} context={filePreviewContext} />
+          <SourceGroup title={t.harness.specSources.integrations} sources={integrations} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} context={filePreviewContext} />
+          <SourceGroup title={t.harness.specSources.legacy} sources={legacy} expandedKeys={activeExpandedKeys} onToggle={toggleKey} labels={labels} context={filePreviewContext} />
         </div>
       ) : null}
 

--- a/src/i18n/locales/en-extended.ts
+++ b/src/i18n/locales/en-extended.ts
@@ -63,6 +63,11 @@ export const enExtended: ExtendedTranslationDictionarySections = {
       specSingular: "{count} spec",
       qoderIntegration: "Qoder integration detected. No spec documents found.",
       integrationDetected: "{system} integration detected, but no spec documents found.",
+      previewFile: "Preview",
+      previewLoading: "Loading preview...",
+      previewClose: "Close",
+      previewError: "Failed to load file content",
+      previewNotFound: "File not found",
     },
     repoSignals: {
       loadingSignals: "Loading repository signals...",

--- a/src/i18n/locales/zh-extended.ts
+++ b/src/i18n/locales/zh-extended.ts
@@ -63,6 +63,11 @@ export const zhExtended: ExtendedTranslationDictionarySections = {
       specSingular: "{count} 规格",
       qoderIntegration: "检测到 Qoder 集成，但未找到规格文档。",
       integrationDetected: "检测到 {system} 集成，但未找到规格文档。",
+      previewFile: "预览",
+      previewLoading: "正在加载预览...",
+      previewClose: "关闭",
+      previewError: "加载文件内容失败",
+      previewNotFound: "文件未找到",
     },
     repoSignals: {
       loadingSignals: "正在加载仓库信号...",

--- a/src/i18n/types-extended.ts
+++ b/src/i18n/types-extended.ts
@@ -62,6 +62,11 @@ export interface ExtendedTranslationDictionarySections extends TailTranslationDi
       specSingular: string;
       qoderIntegration: string;
       integrationDetected: string;
+      previewFile: string;
+      previewLoading: string;
+      previewClose: string;
+      previewError: string;
+      previewNotFound: string;
     };
     repoSignals: {
       loadingSignals: string;


### PR DESCRIPTION
Adds a preview trigger (button) next to each spec file entry in the spec-sources settings section. Clicking the button fetches the file content via a new backend API endpoint and renders it in a height-limited, scrollable read-only area inline. Handles file-not-found and generic read errors with friendly messages. All UI text goes through i18n.

- New API: GET /api/harness/spec-sources/file — reads a single spec file relative to the resolved repo root; blocks path traversal outside root.
- Updated HarnessSpecSourcesPanel: accepts workspaceId/codebaseId/repoPath props and passes a preview context to FlatSpecList / KiroFeatureTree.
- i18n: adds previewFile/previewLoading/previewClose/previewError/ previewNotFound keys to en-extended, zh-extended, and types-extended.
- Settings page passes the existing context props to the panel in both the full (spec-sources section) and compact (thinking node) variants.

## Summary

- What changed:
New backend API GET /api/harness/spec-sources/file: Accepts filePath plus context params (workspaceId/codebaseId/repoPath), resolves the repo root, reads and returns a single spec file's content. Includes path-traversal protection (blocks access outside repoRoot) and distinguishes ENOENT (404) from generic read errors.
Extended HarnessSpecSourcesPanel component: Now accepts workspaceId, codebaseId, repoPath props, assembles them into a FilePreviewContext, and passes it down. Both the full and compact Settings-page call sites inject these context parameters.
Child-component chain updated: SourceGroup → SpecSourceCard → FlatSpecList / KiroFeatureTree now propagate the context prop for triggering and displaying inline previews.
i18n additions: Added 5 keys (previewFile, previewLoading, previewClose, previewError, previewNotFound) to en-extended, zh-extended, and the type definitions.
- Why:
Allows users to click a Preview button inside the Settings spec-sources panel to view spec file contents inline in a height-limited, scrollable read-only area—without jumping to the repo or an external editor—improving spec-file discoverability and reading efficiency.

## Validation

- [x] `npm run lint`
- [x] `npm run test:run`
- [x] UI screenshots or recording attached when applicable
<img width="653" height="279" alt="image" src="https://github.com/user-attachments/assets/8a3155ed-94eb-49e8-afe5-9f668eb9ac43" />
<img width="1408" height="235" alt="image" src="https://github.com/user-attachments/assets/34c32aa5-b18b-4d2c-be5f-bf14b37955e3" />


## Notes

- Related issue:
- Risks or follow-up work:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file preview capability to spec sources, allowing users to preview file contents with loading, error, and not-found states.

* **Internationalization**
  * Added support for file preview UI text in English and Chinese, including labels for loading, closing, errors, and not-found scenarios.

* **Tests**
  * Added comprehensive test coverage for file preview functionality and API endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->