### PR TITLE
fix(ui): onboarding 'show again' button now works correctly

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -280,10 +280,10 @@ function HomePageContent() {
       .slice(0, 3),
     [acp.providers],
   );
-  const needsInlineOnboarding =
-    hasWorkspace &&
-    !onboardingCompleted &&
-    (!hasProviderConfig || !hasCodebase || preferredMode === null);
+  // Show onboarding until the user explicitly dismisses it.
+  // Individual step completion (provider, codebase, mode) is rendered
+  // inside OnboardingCard — no need to auto-hide based on step status.
+  const needsInlineOnboarding = hasWorkspace && !onboardingCompleted;
 
   useEffect(() => {
     if (!activeWorkspaceId || !requestedSurfaceId) return;

--- a/src/client/components/settings-panel.tsx
+++ b/src/client/components/settings-panel.tsx
@@ -63,7 +63,7 @@ export type {
   SettingsPanelProps,
 } from "./settings-panel-shared";
 
-function OnboardingSettingsSection({ onResetOnboarding }: { onResetOnboarding?: () => void }) {
+function OnboardingSettingsSection({ onResetOnboarding, onClose }: { onResetOnboarding?: () => void; onClose?: () => void }) {
   const { t } = useTranslation();
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(() => {
     if (typeof window === "undefined") {
@@ -78,7 +78,8 @@ function OnboardingSettingsSection({ onResetOnboarding }: { onResetOnboarding?: 
     }
     setHasCompletedOnboarding(false);
     onResetOnboarding?.();
-  }, [onResetOnboarding]);
+    onClose?.();
+  }, [onResetOnboarding, onClose]);
 
   return (
     <div className={settingsCardCls}>
@@ -872,7 +873,7 @@ function SettingsPanelContent({ onClose, providers, initialTab, onResetOnboardin
             </p>
           </div>
 
-          <OnboardingSettingsSection onResetOnboarding={onResetOnboarding} />
+          <OnboardingSettingsSection onResetOnboarding={onResetOnboarding} onClose={onClose} />
 
           <ProviderCatalogSection allProviders={providers} />
 


### PR DESCRIPTION
## Summary

- Fixed: clicking "再次显示引导" (show guide again) button in settings had no visible effect
- Settings panel now auto-closes after reset so the onboarding card is immediately visible
- Simplified `needsInlineOnboarding` condition to only depend on `onboardingCompleted`, removing fragile coupling to step-completion state

## Root Cause

Two issues combined:

1. **Panel stayed open** — after resetting onboarding state, the settings panel overlay remained on screen, hiding the re-shown onboarding card underneath.
2. **Fragile visibility condition** — `needsInlineOnboarding` required `(!hasProviderConfig || !hasCodebase || preferredMode === null)`. For users who had completed all steps, the reset relied solely on `preferredMode === null` to trigger re-display — any future change to this condition would silently break the feature.

## Changes

| File | Change |
|---|---|
| `src/client/components/settings-panel.tsx` | Pass `onClose` to `OnboardingSettingsSection`; call it after reset |
| `src/app/page.tsx` | Simplify `needsInlineOnboarding` to `hasWorkspace && !onboardingCompleted` |

## Test plan

- [x] TypeScript compilation: 0 errors
- [x] Unit tests: 12/12 pass (`page.test.tsx`, `onboarding.test.ts`, `settings-panel-render.test.tsx`)
- [ ] Manual: open settings → click "再次显示引导" → panel closes → onboarding card visible on home
- [ ] Manual: `/settings` page → click "再次显示引导" → navigates back to home → onboarding card visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* **Onboarding** — Onboarding card now displays more broadly to users with at least one workspace who haven't dismissed it
* **Settings** — Settings panel automatically closes after resetting onboarding preferences

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/550)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->