### PR TITLE
fix: protect Kanban agent task metadata

### DIFF
--- a/crates/routa-server/src/api/mcp_routes.rs
+++ b/crates/routa-server/src/api/mcp_routes.rs
@@ -125,6 +125,15 @@ pub async fn execute_tool_public(
     tool_executor::execute_tool_public(state, name, args).await
 }
 
+pub(super) async fn execute_tool_for_profile_public(
+    state: &AppState,
+    name: &str,
+    args: &serde_json::Value,
+    mcp_profile: Option<&str>,
+) -> serde_json::Value {
+    tool_executor::execute_tool_for_profile_public(state, name, args, mcp_profile).await
+}
+
 pub fn normalize_tool_name_public(name: &str) -> &str {
     tool_executor::normalize_tool_name_public(name)
 }

--- a/crates/routa-server/src/api/mcp_routes/rmcp_service.rs
+++ b/crates/routa-server/src/api/mcp_routes/rmcp_service.rs
@@ -19,7 +19,8 @@ use crate::state::AppState;
 
 use super::tool_catalog;
 use super::{
-    execute_tool_public, inject_workspace_id, normalize_tool_name_public, McpRequestQuery,
+    execute_tool_for_profile_public, inject_workspace_id, normalize_tool_name_public,
+    McpRequestQuery,
 };
 
 pub(super) type SharedMcpHttpService =
@@ -145,7 +146,13 @@ impl ServerHandler for RoutaMcpHttpServer {
             .unwrap_or_else(|| serde_json::json!({}));
         inject_workspace_id(&mut arguments, &scope.workspace_id);
 
-        let result = execute_tool_public(&self.state, &normalized_tool_name, &arguments).await;
+        let result = execute_tool_for_profile_public(
+            &self.state,
+            &normalized_tool_name,
+            &arguments,
+            scope.mcp_profile.as_deref(),
+        )
+        .await;
         serde_json::from_value(result).map_err(|err| {
             McpError::internal_error(
                 format!("Failed to encode MCP tool result for '{normalized_tool_name}': {err}"),

--- a/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_catalog.rs
@@ -12,6 +12,7 @@ pub(super) fn build_tool_list_for_profile(profile: Option<&str>) -> Vec<serde_js
                     .and_then(|value| value.as_str())
                     .is_some_and(|name| tool_allowed_for_profile(name, Some("kanban-planning")))
             })
+            .map(|tool| restrict_tool_for_profile(tool, Some("kanban-planning")))
             .collect(),
         _ => tools,
     }
@@ -33,6 +34,85 @@ pub(super) fn tool_allowed_for_profile(name: &str, profile: Option<&str>) -> boo
         ),
         _ => true,
     }
