### PR TITLE
fix: clarify canonical contract refinement prompt

### DIFF
--- a/docs/issues/2026-05-22-canonical-contract-comment-only-refinement-loop.md
+++ b/docs/issues/2026-05-22-canonical-contract-comment-only-refinement-loop.md
@@ -1,0 +1,34 @@
+---
+title: "Canonical contract gate can loop when backlog refinement only writes comments"
+kind: issue
+status: active
+github_issue:
+github_state:
+github_url:
+created_at: 2026-05-22
+updated_at: 2026-05-22
+---
+
+## What happened
+
+A QuantDinger workflow card repeatedly failed the canonical story contract gate with a
+"Canonical story YAML is missing" error.
+
+The card's backlog refinement notes claimed the story had been refined, but the persisted task
+`objective` still contained only a short prose sentence. The canonical YAML was not written back to
+the card description/objective, so the gate was correctly rejecting the transition while the agent
+looped through comment-only updates.
+
+## Why it matters
+
+The contract gate is meant to stop malformed backlog stories before downstream lanes begin work.
+If the prompt allows agents to treat comments or completion notes as refinement evidence, Routa can
+produce a false sense of progress and burn repeated lane attempts without changing the gated field.
+
+## Fix direction
+
+- Keep the canonical contract gate strict.
+- Make backlog/contract-gated prompts explicit that the YAML must be persisted in the card
+  description via `update_card`.
+- State that comments, progress notes, and completion summaries do not satisfy the contract gate.
+- Add a prompt regression test so future prompt edits do not remove this instruction.

--- a/src/core/kanban/__tests__/agent-trigger.test.ts
+++ b/src/core/kanban/__tests__/agent-trigger.test.ts
@@ -289,6 +289,8 @@ describe("buildTaskPrompt", () => {
 
     expect(prompt).toContain("## Contract Gates");
     expect(prompt).toContain("Moving this card to Todo requires one valid canonical ```yaml``` story contract");
+    expect(prompt).toContain("call `update_card` with the full corrected description");
+    expect(prompt).toContain("comments, progress notes, and completion summaries do not satisfy this contract gate");
     expect(prompt).toContain("Todo and downstream lanes will not silently repair malformed canonical YAML");
   });
 

--- a/src/core/kanban/agent-trigger.ts
+++ b/src/core/kanban/agent-trigger.ts
@@ -356,6 +356,8 @@ export function buildTaskPrompt(
         "## Contract Gates",
         "",
         `Moving this card to ${transitionArtifacts.nextColumn.name ?? nextColumnId ?? "the next column"} requires ${formatContractRules(transitionArtifacts.nextColumn.automation.contractRules)} in the description.`,
+        "If the current description is missing or has invalid canonical YAML, first call `update_card` with the full corrected description containing exactly one canonical ```yaml``` story contract.",
+        "`update_card` comments, progress notes, and completion summaries do not satisfy this contract gate; the YAML must be persisted in the description before `move_card`.",
         "Do not call `move_card` until the canonical YAML parses cleanly and satisfies the required schema.",
         "Todo and downstream lanes will not silently repair malformed canonical YAML. Regenerate it in Backlog before retrying.",
         "",


### PR DESCRIPTION
## Summary
- clarify contract-gated Kanban prompts so agents must persist canonical YAML in the card description
- state that comments, progress notes, and completion summaries do not satisfy the canonical story gate
- add a regression assertion for the contract gate prompt and a local issue tracker note

## Verification
- npm run test:run -- src/core/kanban/__tests__/agent-trigger.test.ts
- entrix run --dry-run

## Notes
The observed loop was not a parser false negative: the affected card had no canonical YAML in its persisted objective. The failure mode was comment-only backlog refinement that claimed completion without updating the gated description field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying canonical contract gate requirements, including specifications for YAML persistence in card descriptions versus comments or progress notes.

* **Tests**
  * Updated test assertions to ensure contract gate guidance and requirements are properly verified in agent prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->