### PR TITLE
fix: let Kanban agents write artifact evidence

### DIFF
--- a/crates/routa-core/src/rpc/methods/tasks.rs
+++ b/crates/routa-core/src/rpc/methods/tasks.rs
@@ -280,6 +280,34 @@ pub async fn list_artifacts(
 }
 
 // ---------------------------------------------------------------------------
+// tasks.getArtifact
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetArtifactParams {
+    pub artifact_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GetArtifactResult {
+    pub artifact: Artifact,
+}
+
+pub async fn get_artifact(
+    state: &AppState,
+    params: GetArtifactParams,
+) -> Result<GetArtifactResult, RpcError> {
+    let artifact = state
+        .artifact_store
+        .get(&params.artifact_id)
+        .await?
+        .ok_or_else(|| RpcError::NotFound(format!("Artifact {} not found", params.artifact_id)))?;
+
+    Ok(GetArtifactResult { artifact })
+}
+
+// ---------------------------------------------------------------------------
 // tasks.provideArtifact
 // ---------------------------------------------------------------------------
 

--- a/crates/routa-core/src/rpc/methods/tasks.rs
+++ b/crates/routa-core/src/rpc/methods/tasks.rs
@@ -287,6 +287,8 @@ pub async fn list_artifacts(
 #[serde(rename_all = "camelCase")]
 pub struct GetArtifactParams {
     pub artifact_id: String,
+    pub task_id: String,
+    pub workspace_id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -303,6 +305,12 @@ pub async fn get_artifact(
         .get(&params.artifact_id)
         .await?
         .ok_or_else(|| RpcError::NotFound(format!("Artifact {} not found", params.artifact_id)))?;
+    if artifact.task_id != params.task_id || artifact.workspace_id != params.workspace_id {
+        return Err(RpcError::NotFound(format!(
+            "Artifact {} not found",
+            params.artifact_id
+        )));
+    }
 
     Ok(GetArtifactResult { artifact })
 }
@@ -660,6 +668,30 @@ mod tests {
             listed.artifacts[0].context.as_deref(),
             Some("Verification screenshot")
         );
+
+        let fetched = get_artifact(
+            &state,
+            GetArtifactParams {
+                artifact_id: provided.artifact.id.clone(),
+                task_id: provided.artifact.task_id.clone(),
+                workspace_id: provided.artifact.workspace_id.clone(),
+            },
+        )
+        .await
+        .expect("artifact should be fetched within its task scope");
+        assert_eq!(fetched.artifact.id, provided.artifact.id);
+
+        let wrong_scope = get_artifact(
+            &state,
+            GetArtifactParams {
+                artifact_id: provided.artifact.id,
+                task_id: "other-task".to_string(),
+                workspace_id: "default".to_string(),
+            },
+        )
+        .await
+        .expect_err("artifact should not cross task scope");
+        assert!(matches!(wrong_scope, RpcError::NotFound(_)));
     }
 
     #[tokio::test]

--- a/crates/routa-core/src/rpc/router.rs
+++ b/crates/routa-core/src/rpc/router.rs
@@ -183,6 +183,11 @@ impl RpcRouter {
                 let r = methods::tasks::list_artifacts(&self.state, p).await?;
                 Ok(serde_json::to_value(r).unwrap())
             }
+            "tasks.getArtifact" => {
+                let p = parse_params(params)?;
+                let r = methods::tasks::get_artifact(&self.state, p).await?;
+                Ok(serde_json::to_value(r).unwrap())
+            }
             "tasks.provideArtifact" => {
                 let p = parse_params(params)?;
                 let r = methods::tasks::provide_artifact(&self.state, p).await?;
@@ -377,6 +382,7 @@ impl RpcRouter {
             "tasks.updateStatus",
             "tasks.findReady",
             "tasks.listArtifacts",
+            "tasks.getArtifact",
             "tasks.provideArtifact",
             "kanban.listBoards",
             "kanban.createBoard",

--- a/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
@@ -28,6 +28,9 @@ pub(super) fn tool_allowed_for_profile(name: &str, profile: Option<&str>) -> boo
                 | "update_task"
                 | "update_card"
                 | "move_card"
+                | "provide_artifact"
+                | "list_artifacts"
+                | "get_artifact"
                 | "request_previous_lane_handoff"
                 | "submit_lane_handoff"
         ),
@@ -151,6 +154,13 @@ fn build_tool_list_inner() -> Vec<serde_json::Value> {
                 "type": { "type": "string", "enum": ["screenshot", "test_results", "code_diff", "logs"], "description": "Artifact type filter" }
             },
             "required": ["taskId"]
+        })),
+        tool_def("get_artifact", "Read a single task artifact by ID.", serde_json::json!({
+            "type": "object",
+            "properties": {
+                "artifactId": { "type": "string", "description": "Artifact ID" }
+            },
+            "required": ["artifactId"]
         })),
         // ── Delegation tools ─────────────────────────────────────────────
         tool_def("delegate_task_to_agent", "Delegate a task to a new agent by spawning a real process. Use specialist='CRAFTER' for implementation, specialist='GATE' for verification, specialist='DEVELOPER' for solo plan+implement.", serde_json::json!({

--- a/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
@@ -28,9 +28,11 @@ pub(super) fn tool_allowed_for_profile(name: &str, profile: Option<&str>) -> boo
                 | "update_task"
                 | "update_card"
                 | "move_card"
+                | "create_note"
                 | "provide_artifact"
                 | "list_artifacts"
                 | "get_artifact"
+                | "capture_screenshot"
                 | "request_previous_lane_handoff"
                 | "submit_lane_handoff"
         ),
@@ -158,9 +160,11 @@ fn build_tool_list_inner() -> Vec<serde_json::Value> {
         tool_def("get_artifact", "Read a single task artifact by ID.", serde_json::json!({
             "type": "object",
             "properties": {
-                "artifactId": { "type": "string", "description": "Artifact ID" }
+                "artifactId": { "type": "string", "description": "Artifact ID" },
+                "taskId": { "type": "string", "description": "Task ID the artifact belongs to" },
+                "workspaceId": { "type": "string", "description": "Workspace ID the artifact belongs to" }
             },
-            "required": ["artifactId"]
+            "required": ["artifactId", "taskId", "workspaceId"]
         })),
         // ── Delegation tools ─────────────────────────────────────────────
         tool_def("delegate_task_to_agent", "Delegate a task to a new agent by spawning a real process. Use specialist='CRAFTER' for implementation, specialist='GATE' for verification, specialist='DEVELOPER' for solo plan+implement.", serde_json::json!({
@@ -478,6 +482,11 @@ mod tests {
             "update_task",
             "update_card",
             "move_card",
+            "create_note",
+            "provide_artifact",
+            "list_artifacts",
+            "get_artifact",
+            "capture_screenshot",
             "request_previous_lane_handoff",
             "submit_lane_handoff",
         ]

--- a/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
@@ -351,6 +351,18 @@ pub(super) async fn execute(
             }
             Err(error) => tool_result_error(&error),
         },
+        "get_artifact" => match rpc_tool_result(
+            state,
+            "tasks.getArtifact",
+            serde_json::json!({
+                "artifactId": args.get("artifactId").and_then(|v| v.as_str()).unwrap_or(""),
+            }),
+        )
+        .await
+        {
+            Ok(result) => tool_result_json(&result),
+            Err(error) => tool_result_error(&error),
+        },
         _ => return None,
     };
 

--- a/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
@@ -356,6 +356,8 @@ pub(super) async fn execute(
             "tasks.getArtifact",
             serde_json::json!({
                 "artifactId": args.get("artifactId").and_then(|v| v.as_str()).unwrap_or(""),
+                "taskId": args.get("taskId").and_then(|v| v.as_str()).unwrap_or(""),
+                "workspaceId": args.get("workspaceId").and_then(|v| v.as_str()).unwrap_or(""),
             }),
         )
         .await

--- a/crates/routa-server/tests/rust_api_mcp_routes.rs
+++ b/crates/routa-server/tests/rust_api_mcp_routes.rs
@@ -296,6 +296,9 @@ async fn api_mcp_kanban_profile_filters_tools_list() {
         "update_task",
         "update_card",
         "move_card",
+        "provide_artifact",
+        "list_artifacts",
+        "get_artifact",
         "request_previous_lane_handoff",
         "submit_lane_handoff",
     ]
@@ -309,6 +312,16 @@ async fn api_mcp_kanban_profile_filters_tools_list() {
     assert!(
         names.contains(&"create_card") && names.contains(&"decompose_tasks"),
         "kanban profile should include planning tools, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"provide_artifact")
+            && names.contains(&"list_artifacts")
+            && names.contains(&"get_artifact"),
+        "kanban profile should include artifact evidence tools, got: {names:?}"
+    );
+    assert!(
+        !names.contains(&"capture_screenshot"),
+        "kanban planning profile should not expose screenshot capture by default, got: {names:?}"
     );
 }
 

--- a/crates/routa-server/tests/rust_api_mcp_routes.rs
+++ b/crates/routa-server/tests/rust_api_mcp_routes.rs
@@ -296,6 +296,7 @@ async fn api_mcp_kanban_profile_filters_tools_list() {
         "update_task",
         "update_card",
         "move_card",
+        "create_note",
         "provide_artifact",
         "list_artifacts",
         "get_artifact",

--- a/docs/operational/routa-platform-follow-up-prs.zh-CN.md
+++ b/docs/operational/routa-platform-follow-up-prs.zh-CN.md
@@ -1,0 +1,102 @@
+# Routa 平台后续拆分 PR 记录
+
+本文件记录 PR1（Kanban Agent Artifact Tools）之外的后续平台缺口。它们和 PR1 同属“让 Routa 更稳定承接项目迭代”的方向，但不应混入同一个实现分支。
+
+本文件基于当前 Routa 代码现状修订：
+
+- Kanban 已有列级 `automation` 配置，不是完全没有 transition gate。
+- `update_card` 本身不是最大风险面，真正需要治理的是 agent 可写任务/卡片字段边界。
+- Session history 已经有 `session_messages` 和 `HistoryCompactor` 雏形，后续应接线与加固，而不是从零设计。
+
+## PR2: MCP Agent Write Boundary / Task Metadata Protection
+
+问题：Kanban agent 通过 MCP 写卡片和任务时，缺少清晰的 profile / role 级字段写入边界。`update_card` 当前主要更新 `title`、`description`、`comment`、`priority`、`labels`；更大的风险面在 `update_task` / task API，它可以更新 `status`、`columnId`、`dependencies`、`completionSummary`、`verificationVerdict`、`assignedProvider`、`assignedRole`、`assignedSpecialistId` 等流程或运行时字段。后续 AI 可能绕过 lane gate，造成卡片语义、流程状态或验收结论失真。
+
+当前现状：
+
+- `update_card` 是偏卡片展示/正文的工具。
+- `move_card` 是 lane 迁移的明确工具。
+- `update_task` 是宽字段任务更新工具，适合系统内部和受控场景，但不适合所有普通 Kanban agent 无差别使用。
+- `kanban-planning` profile 需要能写方案正文和 canonical story，但不应直接改流程状态。
+
+建议边界：
+
+- 按 MCP profile / specialist role 定义任务字段写入白名单。
+- 普通 planning / product / architecture agent 可写：`objective`、`scope`、`acceptanceCriteria`、`verificationCommands`、`testCases`、必要的 `contextSearchSpec`。
+- 执行 / QA agent 可写：`completionSummary`、`verificationReport`、必要的 evidence artifact；是否可写 `verificationVerdict` 需要单独受 gate 或 reviewer profile 控制。
+- lane/status 迁移统一走 `move_card`，不要通过 `update_task.status` 或 `update_task.columnId` 绕过 transition gate。
+- `dependencies`、`releaseLabel`、approval、owner verdict、assigned runtime/provider/specialist 等流程元数据应只允许系统 orchestrator、human owner/admin 或专门高权限工具修改。
+- 保持 API 兼容：不删除现有字段，但 MCP 普通 profile 不应暴露或不应允许写入高风险字段。
+
+验收：
+
+- `kanban-planning` agent 不能通过 `update_task` 修改 `status` / `columnId` 绕过 `move_card`。
+- 普通 agent 不能覆盖 owner / approval / release / dependency 等关键流程元数据。
+- Product / Architecture agent 仍能正常写入 story 字段和 canonical YAML。
+- Execution / QA agent 仍能写入 completion / verification / artifact 证据。
+- 系统内部 orchestrator、人类 owner/admin、专门工具仍保留必要高权限路径。
+- TS MCP tests 覆盖 profile 字段白名单；Rust MCP parity 如暴露同类工具，也必须覆盖同样约束。
+
+## PR3: Wire and Harden Existing Session Compaction
+
+问题：本地 SQLite 长期运行时，ACP session history 会同时写入 `acp_sessions.message_history` 和 `session_messages`。当前已有 `session_messages` 表和 `HistoryCompactor` 雏形，但它没有形成清晰的运维入口、dry-run、活跃 session 保护和 SQLite 维护流程。结果是长时间 Mode B 运行后，`routa.db` / WAL 仍可能膨胀，并且后续人工清理风险较高。
+
+当前现状：
+
+- `session_messages` 已经存在，用于按事件追加 session history。
+- `acp_sessions.message_history` 仍保留 JSON 历史，形成兼容和回退路径。
+- `HistoryCompactor` 已存在，尝试合并旧 `agent_message_chunk` 并清理旧 trace。
+- 现有 compactor 测试较薄，且没有明确接入 CLI/API/维护命令。
+
+建议边界：
+
+- 不从零设计 compaction，优先把现有 `HistoryCompactor` 接入受控维护入口。
+- 增加 dry-run：输出候选 session 数、候选消息数、预计删除/合并数量、预计影响范围。
+- 增加 apply：只处理非活跃 session，保留 final response、tool call/result 摘要、artifact、completion/verification 相关证据。
+- 明确 `session_messages` 与 `acp_sessions.message_history` 的一致性策略：压缩后不能出现 UI 读旧 JSON 仍膨胀、而新表已压缩的双轨不一致。
+- SQLite 维护命令应考虑 WAL checkpoint / VACUUM，但必须避免服务运行中锁库；优先维护模式或显式停止服务后执行。
+- 不处理 workspace/project 业务数据，不清 artifact，不清 task completion summary，不清 verification report。
+
+验收：
+
+- 构造包含大量 streaming chunk 的旧 session，dry-run 能报告候选数量但不修改数据。
+- apply 后重复 chunk 被合并或裁剪，`session_messages` 记录数下降。
+- `acp_sessions.message_history` 不继续保留同等体量的重复 delta，或有明确兼容策略说明。
+- final response / transcript readout / artifact / task evidence 仍可读。
+- 活跃 session 不被处理。
+- Windows SQLite 下不会因 WAL / 文件锁导致维护失败或破坏数据库。
+
+## PR4: Extend Existing Kanban Transition Gates
+
+问题：Routa 已经有列级 `KanbanColumnAutomation` gate，但能力仍是分散的、部分前后端不对齐的。当前已有 `requiredArtifacts`、`requiredTaskFields`，TS 侧还有 `contractRules`、`deliveryRules`，`move_card` 已经会阻断部分不满足条件的迁移。后续需要扩展为更完整的通用 gate 能力，但不能新造一套与现有 `automation` 并行的 workflow gate。
+
+当前现状：
+
+- TS model 已支持 `requiredArtifacts`、`requiredTaskFields`、`contractRules`、`deliveryRules`。
+- Rust model 目前主要支持 `required_artifacts`、`required_task_fields`，需要补 parity。
+- Kanban settings UI 已支持配置 trigger、required artifacts、required task fields。
+- `move_card` / task status API 已经有部分 gate 检查。
+
+建议边界：
+
+- 在现有 `KanbanColumnAutomation` 上增量扩展，保持旧 board 配置兼容。
+- 补齐 TS / Rust parity，避免 Web 与 Rust/Axum 后端 gate 语义不一致。
+- 新增 gate 字段建议：
+  - `requiredChecklist`
+  - `requiredHumanApproval`
+  - `validatorCommand`
+  - `mode: blocking | warning`
+- `blocking` gate 阻断 lane transition；`warning` gate 允许迁移但必须记录可见 warning / artifact / audit note。
+- `move_card`、task status/column update API、MCP `move_card` 必须走同一套 gate 检查。
+- UI 只做现有 Kanban settings 的最小扩展，不做完整 workflow designer。
+- QuantDinger 的 `8891 -> 8888` 发布前回归门控只能作为 workspace board 配置或示例，不进入 Routa core 的通用产品语义。
+
+验收：
+
+- 旧 board 的 `requiredArtifacts` / `requiredTaskFields` 配置继续有效。
+- TS 和 Rust 后端对同一个 board 配置给出一致的 transition 结果。
+- 缺 blocking artifact / checklist / human approval 时，lane transition 被阻断并返回可读原因。
+- warning gate 不阻断迁移，但在卡片或事件中留下可见 warning。
+- validator command 失败时按 `mode` 决定阻断或警告。
+- Kanban settings 能配置最小 gate 字段；agent prompt 能读到缺口并指导补证据。
+- 不包含任何 QuantDinger 专有端口、环境或发布文案。

--- a/src/core/kanban/__tests__/agent-trigger.test.ts
+++ b/src/core/kanban/__tests__/agent-trigger.test.ts
@@ -289,6 +289,8 @@ describe("buildTaskPrompt", () => {
 
     expect(prompt).toContain("## Contract Gates");
     expect(prompt).toContain("Moving this card to Todo requires one valid canonical ```yaml``` story contract");
+    expect(prompt).toContain("call `update_card` with the full corrected description");
+    expect(prompt).toContain("comments, progress notes, and completion summaries do not satisfy this contract gate");
     expect(prompt).toContain("Todo and downstream lanes will not silently repair malformed canonical YAML");
   });
 
@@ -913,6 +915,57 @@ describe("triggerAssignedTaskAgent ACP prompt lifecycle", () => {
       type: AgentEventType.AGENT_COMPLETED,
       agentId: "sess-1",
     }));
+  });
+
+  it("sets the kanban planning MCP profile when the lane needs artifact evidence", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: "new",
+        result: { sessionId: "sess-evidence" },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+    dispatchSessionPromptMock.mockResolvedValue(undefined);
+
+    const task = createTask({
+      id: "task-evidence-profile",
+      title: "Review release evidence",
+      objective: "The next transition requires stored evidence",
+      workspaceId: "default",
+      boardId: "board-evidence",
+      columnId: "review",
+      assignedProvider: "codex",
+      assignedRole: "GATE",
+    });
+
+    await triggerAssignedTaskAgent({
+      origin: "http://127.0.0.1:3000",
+      workspaceId: "default",
+      cwd: "/tmp/project",
+      task,
+      boardColumns: [
+        { id: "review", name: "Review", stage: "review", position: 0 },
+        {
+          id: "done",
+          name: "Done",
+          stage: "done",
+          position: 1,
+          automation: {
+            enabled: true,
+            requiredArtifacts: ["test_results"],
+          },
+        },
+      ],
+    });
+
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(requestBody.params).toMatchObject({
+      toolMode: "full",
+      mcpProfile: "kanban-planning",
+    });
   });
 
   it("does not emit AGENT_FAILED when ACP prompt times out waiting for the HTTP response", async () => {

--- a/src/core/kanban/__tests__/completion-fallback-artifact.test.ts
+++ b/src/core/kanban/__tests__/completion-fallback-artifact.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { createTask } from "../../models/task";
+import { InMemoryArtifactStore } from "../../store/artifact-store";
+import { createArtifact } from "../../models/artifact";
+import { ensureCompletionFallbackArtifact } from "../completion-fallback-artifact";
+
+describe("ensureCompletionFallbackArtifact", () => {
+  it("creates a logs artifact from a session final response when the task has no artifacts", async () => {
+    const artifactStore = new InMemoryArtifactStore();
+    const task = createTask({
+      id: "task-fallback-1",
+      title: "Review solution",
+      objective: "Capture the review output",
+      workspaceId: "default",
+      columnId: "review",
+    });
+
+    const result = await ensureCompletionFallbackArtifact({
+      task,
+      sessionId: "session-1",
+      workspaceId: "default",
+      stage: "review",
+      artifactStore,
+      finalResponseText: "The solution is ready for owner review.",
+    });
+
+    expect(result.status).toBe("created");
+    const artifacts = await artifactStore.listByTask(task.id);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toMatchObject({
+      type: "logs",
+      status: "provided",
+      content: "The solution is ready for owner review.",
+      metadata: expect.objectContaining({
+        kind: "session_final_response_fallback",
+        fallback: "true",
+        sessionId: "session-1",
+        sensitiveBlocked: "false",
+      }),
+    });
+  });
+
+  it("does not create a fallback artifact when the task already has evidence", async () => {
+    const artifactStore = new InMemoryArtifactStore();
+    const task = createTask({
+      id: "task-fallback-existing",
+      title: "Review solution",
+      objective: "Existing evidence should win",
+      workspaceId: "default",
+      columnId: "review",
+    });
+    await artifactStore.saveArtifact(createArtifact({
+      id: "artifact-existing",
+      type: "test_results",
+      taskId: task.id,
+      workspaceId: "default",
+      status: "provided",
+      content: "ok",
+    }));
+
+    const result = await ensureCompletionFallbackArtifact({
+      task,
+      sessionId: "session-2",
+      workspaceId: "default",
+      stage: "review",
+      artifactStore,
+      finalResponseText: "This should not be copied.",
+    });
+
+    expect(result).toMatchObject({
+      status: "skipped",
+      reason: "task_already_has_artifacts",
+    });
+    expect(await artifactStore.listByTask(task.id)).toHaveLength(1);
+  });
+
+  it("is idempotent for the same task and session", async () => {
+    const artifactStore = new InMemoryArtifactStore();
+    const task = createTask({
+      id: "task-fallback-idempotent",
+      title: "Review solution",
+      objective: "Repeated completion events should not duplicate artifacts",
+      workspaceId: "default",
+      columnId: "review",
+    });
+
+    await ensureCompletionFallbackArtifact({
+      task,
+      sessionId: "session-3",
+      workspaceId: "default",
+      stage: "review",
+      artifactStore,
+      finalResponseText: "Final answer.",
+    });
+    const result = await ensureCompletionFallbackArtifact({
+      task,
+      sessionId: "session-3",
+      workspaceId: "default",
+      stage: "review",
+      artifactStore,
+      finalResponseText: "Final answer.",
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(await artifactStore.listByTask(task.id)).toHaveLength(1);
+  });
+
+  it("stores only a blocking note when the final response appears sensitive", async () => {
+    const artifactStore = new InMemoryArtifactStore();
+    const task = createTask({
+      id: "task-fallback-sensitive",
+      title: "Security gate",
+      objective: "Avoid saving credentials",
+      workspaceId: "default",
+      columnId: "review",
+    });
+
+    const result = await ensureCompletionFallbackArtifact({
+      task,
+      sessionId: "session-4",
+      workspaceId: "default",
+      stage: "review",
+      artifactStore,
+      finalResponseText: "password=super-secret",
+    });
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      reason: "sensitive_content_blocked",
+    });
+    const [artifact] = await artifactStore.listByTask(task.id);
+    expect(artifact.content).toContain("appears to contain sensitive content");
+    expect(artifact.content).not.toContain("super-secret");
+    expect(artifact.metadata).toMatchObject({
+      sensitiveBlocked: "true",
+    });
+  });
+});

--- a/src/core/kanban/__tests__/completion-fallback-artifact.test.ts
+++ b/src/core/kanban/__tests__/completion-fallback-artifact.test.ts
@@ -106,7 +106,7 @@ describe("ensureCompletionFallbackArtifact", () => {
     expect(await artifactStore.listByTask(task.id)).toHaveLength(1);
   });
 
-  it("stores only a blocking note when the final response appears sensitive", async () => {
+  it("does not store a fallback artifact when the final response appears sensitive", async () => {
     const artifactStore = new InMemoryArtifactStore();
     const task = createTask({
       id: "task-fallback-sensitive",
@@ -122,18 +122,13 @@ describe("ensureCompletionFallbackArtifact", () => {
       workspaceId: "default",
       stage: "review",
       artifactStore,
-      finalResponseText: "password=super-secret",
+      finalResponseText: "{\"password\":\"super-secret\"}",
     });
 
     expect(result).toMatchObject({
       status: "blocked",
       reason: "sensitive_content_blocked",
     });
-    const [artifact] = await artifactStore.listByTask(task.id);
-    expect(artifact.content).toContain("appears to contain sensitive content");
-    expect(artifact.content).not.toContain("super-secret");
-    expect(artifact.metadata).toMatchObject({
-      sensitiveBlocked: "true",
-    });
+    expect(await artifactStore.listByTask(task.id)).toHaveLength(0);
   });
 });

--- a/src/core/kanban/agent-trigger.ts
+++ b/src/core/kanban/agent-trigger.ts
@@ -16,6 +16,7 @@ import type { TaskLaneSession } from "../models/task";
 import { resolveCurrentLaneAutomationState } from "./lane-automation-state";
 import { getLatestLaneSessionForColumn, getPreviousLaneRun } from "./task-lane-history";
 import type { KanbanAutomationStep, KanbanTransport } from "../models/kanban";
+import type { McpServerProfile } from "../mcp/mcp-server-profiles";
 import type { FlowDiagnosisReport } from "./flow-ledger-types";
 import { formatFlowGuidanceForPrompt } from "./flow-ledger";
 import { buildKanbanTaskAdaptiveHarnessOptions } from "./task-adaptive";
@@ -31,6 +32,19 @@ export interface TaskPromptSummaryContext {
   evidenceSummary?: TaskEvidenceSummary;
   storyReadiness?: TaskStoryReadiness;
   investValidation?: TaskInvestValidation;
+}
+
+export function resolveKanbanAutomationMcpProfile(
+  task: Task,
+  boardColumns: KanbanColumn[] = [],
+  summaryContext?: TaskPromptSummaryContext,
+): McpServerProfile | undefined {
+  const transitionArtifacts = resolveKanbanTransitionArtifacts(boardColumns, task.columnId ?? "backlog");
+  const hasArtifactGate = transitionArtifacts.currentRequiredArtifacts.length > 0
+    || transitionArtifacts.nextRequiredArtifacts.length > 0;
+  const hasMissingArtifacts = (summaryContext?.evidenceSummary?.artifact.missingRequired.length ?? 0) > 0;
+
+  return hasArtifactGate || hasMissingArtifacts ? "kanban-planning" : undefined;
 }
 
 function formatHandoffRequestType(
@@ -356,6 +370,8 @@ export function buildTaskPrompt(
         "## Contract Gates",
         "",
         `Moving this card to ${transitionArtifacts.nextColumn.name ?? nextColumnId ?? "the next column"} requires ${formatContractRules(transitionArtifacts.nextColumn.automation.contractRules)} in the description.`,
+        "If the current description is missing or has invalid canonical YAML, first call `update_card` with the full corrected description containing exactly one canonical ```yaml``` story contract.",
+        "`update_card` comments, progress notes, and completion summaries do not satisfy this contract gate; the YAML must be persisted in the description before `move_card`.",
         "Do not call `move_card` until the canonical YAML parses cleanly and satisfies the required schema.",
         "Todo and downstream lanes will not silently repair malformed canonical YAML. Regenerate it in Backlog before retrying.",
         "",
@@ -617,6 +633,11 @@ async function triggerAcpTaskAgent(params: {
   const sessionLabel = params.task.assignedSpecialistName
     ?? params.task.assignedSpecialistId
     ?? role;
+  const mcpProfile = resolveKanbanAutomationMcpProfile(
+    params.task,
+    params.boardColumns,
+    params.summaryContext,
+  );
 
   const newSessionResponse = await fetch(`${params.origin}/api/acp`, {
     method: "POST",
@@ -631,6 +652,7 @@ async function triggerAcpTaskAgent(params: {
         provider,
         role,
         toolMode: "full",
+        mcpProfile,
         workspaceId: params.workspaceId,
         specialistId: params.task.assignedSpecialistId,
         specialistLocale: params.specialistLocale,

--- a/src/core/kanban/completion-fallback-artifact.ts
+++ b/src/core/kanban/completion-fallback-artifact.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+
+import { loadSessionHistory } from "@/core/session-history";
+import { historyNotificationsToMessages } from "@/core/session-transcript";
+import { createArtifact } from "../models/artifact";
+import type { KanbanColumnStage, KanbanTransport } from "../models/kanban";
+import type { Task } from "../models/task";
+import type { ArtifactStore } from "../store/artifact-store";
+
+const FALLBACK_KIND = "session_final_response_fallback";
+const MAX_FALLBACK_CONTENT_LENGTH = 16_000;
+
+export interface CompletionFallbackArtifactResult {
+  status: "created" | "skipped" | "blocked";
+  reason?: string;
+  artifactId?: string;
+}
+
+export interface CompletionFallbackArtifactParams {
+  task: Task;
+  sessionId: string;
+  workspaceId: string;
+  stage: KanbanColumnStage;
+  transport?: KanbanTransport;
+  artifactStore: ArtifactStore;
+  finalResponseText?: string;
+}
+
+function isFallbackEligible(task: Task, stage: KanbanColumnStage): boolean {
+  if (stage !== "dev") {
+    return true;
+  }
+
+  const searchable = [
+    task.columnId,
+    task.title,
+    task.objective,
+    task.scope,
+    task.comment,
+    task.assignedRole,
+    task.assignedSpecialistId,
+    task.assignedSpecialistName,
+    ...task.labels,
+  ].filter(Boolean).join(" ").toLowerCase();
+
+  return /\b(product|architecture|architect|qa|ops|security|review|release|gate|solution|design|docs?)\b/i
+    .test(searchable);
+}
+
+function containsSensitiveText(text: string): boolean {
+  return [
+    /\b(password|passwd|api[_-]?key|secret|token|cookie|authorization)\b\s*[:=]/i,
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/,
+    /\bgh[pousr]_[A-Za-z0-9_]{20,}/,
+    /\bsk-[A-Za-z0-9_-]{20,}/,
+    /\bANTHROPIC_[A-Z0-9_]*\s*[:=]/i,
+  ].some((pattern) => pattern.test(text));
+}
+
+function truncateContent(text: string): { content: string; truncated: boolean } {
+  if (text.length <= MAX_FALLBACK_CONTENT_LENGTH) {
+    return { content: text, truncated: false };
+  }
+  return {
+    content: `${text.slice(0, MAX_FALLBACK_CONTENT_LENGTH)}\n\n[truncated]`,
+    truncated: true,
+  };
+}
+
+function stableFallbackArtifactId(taskId: string, sessionId: string): string {
+  return `session-final-response-fallback-${taskId}-${sessionId}`.replace(/[^A-Za-z0-9_.:-]/g, "-");
+}
+
+export async function loadLatestAssistantFinalResponse(sessionId: string): Promise<string | undefined> {
+  const history = await loadSessionHistory(sessionId, { consolidated: true });
+  const messages = historyNotificationsToMessages(history, sessionId);
+  return [...messages]
+    .reverse()
+    .find((message) => message.role === "assistant" && message.content.trim().length > 0)
+    ?.content
+    .trim();
+}
+
+export async function ensureCompletionFallbackArtifact(
+  params: CompletionFallbackArtifactParams,
+): Promise<CompletionFallbackArtifactResult> {
+  if (!isFallbackEligible(params.task, params.stage)) {
+    return { status: "skipped", reason: "lane_not_eligible" };
+  }
+
+  const existingArtifacts = await params.artifactStore.listByTask(params.task.id);
+  if (existingArtifacts.length > 0) {
+    return { status: "skipped", reason: "task_already_has_artifacts" };
+  }
+
+  const artifactId = stableFallbackArtifactId(params.task.id, params.sessionId);
+  const existingFallback = await params.artifactStore.getArtifact(artifactId);
+  if (existingFallback) {
+    return { status: "skipped", reason: "fallback_already_exists", artifactId };
+  }
+
+  const rawText = params.finalResponseText?.trim()
+    ?? await loadLatestAssistantFinalResponse(params.sessionId);
+  if (!rawText) {
+    return { status: "skipped", reason: "empty_final_response" };
+  }
+
+  const sensitiveBlocked = containsSensitiveText(rawText);
+  const { content, truncated } = sensitiveBlocked
+    ? {
+        content: "Session final response fallback was not stored because it appears to contain sensitive content.",
+        truncated: false,
+      }
+    : truncateContent(rawText);
+
+  const contentHash = createHash("sha256").update(rawText).digest("hex");
+  const artifact = createArtifact({
+    id: artifactId,
+    type: "logs",
+    taskId: params.task.id,
+    workspaceId: params.workspaceId,
+    providedByAgentId: params.sessionId,
+    content,
+    context: sensitiveBlocked
+      ? "Sensitive session final response fallback blocked"
+      : "Session final response fallback",
+    status: "provided",
+    metadata: {
+      kind: FALLBACK_KIND,
+      source: "session-final-response",
+      fallback: "true",
+      sessionId: params.sessionId,
+      transport: params.transport ?? "acp",
+      contentHash,
+      truncated: String(truncated),
+      sensitiveBlocked: String(sensitiveBlocked),
+    },
+  });
+
+  await params.artifactStore.saveArtifact(artifact);
+  return {
+    status: sensitiveBlocked ? "blocked" : "created",
+    reason: sensitiveBlocked ? "sensitive_content_blocked" : undefined,
+    artifactId,
+  };
+}

--- a/src/core/kanban/completion-fallback-artifact.ts
+++ b/src/core/kanban/completion-fallback-artifact.ts
@@ -49,7 +49,7 @@ function isFallbackEligible(task: Task, stage: KanbanColumnStage): boolean {
 
 function containsSensitiveText(text: string): boolean {
   return [
-    /\b(password|passwd|api[_-]?key|secret|token|cookie|authorization)\b\s*[:=]/i,
+    /["']?(password|passwd|api[_-]?key|secret|token|cookie|authorization)["']?\s*[:=]\s*["']?[^\s"']+/i,
     /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/,
     /\bgh[pousr]_[A-Za-z0-9_]{20,}/,
     /\bsk-[A-Za-z0-9_-]{20,}/,
@@ -106,12 +106,15 @@ export async function ensureCompletionFallbackArtifact(
   }
 
   const sensitiveBlocked = containsSensitiveText(rawText);
-  const { content, truncated } = sensitiveBlocked
-    ? {
-        content: "Session final response fallback was not stored because it appears to contain sensitive content.",
-        truncated: false,
-      }
-    : truncateContent(rawText);
+  if (sensitiveBlocked) {
+    return {
+      status: "blocked",
+      reason: "sensitive_content_blocked",
+      artifactId,
+    };
+  }
+
+  const { content, truncated } = truncateContent(rawText);
 
   const contentHash = createHash("sha256").update(rawText).digest("hex");
   const artifact = createArtifact({
@@ -133,7 +136,7 @@ export async function ensureCompletionFallbackArtifact(
       transport: params.transport ?? "acp",
       contentHash,
       truncated: String(truncated),
-      sensitiveBlocked: String(sensitiveBlocked),
+      sensitiveBlocked: "false",
     },
   });
 

--- a/src/core/kanban/workflow-orchestrator-singleton.ts
+++ b/src/core/kanban/workflow-orchestrator-singleton.ts
@@ -45,6 +45,7 @@ import {
   buildTaskInvestValidation,
   buildTaskStoryReadiness,
 } from "./task-derived-summary";
+import { ensureCompletionFallbackArtifact } from "./completion-fallback-artifact";
 
 // Use globalThis to survive HMR in Next.js dev mode
 const GLOBAL_KEY = "__routa_workflow_orchestrator__";
@@ -445,6 +446,16 @@ export function startWorkflowOrchestrator(system: RoutaSystem): void {
     sessionId: params.sessionId,
     prompt: params.prompt,
   }));
+  orchestrator.setEnsureCompletionFallbackArtifact(async (params) => {
+    await ensureCompletionFallbackArtifact({
+      task: params.task,
+      sessionId: params.sessionId,
+      workspaceId: params.workspaceId,
+      stage: params.stage,
+      transport: params.transport === "a2a" ? "a2a" : "acp",
+      artifactStore: system.artifactStore,
+    });
+  });
   orchestrator.start();
   queue.start();
   g[STARTED_KEY] = true;

--- a/src/core/kanban/workflow-orchestrator.ts
+++ b/src/core/kanban/workflow-orchestrator.ts
@@ -187,6 +187,14 @@ export type ResolveDevSessionSupervision = (params: {
   stage: KanbanColumnStage;
 }) => Promise<KanbanDevSessionSupervision>;
 
+export type EnsureCompletionFallbackArtifact = (params: {
+  task: Task;
+  sessionId: string;
+  workspaceId: string;
+  stage: KanbanColumnStage;
+  transport?: string;
+}) => Promise<void>;
+
 export class KanbanWorkflowOrchestrator {
   private handlerKey = "kanban-workflow-orchestrator";
   private activeAutomations = new Map<string, ActiveAutomation>();
@@ -194,6 +202,7 @@ export class KanbanWorkflowOrchestrator {
   private cleanupCardSession?: CleanupCardSession;
   private resolveDevSessionSupervision?: ResolveDevSessionSupervision;
   private sendKanbanSessionPrompt?: SendKanbanSessionPrompt;
+  private ensureCompletionFallbackArtifact?: EnsureCompletionFallbackArtifact;
   private watchdogTimer?: ReturnType<typeof setInterval>;
 
   constructor(
@@ -260,6 +269,10 @@ export class KanbanWorkflowOrchestrator {
   /** Set the callback used to send a prompt message into a live ACP session */
   setSendKanbanSessionPrompt(fn: SendKanbanSessionPrompt): void {
     this.sendKanbanSessionPrompt = fn;
+  }
+
+  setEnsureCompletionFallbackArtifact(fn: EnsureCompletionFallbackArtifact): void {
+    this.ensureCompletionFallbackArtifact = fn;
   }
 
   /** Get all active automations */
@@ -493,6 +506,26 @@ export class KanbanWorkflowOrchestrator {
           task.lastSyncError = this.buildFailureMessage(automation, event, completionSatisfied);
         }
         await this.taskStore.save(task);
+      }
+
+      if (
+        task
+        && !failedToAdvanceWithinLane
+        && successEvent
+        && completionSatisfied
+        && this.ensureCompletionFallbackArtifact
+      ) {
+        try {
+          await this.ensureCompletionFallbackArtifact({
+            task,
+            sessionId: eventSessionId,
+            workspaceId: automation.workspaceId,
+            stage: automation.stage,
+            transport: typeof event.data?.transport === "string" ? event.data.transport : undefined,
+          });
+        } catch (error) {
+          console.warn("[WorkflowOrchestrator] Failed to create completion fallback artifact:", error);
+        }
       }
 
       // Auto-advance if configured and successful.

--- a/src/core/mcp/__tests__/mcp-tool-executor.test.ts
+++ b/src/core/mcp/__tests__/mcp-tool-executor.test.ts
@@ -266,6 +266,18 @@ describe("executeMcpTool", () => {
     expect(
       getMcpToolDefinitions("essential", "kanban-planning").some((tool) => tool.name === "save_history_memory_context"),
     ).toBe(true);
+    expect(
+      getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "provide_artifact"),
+    ).toBe(true);
+    expect(
+      getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "list_artifacts"),
+    ).toBe(true);
+    expect(
+      getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "get_artifact"),
+    ).toBe(true);
+    expect(
+      getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "capture_screenshot"),
+    ).toBe(false);
 
     const loadFeatureTreeTool = getMcpToolDefinitions("essential", "kanban-planning")
       .find((tool) => tool.name === "load_feature_tree_context");

--- a/src/core/mcp/__tests__/mcp-tool-executor.test.ts
+++ b/src/core/mcp/__tests__/mcp-tool-executor.test.ts
@@ -277,7 +277,10 @@ describe("executeMcpTool", () => {
     ).toBe(true);
     expect(
       getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "capture_screenshot"),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      getMcpToolDefinitions("full", "kanban-planning").some((tool) => tool.name === "create_note"),
+    ).toBe(true);
 
     const loadFeatureTreeTool = getMcpToolDefinitions("essential", "kanban-planning")
       .find((tool) => tool.name === "load_feature_tree_context");

--- a/src/core/mcp/mcp-server-profiles.ts
+++ b/src/core/mcp/mcp-server-profiles.ts
@@ -19,6 +19,9 @@ const KANBAN_PLANNING_TOOL_NAMES = [
   "update_task",
   "update_card",
   "move_card",
+  "provide_artifact",
+  "list_artifacts",
+  "get_artifact",
 ] as const;
 
 const TEAM_COORDINATION_TOOL_NAMES = [

--- a/src/core/mcp/mcp-server-profiles.ts
+++ b/src/core/mcp/mcp-server-profiles.ts
@@ -19,9 +19,11 @@ const KANBAN_PLANNING_TOOL_NAMES = [
   "update_task",
   "update_card",
   "move_card",
+  "create_note",
   "provide_artifact",
   "list_artifacts",
   "get_artifact",
+  "capture_screenshot",
 ] as const;
 
 const TEAM_COORDINATION_TOOL_NAMES = [

--- a/src/core/mcp/mcp-tool-executor.ts
+++ b/src/core/mcp/mcp-tool-executor.ts
@@ -475,7 +475,11 @@ export async function executeMcpTool(
         })
       );
     case "get_artifact":
-      return formatResult(await tools.getArtifact(args.artifactId as string));
+      return formatResult(await tools.getArtifact({
+        artifactId: args.artifactId as string,
+        taskId: args.taskId as string | undefined,
+        workspaceId: args.workspaceId as string | undefined,
+      }));
     case "list_pending_artifact_requests":
       return formatResult(await tools.listPendingArtifactRequests(args.agentId as string));
     case "capture_screenshot":
@@ -1318,8 +1322,10 @@ export function getMcpToolDefinitions(
         type: "object",
         properties: {
           artifactId: { type: "string", description: "Artifact ID" },
+          taskId: { type: "string", description: "Task/card ID the artifact belongs to" },
+          workspaceId: { type: "string", description: "Workspace ID the artifact belongs to" },
         },
-        required: ["artifactId"],
+        required: ["artifactId", "taskId", "workspaceId"],
       },
     },
     {

--- a/src/core/mcp/routa-mcp-tool-manager.ts
+++ b/src/core/mcp/routa-mcp-tool-manager.ts
@@ -1487,9 +1487,15 @@ Can be in response to a request or proactively provided.`,
       "Get a specific artifact by ID",
       {
         artifactId: z.string().describe("Artifact ID"),
+        taskId: z.string().describe("Task ID the artifact belongs to"),
+        workspaceId: z.string().describe("Workspace ID the artifact belongs to"),
       },
       async (params) => {
-        const result = await this.tools.getArtifact(params.artifactId);
+        const result = await this.tools.getArtifact({
+          artifactId: params.artifactId,
+          taskId: params.taskId,
+          workspaceId: params.workspaceId,
+        });
         return this.toMcpResult(result);
       }
     );

--- a/src/core/tools/agent-tools.ts
+++ b/src/core/tools/agent-tools.ts
@@ -1214,14 +1214,27 @@ export class AgentTools {
   /**
    * Get a specific artifact by ID.
    */
-  async getArtifact(artifactId: string): Promise<ToolResult> {
+  async getArtifact(params: string | {
+    artifactId: string;
+    taskId?: string;
+    workspaceId?: string;
+  }): Promise<ToolResult> {
     if (!this.artifactStore) {
       return errorResult("Artifact store not configured");
     }
 
+    const artifactId = typeof params === "string" ? params : params.artifactId;
     const artifact = await this.artifactStore.getArtifact(artifactId);
     if (!artifact) {
       return errorResult(`Artifact not found: ${artifactId}`);
+    }
+    if (typeof params !== "string") {
+      if (params.taskId && artifact.taskId !== params.taskId) {
+        return errorResult(`Artifact not found: ${artifactId}`);
+      }
+      if (params.workspaceId && artifact.workspaceId !== params.workspaceId) {
+        return errorResult(`Artifact not found: ${artifactId}`);
+      }
     }
 
     return successResult({


### PR DESCRIPTION
﻿## Summary
- expose `provide_artifact`, `list_artifacts`, and `get_artifact` in the `kanban-planning` MCP profile without adding screenshot capture to ordinary planning sessions
- select the Kanban MCP planning profile for artifact/evidence-gated automation sessions
- persist a safe, idempotent final-response fallback `logs` artifact when plan/review/QA/Ops-style Kanban runs complete without explicit artifacts
- add Rust MCP route parity for `get_artifact`
- document follow-up platform PRs for metadata protection, session retention/SQLite compaction, and generic workflow/evidence gates

## Verification
- `npm run test:run -- src/core/kanban/__tests__/completion-fallback-artifact.test.ts src/core/kanban/__tests__/agent-trigger.test.ts src/core/mcp/__tests__/mcp-tool-executor.test.ts`
- `cargo test -p routa-server api_mcp_kanban_profile --test rust_api_mcp_routes`
- `node_modules\.bin\eslint.cmd src/core/kanban/completion-fallback-artifact.ts src/core/kanban/agent-trigger.ts src/core/kanban/workflow-orchestrator.ts src/core/kanban/workflow-orchestrator-singleton.ts src/core/mcp/mcp-server-profiles.ts src/core/kanban/__tests__/completion-fallback-artifact.test.ts src/core/kanban/__tests__/agent-trigger.test.ts src/core/mcp/__tests__/mcp-tool-executor.test.ts`
- `cargo run -p entrix -- run --dry-run`
- Manual smoke on `127.0.0.1:3890` with SQLite: initialized `kanban-planning` MCP session, verified artifact tools are listed, verified `capture_screenshot` is not exposed, called `provide_artifact`, `list_artifacts`, and `get_artifact` successfully.

## Notes
- `git fetch origin` was failing locally with GitHub connection resets, so I compared the branch base against upstream `main` via GitHub API. The only overlapping upstream files were `src/core/kanban/agent-trigger.ts` and `src/core/kanban/__tests__/agent-trigger.test.ts`; the upstream canonical YAML prompt/test additions are included here.
- `cargo run -p entrix -- run --tier fast` is not clean on this Windows workstation because unrelated environment/repo-wide checks fail: npm audit mirror lacks the audit endpoint, repo-wide ESLint has pre-existing unrelated errors, and clippy reports unrelated `trace-parser` warnings when run with `-D warnings`. Targeted tests and the dry-run fitness report pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `get_artifact` RPC method with task and workspace scoping for secure artifact retrieval.
  * Introduced automatic fallback artifact creation for task completion events.
  * Enhanced Kanban automation to use "kanban-planning" MCP profile for artifact-gated transitions.
  * Expanded artifact tools (`provide_artifact`, `list_artifacts`, `get_artifact`, `create_note`) in Kanban profile.

* **Documentation**
  * Added operational follow-up PR documentation outlining platform gaps and roadmap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->