+}
+
+pub(super) fn protected_update_task_fields_for_profile(
+    args: &serde_json::Value,
+    profile: Option<&str>,
+) -> Vec<String> {
+    if profile != Some("kanban-planning") {
+        return Vec::new();
+    }
+
+    let Some(object) = args.as_object() else {
+        return Vec::new();
+    };
+
+    object
+        .keys()
+        .filter(|key| {
+            matches!(
+                key.as_str(),
+                "status"
+                    | "columnId"
+                    | "column_id"
+                    | "dependencies"
+                    | "completionSummary"
+                    | "verificationVerdict"
+                    | "verificationReport"
+                    | "assignedTo"
+                    | "assignedProvider"
+                    | "assignedRole"
+                    | "assignedSpecialistId"
+                    | "releaseLabel"
+                    | "approval"
+                    | "ownerVerdict"
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+fn restrict_tool_for_profile(
+    mut tool: serde_json::Value,
+    profile: Option<&str>,
+) -> serde_json::Value {
+    if profile != Some("kanban-planning")
+        || tool.get("name").and_then(|value| value.as_str()) != Some("update_task")
+    {
+        return tool;
+    }
+
+    tool["description"] = serde_json::json!("Update story-readiness task fields. This profile cannot change status, lane, dependencies, completion, verification verdict, or assignment metadata; use move_card and gate-specific tools for workflow transitions.");
+
+    let Some(properties) = tool
+        .get_mut("inputSchema")
+        .and_then(|schema| schema.get_mut("properties"))
+        .and_then(|properties| properties.as_object_mut())
+    else {
+        return tool;
+    };
+
+    for field in [
+        "status",
+        "columnId",
+        "column_id",
+        "dependencies",
+        "completionSummary",
+        "verificationVerdict",
+        "verificationReport",
+        "assignedTo",
+        "assignedProvider",
+        "assignedRole",
+        "assignedSpecialistId",
+        "releaseLabel",
+        "approval",
+        "ownerVerdict",
+    ] {
+        properties.remove(field);
+    }
+
+    tool
 }
 
 fn build_tool_list_inner() -> Vec<serde_json::Value> {
@@ -476,5 +556,26 @@ mod tests {
 
         assert!(!names.is_empty());
         assert!(names.iter().all(|name| allowed.contains(name)));
+    }
+
+    #[test]
+    fn kanban_profile_update_task_schema_hides_protected_fields() {
+        let tools = build_tool_list_for_profile(Some("kanban-planning"));
+        let update_task = tools
+            .iter()
+            .find(|tool| tool.get("name").and_then(|value| value.as_str()) == Some("update_task"))
+            .expect("kanban profile should expose update_task");
+        let properties = update_task
+            .get("inputSchema")
+            .and_then(|schema| schema.get("properties"))
+            .and_then(|properties| properties.as_object())
+            .expect("update_task should expose input properties");
+
+        assert!(properties.contains_key("scope"));
+        assert!(properties.contains_key("acceptanceCriteria"));
+        assert!(!properties.contains_key("status"));
+        assert!(!properties.contains_key("completionSummary"));
+        assert!(!properties.contains_key("verificationVerdict"));
+        assert!(!properties.contains_key("assignedTo"));
     }
 }

--- a/crates/routa-server/src/api/mcp_routes/tool_executor.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_executor.rs
@@ -11,20 +11,35 @@ pub(super) async fn execute_tool_public(
     name: &str,
     args: &serde_json::Value,
 ) -> serde_json::Value {
-    execute_tool(state, normalize_tool_name(name), args).await
+    execute_tool(state, normalize_tool_name(name), args, None).await
+}
+
+pub(super) async fn execute_tool_for_profile_public(
+    state: &AppState,
+    name: &str,
+    args: &serde_json::Value,
+    mcp_profile: Option<&str>,
+) -> serde_json::Value {
+    execute_tool(state, normalize_tool_name(name), args, mcp_profile).await
 }
 
 pub(super) fn normalize_tool_name_public(name: &str) -> &str {
     normalize_tool_name(name)
 }
 
-async fn execute_tool(state: &AppState, name: &str, args: &serde_json::Value) -> serde_json::Value {
+async fn execute_tool(
+    state: &AppState,
+    name: &str,
+    args: &serde_json::Value,
+    mcp_profile: Option<&str>,
+) -> serde_json::Value {
     let workspace_id = args
         .get("workspaceId")
         .and_then(|v| v.as_str())
         .unwrap_or("default");
 
-    if let Some(result) = agents_tasks::execute(state, name, args, workspace_id).await {
+    if let Some(result) = agents_tasks::execute(state, name, args, workspace_id, mcp_profile).await
+    {
         return result;
     }
     if let Some(result) = delegation::execute(state, name, args, workspace_id).await {

--- a/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
+++ b/crates/routa-server/src/api/mcp_routes/tool_executor/agents_tasks.rs
@@ -7,6 +7,7 @@ pub(super) async fn execute(
     name: &str,
     args: &serde_json::Value,
     workspace_id: &str,
+    mcp_profile: Option<&str>,
 ) -> Option<serde_json::Value> {
     let result = match name {
         "list_agents" => match state.agent_store.list_by_workspace(workspace_id).await {
@@ -208,6 +209,19 @@ pub(super) async fn execute(
             }
         }
         "update_task" => {
+            let blocked_fields =
+                super::super::tool_catalog::protected_update_task_fields_for_profile(
+                    args,
+                    mcp_profile,
+                );
+            if !blocked_fields.is_empty() {
+                return Some(tool_result_error(&format!(
+                    "{} cannot write protected task workflow fields via update_task: {}. Use move_card for lane/status changes, provide artifacts for evidence, and leave owner/review metadata to the appropriate gate.",
+                    mcp_profile.unwrap_or("MCP profile"),
+                    blocked_fields.join(", ")
+                )));
+            }
+
             let task_id = args.get("taskId").and_then(|v| v.as_str()).unwrap_or("");
             let agent_id = args
                 .get("agentId")

--- a/crates/routa-server/tests/rust_api_mcp_routes.rs
+++ b/crates/routa-server/tests/rust_api_mcp_routes.rs
@@ -310,6 +310,26 @@ async fn api_mcp_kanban_profile_filters_tools_list() {
         names.contains(&"create_card") && names.contains(&"decompose_tasks"),
         "kanban profile should include planning tools, got: {names:?}"
     );
+
+    let update_task = tools
+        .iter()
+        .find(|tool| tool["name"] == "update_task")
+        .expect("kanban profile should include update_task");
+    let update_task_properties = update_task["inputSchema"]["properties"]
+        .as_object()
+        .expect("update_task should expose input properties");
+    assert!(
+        update_task_properties.contains_key("scope"),
+        "kanban update_task should keep story fields"
+    );
+    assert!(
+        !update_task_properties.contains_key("status"),
+        "kanban update_task should hide protected status field"
+    );
+    assert!(
+        !update_task_properties.contains_key("verificationVerdict"),
+        "kanban update_task should hide protected verification verdict field"
+    );
 }
 
 #[tokio::test]
@@ -543,4 +563,72 @@ async fn api_mcp_kanban_profile_allows_update_task_for_story_readiness() {
         get_body["task"]["testCases"],
         json!(["Move to Dev is unblocked once fields exist"])
     );
+}
+
+#[tokio::test]
+async fn api_mcp_kanban_profile_blocks_update_task_workflow_metadata() {
+    let fixture = ApiFixture::new().await;
+
+    let create_response = fixture
+        .client
+        .post(fixture.endpoint("/api/tasks"))
+        .json(&json!({
+            "title": "Protect metadata",
+            "objective": "Keep workflow state behind move_card",
+            "workspaceId": "default"
+        }))
+        .send()
+        .await
+        .expect("POST /api/tasks");
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body = read_json(create_response, "create task response").await;
+    let task_id = create_body["task"]["id"]
+        .as_str()
+        .expect("created task should include id");
+
+    let profile_query = "mcpProfile=kanban-planning";
+    let (session_id, _) = fixture.initialize_session(Some(profile_query)).await;
+    fixture
+        .complete_initialization(Some(profile_query), &session_id)
+        .await;
+
+    let update_response = fixture
+        .post_mcp(
+            Some(profile_query),
+            Some(&session_id),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "tools-call-update-task-protected",
+                "method": "tools/call",
+                "params": {
+                    "name": "update_task",
+                    "arguments": {
+                        "taskId": task_id,
+                        "status": "COMPLETED",
+                        "verificationVerdict": "APPROVED"
+                    }
+                }
+            }),
+        )
+        .await;
+    assert_eq!(update_response.status(), StatusCode::OK);
+    let update_body = read_first_sse_json(update_response, "blocked update_task response").await;
+    let update_text = update_body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("blocked update_task should return text payload");
+    assert!(
+        update_text.contains("protected task workflow fields"),
+        "expected protected-field error, got: {update_text}"
+    );
+
+    let get_response = fixture
+        .client
+        .get(fixture.endpoint(&format!("/api/tasks/{task_id}")))
+        .send()
+        .await
+        .expect("GET /api/tasks/{id}");
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body = read_json(get_response, "get task after blocked update_task").await;
+    assert_ne!(get_body["task"]["status"], json!("COMPLETED"));
+    assert!(get_body["task"]["verificationVerdict"].is_null());
 }

--- a/src/app/api/mcp/tools/route.ts
+++ b/src/app/api/mcp/tools/route.ts
@@ -4,6 +4,7 @@ import { executeMcpTool, getMcpToolDefinitions } from "@/core/mcp/mcp-tool-execu
 import { ToolMode } from "@/core/mcp/routa-mcp-tool-manager";
 import { KanbanTools } from "@/core/tools/kanban-tools";
 import { setGlobalToolMode, getGlobalToolMode } from "@/core/mcp/tool-mode-config";
+import { resolveMcpServerProfile } from "@/core/mcp/mcp-server-profiles";
 
 /**
  * GET /api/mcp/tools - List all MCP tool definitions
@@ -16,6 +17,7 @@ import { setGlobalToolMode, getGlobalToolMode } from "@/core/mcp/tool-mode-confi
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const modeParam = searchParams.get("mode") as ToolMode | null;
+  const mcpProfile = resolveMcpServerProfile(searchParams.get("mcpProfile") ?? undefined);
 
   // Use global mode if not explicitly specified
   const toolMode: ToolMode = modeParam === "full"
@@ -25,9 +27,10 @@ export async function GET(request: NextRequest) {
       : getGlobalToolMode();
 
   return NextResponse.json({
-    tools: getMcpToolDefinitions(toolMode),
+    tools: getMcpToolDefinitions(toolMode, mcpProfile),
     mode: toolMode,
     globalMode: getGlobalToolMode(),
+    mcpProfile,
   });
 }
 
@@ -76,13 +79,18 @@ export async function POST(request: NextRequest) {
         ? (body.args as Record<string, unknown>)
         : {};
     const toolMode: ToolMode = body?.mode === "full" ? "full" : "essential";
+    const mcpProfile = resolveMcpServerProfile(
+      typeof body?.mcpProfile === "string"
+        ? body.mcpProfile
+        : new URL(request.url).searchParams.get("mcpProfile") ?? undefined,
+    );
 
     if (!name) {
       return NextResponse.json({ error: "Tool name is required" }, { status: 400 });
     }
 
     // Always validate against full tool list (execution should work regardless of mode)
-    const toolExists = getMcpToolDefinitions("full").some((tool) => tool.name === name);
+    const toolExists = getMcpToolDefinitions("full", mcpProfile).some((tool) => tool.name === name);
     if (!toolExists) {
       return NextResponse.json({ error: `Unknown tool: ${name}` }, { status: 400 });
     }
@@ -92,11 +100,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "workspaceId is required in args or body" }, { status: 400 });
     }
 
-    const { system } = createRoutaMcpServer({ workspaceId, toolMode });
+    const { system } = createRoutaMcpServer({ workspaceId, toolMode, mcpProfile });
     const kanbanTools = new KanbanTools(system.kanbanBoardStore, system.taskStore);
     kanbanTools.setEventBus(system.eventBus);
     kanbanTools.setAutomationSystem(system);
-    const result = await executeMcpTool(system.tools, name, args, system.noteTools, system.workspaceTools, kanbanTools);
+    const result = await executeMcpTool(system.tools, name, args, system.noteTools, system.workspaceTools, kanbanTools, mcpProfile);
     return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json(

--- a/src/core/mcp/__tests__/mcp-tool-executor.test.ts
+++ b/src/core/mcp/__tests__/mcp-tool-executor.test.ts
@@ -277,6 +277,90 @@ describe("executeMcpTool", () => {
       .toBe("integer");
   });
 
+  it("hides protected update_task workflow fields for kanban-planning", () => {
+    const updateTaskTool = getMcpToolDefinitions("full", "kanban-planning")
+      .find((tool) => tool.name === "update_task");
+    const properties = updateTaskTool?.inputSchema?.properties as Record<string, unknown> | undefined;
+
+    expect(properties).toBeDefined();
+    expect(properties).toHaveProperty("scope");
+    expect(properties).toHaveProperty("acceptanceCriteria");
+    expect(properties).not.toHaveProperty("status");
+    expect(properties).not.toHaveProperty("completionSummary");
+    expect(properties).not.toHaveProperty("verificationVerdict");
+    expect(properties).not.toHaveProperty("assignedTo");
+  });
+
+  it("blocks kanban-planning update_task calls that try to write workflow metadata", async () => {
+    const tools = {
+      updateTask: vi.fn(async () => ({
+        success: true,
+        data: { taskId: "task-1" },
+      })),
+    } as never;
+
+    const result = await executeMcpTool(
+      tools,
+      "update_task",
+      {
+        workspaceId: "workspace-1",
+        taskId: "task-1",
+        status: "COMPLETED",
+        verificationVerdict: "APPROVED",
+      },
+      undefined,
+      undefined,
+      undefined,
+      "kanban-planning",
+    );
+
+    expect((tools as { updateTask: ReturnType<typeof vi.fn> }).updateTask).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ isError: true });
+    expect((result as { content: Array<{ text: string }> }).content[0]?.text).toContain(
+      "protected task workflow fields",
+    );
+  });
+
+  it("allows kanban-planning update_task calls for story-readiness fields", async () => {
+    const tools = {
+      updateTask: vi.fn(async (params) => ({
+        success: true,
+        data: { taskId: params.taskId, updatedFields: Object.keys(params.updates) },
+      })),
+    } as never;
+
+    const result = await executeMcpTool(
+      tools,
+      "update_task",
+      {
+        workspaceId: "workspace-1",
+        taskId: "task-1",
+        scope: "Clarify the story boundary",
+        acceptanceCriteria: ["Story fields are complete"],
+        verificationCommands: ["npm run test -- kanban"],
+        testCases: ["Move gate can read structured fields"],
+      },
+      undefined,
+      undefined,
+      undefined,
+      "kanban-planning",
+    );
+
+    expect((tools as { updateTask: ReturnType<typeof vi.fn> }).updateTask).toHaveBeenCalledWith({
+      taskId: "task-1",
+      expectedVersion: undefined,
+      agentId: "system",
+      sessionId: undefined,
+      updates: expect.objectContaining({
+        scope: "Clarify the story boundary",
+        acceptanceCriteria: ["Story fields are complete"],
+        verificationCommands: ["npm run test -- kanban"],
+        testCases: ["Move gate can read structured fields"],
+      }),
+    });
+    expect(result).toMatchObject({ isError: false });
+  });
+
   it("loads prompt-ready feature tree context from MCP args", async () => {
     const result = await executeMcpTool(
       {} as never,

--- a/src/core/mcp/mcp-task-write-boundary.ts
+++ b/src/core/mcp/mcp-task-write-boundary.ts
@@ -1,0 +1,57 @@
+import type { McpServerProfile } from "./mcp-server-profiles";
+
+export const KANBAN_PLANNING_UPDATE_TASK_FIELDS = new Set([
+  "taskId",
+  "expectedVersion",
+  "agentId",
+  "sessionId",
+  "title",
+  "objective",
+  "scope",
+  "acceptanceCriteria",
+  "verificationCommands",
+  "testCases",
+  "contextSearchSpec",
+  "jitContextAnalysis",
+]);
+
+export const HIGH_RISK_UPDATE_TASK_FIELDS = new Set([
+  "status",
+  "columnId",
+  "column_id",
+  "dependencies",
+  "completionSummary",
+  "verificationVerdict",
+  "verificationReport",
+  "assignedTo",
+  "assignedProvider",
+  "assignedRole",
+  "assignedSpecialistId",
+  "releaseLabel",
+  "approval",
+  "ownerVerdict",
+]);
+
+export function blockedUpdateTaskFieldsForProfile(
+  params: Record<string, unknown>,
+  profile?: McpServerProfile,
+): string[] {
+  if (profile !== "kanban-planning") {
+    return [];
+  }
+
+  return Object.keys(params).filter((field) => {
+    if (KANBAN_PLANNING_UPDATE_TASK_FIELDS.has(field)) {
+      return false;
+    }
+    return HIGH_RISK_UPDATE_TASK_FIELDS.has(field);
+  });
+}
+
+export function updateTaskBoundaryError(
+  fields: string[],
+  profile: McpServerProfile,
+): string {
+  const fieldList = fields.map((field) => `\`${field}\``).join(", ");
+  return `${profile} cannot write protected task workflow fields via update_task: ${fieldList}. Use move_card for lane/status changes, provide artifacts for evidence, and leave owner/review metadata to the appropriate gate.`;
+}

--- a/src/core/mcp/mcp-tool-executor.ts
+++ b/src/core/mcp/mcp-tool-executor.ts
@@ -19,6 +19,10 @@ import {
 import { readFeatureTreeSpecResource } from "@/core/spec/feature-tree-spec-resource-contract";
 import { ToolMode } from "./routa-mcp-tool-manager";
 import { getMcpProfileToolAllowlist, type McpServerProfile } from "./mcp-server-profiles";
+import {
+  blockedUpdateTaskFieldsForProfile,
+  updateTaskBoundaryError,
+} from "./mcp-task-write-boundary";
 import { parseTaskJitContextAnalysis } from "../models/task";
 import {
   CONFIRM_FEATURE_TREE_STORY_CONTEXT_DESCRIPTION,
@@ -172,6 +176,45 @@ const ESSENTIAL_TOOL_NAMES = new Set([
   CONFIRM_FEATURE_TREE_STORY_CONTEXT_TOOL_NAME,
 ]);
 
+function buildUpdateTaskToolDefinition(mcpProfile?: McpServerProfile) {
+  const baseProperties = {
+    taskId: { type: "string", description: "Task ID" },
+    expectedVersion: { type: "number", description: "Expected version for optimistic locking" },
+    agentId: { type: "string", description: "Agent performing the update (optional in Kanban sessions)" },
+    title: { type: "string" },
+    objective: { type: "string" },
+    scope: { type: "string" },
+    acceptanceCriteria: { type: "array", items: { type: "string" } },
+    verificationCommands: { type: "array", items: { type: "string" } },
+    testCases: { type: "array", items: { type: "string" } },
+    contextSearchSpec: TASK_CONTEXT_SEARCH_SPEC_SCHEMA,
+    jitContextAnalysis: TASK_JIT_CONTEXT_ANALYSIS_SCHEMA,
+  };
+
+  const properties = mcpProfile === "kanban-planning"
+    ? baseProperties
+    : {
+        ...baseProperties,
+        status: { type: "string" },
+        completionSummary: { type: "string" },
+        verificationVerdict: { type: "string", enum: ["APPROVED", "NOT_APPROVED", "BLOCKED"] },
+        verificationReport: { type: "string" },
+        assignedTo: { type: "string" },
+      };
+
+  return {
+    name: "update_task",
+    description: mcpProfile === "kanban-planning"
+      ? "Update story-readiness task fields. This profile cannot change status, lane, dependencies, completion, verification verdict, or assignment metadata; use move_card and gate-specific tools for workflow transitions."
+      : "Atomically update structured task fields with optimistic locking. Use this for story-readiness fields such as scope, acceptance criteria, verification commands, and test cases. agentId is optional for Kanban sessions. In backlog planning, only persist contextSearchSpec after repo inspection or feature-tree lookup confirms the feature/files.",
+    inputSchema: {
+      type: "object",
+      properties,
+      required: ["taskId"],
+    },
+  };
+}
+
 export async function executeMcpTool(
   tools: AgentTools,
   name: string,
@@ -179,6 +222,7 @@ export async function executeMcpTool(
   noteTools?: NoteTools,
   workspaceTools?: WorkspaceTools,
   kanbanTools?: KanbanTools,
+  mcpProfile?: McpServerProfile,
 ) {
   // ── Tools that don't require workspaceId ─────────────────────────────
   // ── Tools that don't require workspaceId ─────────────────────────────
@@ -298,6 +342,15 @@ export async function executeMcpTool(
         })
       );
     case "update_task":
+      {
+        const blockedFields = blockedUpdateTaskFieldsForProfile(args, mcpProfile);
+        if (blockedFields.length > 0 && mcpProfile) {
+          return formatResult({
+            success: false,
+            error: updateTaskBoundaryError(blockedFields, mcpProfile),
+          });
+        }
+      }
       return formatResult(
         await tools.updateTask({
           taskId: args.taskId as string,
@@ -1111,32 +1164,7 @@ export function getMcpToolDefinitions(
         required: ["taskId", "status", "agentId"],
       },
     },
-    {
-      name: "update_task",
-      description: "Atomically update structured task fields with optimistic locking. Use this for story-readiness fields such as scope, acceptance criteria, verification commands, and test cases. agentId is optional for Kanban sessions. In backlog planning, only persist contextSearchSpec after repo inspection or feature-tree lookup confirms the feature/files.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          taskId: { type: "string", description: "Task ID" },
-          expectedVersion: { type: "number", description: "Expected version for optimistic locking" },
-          agentId: { type: "string", description: "Agent performing the update (optional in Kanban sessions)" },
-          title: { type: "string" },
-          objective: { type: "string" },
-          scope: { type: "string" },
-          status: { type: "string" },
-          completionSummary: { type: "string" },
-          verificationVerdict: { type: "string", enum: ["APPROVED", "NOT_APPROVED", "BLOCKED"] },
-          verificationReport: { type: "string" },
-          assignedTo: { type: "string" },
-          acceptanceCriteria: { type: "array", items: { type: "string" } },
-          verificationCommands: { type: "array", items: { type: "string" } },
-          testCases: { type: "array", items: { type: "string" } },
-          contextSearchSpec: TASK_CONTEXT_SEARCH_SPEC_SCHEMA,
-          jitContextAnalysis: TASK_JIT_CONTEXT_ANALYSIS_SCHEMA,
-        },
-        required: ["taskId"],
-      },
-    },
+    buildUpdateTaskToolDefinition(mcpProfile),
     {
       name: "save_history_memory_context",
       description: "Persist the minimal task-adaptive history memory result for a task so later sessions can load it directly.",

--- a/src/core/mcp/routa-mcp-server.ts
+++ b/src/core/mcp/routa-mcp-server.ts
@@ -63,6 +63,7 @@ export function createRoutaMcpServer(
 
   const toolManager = new RoutaMcpToolManager(routaSystem.tools, opts.workspaceId);
   toolManager.setToolMode(toolMode);
+  toolManager.setMcpProfile(opts.mcpProfile);
   toolManager.setAllowedTools(getMcpProfileToolAllowlist(opts.mcpProfile));
 
   // Scope note/task creation to this ACP session when provided

--- a/src/core/mcp/routa-mcp-tool-manager.ts
+++ b/src/core/mcp/routa-mcp-tool-manager.ts
@@ -42,6 +42,11 @@ import {
   registerSummarizeFileSessionContextTool,
   registerSummarizeTaskHistoryContextTool,
 } from "./task-adaptive-mcp-tools";
+import type { McpServerProfile } from "./mcp-server-profiles";
+import {
+  blockedUpdateTaskFieldsForProfile,
+  updateTaskBoundaryError,
+} from "./mcp-task-write-boundary";
 
 /**
  * Tool registration mode for MCP server.
@@ -96,6 +101,7 @@ export class RoutaMcpToolManager {
   private toolMode: ToolMode = "essential";
   private allowedTools?: ReadonlySet<string>;
   private sessionId?: string;
+  private mcpProfile?: McpServerProfile;
 
   constructor(
     private tools: AgentTools,
@@ -120,6 +126,10 @@ export class RoutaMcpToolManager {
 
   setAllowedTools(allowedTools?: ReadonlySet<string>): void {
     this.allowedTools = allowedTools;
+  }
+
+  setMcpProfile(profile?: McpServerProfile): void {
+    this.mcpProfile = profile;
   }
 
   /**
@@ -357,28 +367,42 @@ export class RoutaMcpToolManager {
   }
 
   private registerUpdateTask(server: McpServer) {
+    const protectedWorkflowFields = {
+      status: z.string().optional().describe("Update the task status"),
+      completionSummary: z.string().optional().describe("Set completion summary"),
+      verificationVerdict: z.enum(["APPROVED", "NOT_APPROVED", "BLOCKED"]).optional().describe("Set verification verdict"),
+      verificationReport: z.string().optional().describe("Set verification report"),
+      assignedTo: z.string().optional().describe("Assign to agent ID"),
+    };
+    const inputSchema = {
+      taskId: z.string().describe("ID of the task to update"),
+      expectedVersion: z.number().optional().describe("Expected version for optimistic locking (from prior task read)"),
+      agentId: z.string().optional().describe("ID of the agent performing the update (optional in Kanban sessions)"),
+      title: z.string().optional().describe("Update the task title"),
+      objective: z.string().optional().describe("Update the task objective"),
+      scope: z.string().optional().describe("Update the task scope"),
+      acceptanceCriteria: z.array(z.string()).optional().describe("Update acceptance criteria"),
+      verificationCommands: z.array(z.string()).optional().describe("Update verification commands"),
+      testCases: z.array(z.string()).optional().describe("Update test cases"),
+      contextSearchSpec: taskContextSearchSpecSchema.optional().describe("Confirmed retrieval hints for JIT Context and history search. In backlog planning, only persist this after repo inspection or load_feature_tree_context confirms the feature/files."),
+      jitContextAnalysis: taskJitContextAnalysisSchema.nullable().optional().describe("Structured JIT/history analysis to persist on the task for later reuse."),
+      ...(this.mcpProfile === "kanban-planning" ? {} : protectedWorkflowFields),
+    };
+
     server.tool(
       "update_task",
-      "Atomically update structured task fields with optimistic locking. Use this for story-readiness fields such as scope, acceptance criteria, verification commands, and test cases. agentId is optional for Kanban sessions.",
-      {
-        taskId: z.string().describe("ID of the task to update"),
-        expectedVersion: z.number().optional().describe("Expected version for optimistic locking (from prior task read)"),
-        agentId: z.string().optional().describe("ID of the agent performing the update (optional in Kanban sessions)"),
-        title: z.string().optional().describe("Update the task title"),
-        objective: z.string().optional().describe("Update the task objective"),
-        scope: z.string().optional().describe("Update the task scope"),
-        status: z.string().optional().describe("Update the task status"),
-        completionSummary: z.string().optional().describe("Set completion summary"),
-        verificationVerdict: z.enum(["APPROVED", "NOT_APPROVED", "BLOCKED"]).optional().describe("Set verification verdict"),
-        verificationReport: z.string().optional().describe("Set verification report"),
-        assignedTo: z.string().optional().describe("Assign to agent ID"),
-        acceptanceCriteria: z.array(z.string()).optional().describe("Update acceptance criteria"),
-        verificationCommands: z.array(z.string()).optional().describe("Update verification commands"),
-        testCases: z.array(z.string()).optional().describe("Update test cases"),
-        contextSearchSpec: taskContextSearchSpecSchema.optional().describe("Confirmed retrieval hints for JIT Context and history search. In backlog planning, only persist this after repo inspection or load_feature_tree_context confirms the feature/files."),
-        jitContextAnalysis: taskJitContextAnalysisSchema.nullable().optional().describe("Structured JIT/history analysis to persist on the task for later reuse."),
-      },
+      this.mcpProfile === "kanban-planning"
+        ? "Update story-readiness task fields. This profile cannot change status, lane, dependencies, completion, verification verdict, or assignment metadata; use move_card and gate-specific tools for workflow transitions."
+        : "Atomically update structured task fields with optimistic locking. Use this for story-readiness fields such as scope, acceptance criteria, verification commands, and test cases. agentId is optional for Kanban sessions.",
+      inputSchema,
       async (params) => {
+        const blockedFields = blockedUpdateTaskFieldsForProfile(params, this.mcpProfile);
+        if (blockedFields.length > 0 && this.mcpProfile) {
+          return this.toMcpResult({
+            success: false,
+            error: updateTaskBoundaryError(blockedFields, this.mcpProfile),
+          });
+        }
         const { taskId, expectedVersion, agentId, ...updates } = params;
         const result = await this.tools.updateTask({
           taskId,


### PR DESCRIPTION
## Summary
- restrict `kanban-planning` `update_task` to story/readiness fields and hide protected workflow metadata from its tool schema
- block protected `update_task` writes at execution time in both TS and Rust MCP paths
- thread `mcpProfile` through MCP tool listing/execution and add TS/Rust regression coverage

## Test Plan
- `npm test -- --run src/core/mcp/__tests__/mcp-tool-executor.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/core/mcp/mcp-tool-executor.ts src/core/mcp/routa-mcp-tool-manager.ts src/core/mcp/routa-mcp-server.ts src/core/mcp/mcp-task-write-boundary.ts src/core/mcp/__tests__/mcp-tool-executor.test.ts src/app/api/mcp/tools/route.ts`
- `cargo test -p routa-server --test rust_api_mcp_routes`
- `cargo test -p routa-server kanban_profile_update_task_schema_hides_protected_fields`
- `cargo fmt --check`

## Notes
- `kanban-planning` agents can still write `scope`, `acceptanceCriteria`, `verificationCommands`, `testCases`, `contextSearchSpec`, and JIT context.
- Lane/status changes remain on `move_card`; completion/verdict/assignment/release metadata stays out of the ordinary planning profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP tool execution is now profile-aware, enabling fine-grained permission controls.
  * The kanban-planning profile restricts certain task update operations (status changes, assignments, verification metadata).
  * Tool definitions dynamically reflect allowed fields based on the active MCP profile.
  * API endpoints now accept and enforce profile parameters for enhanced access control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->