### PR TITLE
Fix Docker build and Postgres compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ build
 .env
 .env*.local
 .env.local
+docker-compose.override.yml
 
 # IDE / OS
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,20 @@ RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --legacy-peer-deps
+COPY apps/desktop/package.json ./apps/desktop/package.json
+COPY packages/office-render/package.json ./packages/office-render/package.json
+RUN npm ci --ignore-scripts --legacy-peer-deps
 
-# ── Stage 2: build ───────────────────────────────────────────────────────
+# ── Stage 2: database schema migrator ────────────────────────────────────
+FROM base AS migrator
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+CMD ["npm", "run", "db:push"]
+
+# ── Stage 3: build ───────────────────────────────────────────────────────
 FROM base AS builder
 WORKDIR /app
 
@@ -28,7 +39,7 @@ COPY . .
 # standalone chunks directory so ROUTA_DB_DRIVER=sqlite works at runtime.
 RUN npm run build:docker
 
-# ── Stage 3: production runner ────────────────────────────────────────────
+# ── Stage 4: production runner ────────────────────────────────────────────
 FROM base AS runner
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 #   docker compose up
 #
 # Postgres profile: uses a bundled Postgres container
-#   docker compose --profile postgres up
+#   ROUTA_DB_DRIVER=postgres docker compose --profile postgres up
 #
 # Production Postgres (external):
 #   Set DATABASE_URL in .env before running `docker compose up`.
@@ -21,23 +21,42 @@ services:
       # SQLite mode (default) — no external DB required
       ROUTA_DB_DRIVER: ${ROUTA_DB_DRIVER:-sqlite}
       ROUTA_DB_PATH: /app/data/routa.db
-      # Set DATABASE_URL (and ROUTA_DB_DRIVER=postgres) in .env to use Postgres.
+      # Set ROUTA_DB_DRIVER=postgres in .env to use the bundled Postgres profile.
+      # Set DATABASE_URL to override the bundled database with an external Postgres.
       # Example for the bundled postgres service:
       #   DATABASE_URL=postgresql://routa:routa_secret@postgres:5432/routa
-      DATABASE_URL: ${DATABASE_URL:-}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://routa:${POSTGRES_PASSWORD:-routa_secret}@postgres:5432/routa}
     volumes:
       - routa_data:/app/data
     depends_on:
       postgres:
         condition: service_healthy
         required: false  # only enforced when the postgres profile is active
+      migrate:
+        condition: service_completed_successfully
+        required: false  # only enforced when the postgres profile is active
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  # ── PostgreSQL schema sync (optional) ───────────────────────────────────
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: migrator
+    profiles:
+      - postgres
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://routa:${POSTGRES_PASSWORD:-routa_secret}@postgres:5432/routa}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
 
   # ── PostgreSQL (optional) ─────────────────────────────────────────────────
   postgres:


### PR DESCRIPTION
## Summary

Fixes the Docker setup so the production image can be built from a clean checkout and the bundled Postgres profile starts with an initialized schema.

## What changed

- Copies workspace `package.json` files before `npm ci`, so workspace dependencies are installed during Docker builds.
- Uses `npm ci --ignore-scripts` in the dependency layer because lifecycle scripts require files that are only available after the full source tree is copied.
- Adds a `migrator` Docker target that runs `npm run db:push`.
- Adds a `migrate` Compose service for the Postgres profile and makes the app wait for it.
- Updates the app healthcheck to use `127.0.0.1` inside the container.
- Ignores local `docker-compose.override.yml` files in Docker build context.

## Why

A clean Docker build currently fails before the app image is produced because install scripts run before their source files exist, and workspace dependencies such as `esbuild-plugin-css-modules` are not installed. After fixing the image build, the bundled Postgres profile starts with an empty schema, causing runtime errors for missing tables such as `background_tasks` and `schedules`.

## Validation

- `docker build --target migrator -t routa-migrator-pr-check .`
- `docker compose --env-file /dev/null -f docker-compose.yml config`
- `docker compose --env-file /dev/null -f docker-compose.yml --profile postgres config`
- Local Postgres deployment verified with `/api/health` returning `{"status":"ok"}` after applying schema sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prevents local compose override from being included in Docker build context.
  * Adds an optional, profile-scoped migration service to run database migrations during container runs.
  * Sets a sensible default database connection for the app service to improve local/startup reliability.
  * Updates container healthcheck target to increase service readiness accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->