### PR TITLE
fix: wire SQLite session history compaction

### DIFF
--- a/docs/operational/sqlite-session-history-maintenance.zh-CN.md
+++ b/docs/operational/sqlite-session-history-maintenance.zh-CN.md
@@ -1,0 +1,32 @@
+# SQLite Session History Maintenance
+
+Routa 本地 SQLite 长时间运行后，ACP 会话历史可能同时占用：
+
+- `session_messages`：按事件追加的会话消息表。
+- `acp_sessions.message_history`：兼容旧读取路径的 JSON 历史列。
+- `routa.db-wal`：SQLite WAL 文件。
+
+维护入口：
+
+```bash
+npm run db:sqlite:compact-sessions -- --db ./routa.db --dry-run --json
+npm run db:sqlite:compact-sessions -- --db ./routa.db --apply --checkpoint
+```
+
+如需在确认服务已停止后回收更多磁盘空间：
+
+```bash
+npm run db:sqlite:compact-sessions -- --db ./routa.db --apply --checkpoint --vacuum
+```
+
+行为边界：
+
+- 默认 `dry-run`，只报告候选 session、可合并 chunk 和可删除行数。
+- `--apply` 才会写入数据库。
+- 默认保护 60 分钟内更新过的 session，也保护 `lease_expires_at` 尚未过期的 session。
+- 可以用 `--active-session <id>` 显式保护正在运行的 session。
+- 只合并连续的 `agent_message_chunk` 为 `agent_message`。
+- 不删除 artifact、task completion summary、verification report 或业务对象。
+- compaction 不更新 `acp_sessions.updated_at`，避免维护操作污染会话活跃时间线。
+- `--checkpoint` 会执行 `PRAGMA wal_checkpoint(TRUNCATE)`。
+- `--vacuum` 会执行 `VACUUM`，建议只在 Routa 服务停止后使用，避免 Windows SQLite 文件锁问题。

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "db:sqlite:generate": "drizzle-kit generate --config=drizzle-sqlite.config.ts",
     "db:sqlite:migrate": "drizzle-kit migrate --config=drizzle-sqlite.config.ts",
     "db:sqlite:push": "drizzle-kit push --config=drizzle-sqlite.config.ts",
+    "db:sqlite:compact-sessions": "node --import tsx scripts/maintenance/compact-session-history.ts",
     "api:check": "node --import tsx scripts/fitness/check-api-parity.ts",
     "api:check:json": "node --import tsx scripts/fitness/check-api-parity.ts --json",
     "api:check:fix": "node --import tsx scripts/fitness/check-api-parity.ts --fix-hint",

--- a/scripts/__tests__/compact-session-history.test.ts
+++ b/scripts/__tests__/compact-session-history.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import BetterSqlite3 from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { runSessionHistoryMaintenance } from "../maintenance/compact-session-history";
+
+const tempDirs: string[] = [];
+type CountRow = { count: number };
+type PayloadRow = { payload: string };
+type SessionHistoryRow = { message_history: string };
+
+function createFixtureDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "routa-session-compact-"));
+  tempDirs.push(dir);
+  const dbPath = path.join(dir, "routa.db");
+  const sqlite = new BetterSqlite3(dbPath);
+  const old = Date.now() - 10 * 24 * 60 * 60 * 1000;
+  const active = Date.now();
+  sqlite.exec(`
+    CREATE TABLE acp_sessions (
+      id TEXT PRIMARY KEY,
+      message_history TEXT DEFAULT '[]',
+      updated_at INTEGER,
+      lease_expires_at INTEGER
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      message_index INTEGER NOT NULL,
+      event_type TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      created_at INTEGER
+    );
+  `);
+  sqlite.prepare("INSERT INTO acp_sessions (id, message_history, updated_at, lease_expires_at) VALUES (?, ?, ?, ?)").run(
+    "old-session",
+    JSON.stringify([
+      { sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } } },
+      { sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "lo" } } },
+      { sessionId: "old-session", update: { sessionUpdate: "turn_complete" } },
+    ]),
+    old,
+    null,
+  );
+  sqlite.prepare("INSERT INTO acp_sessions (id, message_history, updated_at, lease_expires_at) VALUES (?, ?, ?, ?)").run(
+    "active-session",
+    JSON.stringify([
+      { sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Act" } } },
+      { sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "ive" } } },
+    ]),
+    active,
+    Date.now() + 60_000,
+  );
+  const insertMessage = sqlite.prepare(
+    "INSERT INTO session_messages (id, session_id, message_index, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  insertMessage.run("m1", "old-session", 0, "agent_message_chunk", JSON.stringify({ sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "A" } } }), old);
+  insertMessage.run("m2", "old-session", 1, "agent_message_chunk", JSON.stringify({ sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "B" } } }), old);
+  insertMessage.run("m3", "active-session", 0, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "C" } } }), old);
+  insertMessage.run("m4", "active-session", 1, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "D" } } }), old);
+  sqlite.close();
+  return dbPath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("compact-session-history maintenance script", () => {
+  it("reports dry-run changes without writing", () => {
+    const dbPath = createFixtureDb();
+    const summary = runSessionHistoryMaintenance({
+      dbPath,
+      mode: "dry-run",
+      sessionCutoffDays: 7,
+      activeWindowMinutes: 60,
+      activeSessionIds: new Set(),
+      checkpoint: true,
+      vacuum: true,
+      json: true,
+    });
+
+    expect(summary.sessionMessages.mergedGroups).toBe(1);
+    expect(summary.sessionMessages.deletedRows).toBe(1);
+    expect(summary.acpSessions.compactedSessions).toBe(1);
+    expect(summary.protectedActiveSessions).toEqual(["active-session"]);
+
+    const sqlite = new BetterSqlite3(dbPath);
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get()).toEqual({ count: 4 });
+    sqlite.close();
+  });
+
+  it("applies compaction and skips active sessions", () => {
+    const dbPath = createFixtureDb();
+    const summary = runSessionHistoryMaintenance({
+      dbPath,
+      mode: "apply",
+      sessionCutoffDays: 7,
+      activeWindowMinutes: 60,
+      activeSessionIds: new Set(),
+      checkpoint: false,
+      vacuum: false,
+      json: true,
+    });
+
+    expect(summary.sessionMessages.deletedRows).toBe(1);
+    const sqlite = new BetterSqlite3(dbPath);
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get() as CountRow).toEqual({ count: 3 });
+    const oldPayloadRow = sqlite.prepare("SELECT payload FROM session_messages WHERE id = ?").get("m1") as PayloadRow;
+    const oldPayload = JSON.parse(oldPayloadRow.payload);
+    expect(oldPayload.update.sessionUpdate).toBe("agent_message");
+    expect(oldPayload.update.content.text).toBe("AB");
+
+    const activePayloadRow = sqlite.prepare("SELECT payload FROM session_messages WHERE id = ?").get("m3") as PayloadRow;
+    const activePayload = JSON.parse(activePayloadRow.payload);
+    expect(activePayload.update.sessionUpdate).toBe("agent_message_chunk");
+
+    const oldSession = sqlite.prepare("SELECT message_history FROM acp_sessions WHERE id = ?").get("old-session") as SessionHistoryRow;
+    expect(JSON.parse(oldSession.message_history)).toHaveLength(2);
+    const activeSession = sqlite.prepare("SELECT message_history FROM acp_sessions WHERE id = ?").get("active-session") as SessionHistoryRow;
+    expect(JSON.parse(activeSession.message_history)).toHaveLength(2);
+    sqlite.close();
+  });
+});

--- a/scripts/__tests__/compact-session-history.test.ts
+++ b/scripts/__tests__/compact-session-history.test.ts
@@ -52,6 +52,12 @@ function createFixtureDb(): string {
     active,
     Date.now() + 60_000,
   );
+  sqlite.prepare("INSERT INTO acp_sessions (id, message_history, updated_at, lease_expires_at) VALUES (?, ?, ?, ?)").run(
+    "invalid-session",
+    JSON.stringify([]),
+    old,
+    null,
+  );
   const insertMessage = sqlite.prepare(
     "INSERT INTO session_messages (id, session_id, message_index, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
   );
@@ -59,6 +65,8 @@ function createFixtureDb(): string {
   insertMessage.run("m2", "old-session", 1, "agent_message_chunk", JSON.stringify({ type: "agent_message_chunk", text: "B" }), old);
   insertMessage.run("m3", "active-session", 0, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "C" } } }), old);
   insertMessage.run("m4", "active-session", 1, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "D" } } }), old);
+  insertMessage.run("m5", "invalid-session", 0, "agent_message_chunk", JSON.stringify({ type: "agent_message", text: "Keep" }), old);
+  insertMessage.run("m6", "invalid-session", 1, "agent_message_chunk", JSON.stringify({ type: "agent_message", text: "Me" }), old);
   sqlite.close();
   return dbPath;
 }
@@ -89,7 +97,7 @@ describe("compact-session-history maintenance script", () => {
     expect(summary.protectedActiveSessions).toEqual(["active-session"]);
 
     const sqlite = new BetterSqlite3(dbPath);
-    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get()).toEqual({ count: 4 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get()).toEqual({ count: 6 });
     sqlite.close();
   });
 
@@ -108,7 +116,7 @@ describe("compact-session-history maintenance script", () => {
 
     expect(summary.sessionMessages.deletedRows).toBe(1);
     const sqlite = new BetterSqlite3(dbPath);
-    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get() as CountRow).toEqual({ count: 3 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM session_messages").get() as CountRow).toEqual({ count: 5 });
     const oldPayloadRow = sqlite.prepare("SELECT payload FROM session_messages WHERE id = ?").get("m1") as PayloadRow;
     const oldPayload = JSON.parse(oldPayloadRow.payload);
     expect(oldPayload.update.sessionUpdate).toBe("agent_message");
@@ -119,6 +127,13 @@ describe("compact-session-history maintenance script", () => {
     const activePayloadRow = sqlite.prepare("SELECT payload FROM session_messages WHERE id = ?").get("m3") as PayloadRow;
     const activePayload = JSON.parse(activePayloadRow.payload);
     expect(activePayload.update.sessionUpdate).toBe("agent_message_chunk");
+
+    const invalidPayloadRow = sqlite.prepare("SELECT event_type, payload FROM session_messages WHERE id = ?").get("m6") as {
+      event_type: string;
+      payload: string;
+    };
+    expect(invalidPayloadRow.event_type).toBe("agent_message_chunk");
+    expect(JSON.parse(invalidPayloadRow.payload).text).toBe("Me");
 
     const oldSession = sqlite.prepare("SELECT message_history FROM acp_sessions WHERE id = ?").get("old-session") as SessionHistoryRow;
     expect(JSON.parse(oldSession.message_history)).toHaveLength(2);

--- a/scripts/__tests__/compact-session-history.test.ts
+++ b/scripts/__tests__/compact-session-history.test.ts
@@ -55,8 +55,8 @@ function createFixtureDb(): string {
   const insertMessage = sqlite.prepare(
     "INSERT INTO session_messages (id, session_id, message_index, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
   );
-  insertMessage.run("m1", "old-session", 0, "agent_message_chunk", JSON.stringify({ sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "A" } } }), old);
-  insertMessage.run("m2", "old-session", 1, "agent_message_chunk", JSON.stringify({ sessionId: "old-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "B" } } }), old);
+  insertMessage.run("m1", "old-session", 0, "agent_message_chunk", JSON.stringify({ type: "agent_message_chunk", text: "A" }), old);
+  insertMessage.run("m2", "old-session", 1, "agent_message_chunk", JSON.stringify({ type: "agent_message_chunk", text: "B" }), old);
   insertMessage.run("m3", "active-session", 0, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "C" } } }), old);
   insertMessage.run("m4", "active-session", 1, "agent_message_chunk", JSON.stringify({ sessionId: "active-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "D" } } }), old);
   sqlite.close();
@@ -113,6 +113,8 @@ describe("compact-session-history maintenance script", () => {
     const oldPayload = JSON.parse(oldPayloadRow.payload);
     expect(oldPayload.update.sessionUpdate).toBe("agent_message");
     expect(oldPayload.update.content.text).toBe("AB");
+    expect(oldPayload.type).toBe("agent_message");
+    expect(oldPayload.text).toBe("AB");
 
     const activePayloadRow = sqlite.prepare("SELECT payload FROM session_messages WHERE id = ?").get("m3") as PayloadRow;
     const activePayload = JSON.parse(activePayloadRow.payload);

--- a/scripts/maintenance/compact-session-history.ts
+++ b/scripts/maintenance/compact-session-history.ts
@@ -1,0 +1,351 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import BetterSqlite3 from "better-sqlite3";
+import * as historyCompactorModule from "../../src/core/storage/history-compactor";
+import type { SessionHistoryNotification } from "../../src/core/storage/history-compactor";
+
+type HistoryCompactorModule = typeof import("../../src/core/storage/history-compactor");
+const runtimeHistoryCompactorModule = (
+  "compactSessionHistoryNotifications" in historyCompactorModule
+    ? historyCompactorModule
+    : (historyCompactorModule as unknown as { default?: HistoryCompactorModule }).default
+) as HistoryCompactorModule | undefined;
+
+if (!runtimeHistoryCompactorModule?.compactSessionHistoryNotifications) {
+  throw new Error("Unable to load session history compaction helpers");
+}
+
+const {
+  compactSessionHistoryNotifications,
+  getSessionHistoryChunkText,
+} = runtimeHistoryCompactorModule;
+
+type Mode = "dry-run" | "apply";
+
+interface Options {
+  dbPath: string;
+  mode: Mode;
+  sessionCutoffDays: number;
+  activeWindowMinutes: number;
+  activeSessionIds: Set<string>;
+  checkpoint: boolean;
+  vacuum: boolean;
+  json: boolean;
+}
+
+interface SessionRow {
+  id: string;
+  message_history: string | null;
+  updated_at: number | null;
+  lease_expires_at: number | null;
+}
+
+interface MessageRow {
+  id: string;
+  session_id: string;
+  message_index: number;
+  payload: string | Record<string, unknown>;
+}
+
+interface MaintenanceSummary {
+  mode: Mode;
+  dbPath: string;
+  protectedActiveSessions: string[];
+  sessionMessages: {
+    candidateSessions: number;
+    mergedGroups: number;
+    mergedChunks: number;
+    deletedRows: number;
+  };
+  acpSessions: {
+    candidateSessions: number;
+    compactedSessions: number;
+    originalMessages: number;
+    compactedMessages: number;
+    mergedChunks: number;
+  };
+  sqlite: {
+    checkpoint: "skipped" | "planned" | "applied";
+    vacuum: "skipped" | "planned" | "applied";
+  };
+}
+
+function parseOptions(argv: string[]): Options {
+  const options: Options = {
+    dbPath: process.env.ROUTA_DB_PATH ?? "routa.db",
+    mode: "dry-run",
+    sessionCutoffDays: 7,
+    activeWindowMinutes: 60,
+    activeSessionIds: new Set(),
+    checkpoint: false,
+    vacuum: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[++index];
+      if (!value) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      return value;
+    };
+
+    if (arg === "--db") options.dbPath = next();
+    else if (arg === "--apply") options.mode = "apply";
+    else if (arg === "--dry-run") options.mode = "dry-run";
+    else if (arg === "--session-cutoff-days") options.sessionCutoffDays = Number(next());
+    else if (arg === "--active-window-minutes") options.activeWindowMinutes = Number(next());
+    else if (arg === "--active-session") options.activeSessionIds.add(next());
+    else if (arg === "--checkpoint") options.checkpoint = true;
+    else if (arg === "--vacuum") options.vacuum = true;
+    else if (arg === "--json") options.json = true;
+    else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.sessionCutoffDays) || options.sessionCutoffDays < 0) {
+    throw new Error("--session-cutoff-days must be a non-negative number");
+  }
+  if (!Number.isFinite(options.activeWindowMinutes) || options.activeWindowMinutes < 0) {
+    throw new Error("--active-window-minutes must be a non-negative number");
+  }
+
+  options.dbPath = path.resolve(options.dbPath);
+  return options;
+}
+
+function printUsage(): void {
+  console.log(`Compact Routa SQLite ACP session history.
+
+Usage:
+  node --import tsx scripts/maintenance/compact-session-history.ts [options]
+
+Options:
+  --db <path>                    SQLite db path, defaults to ROUTA_DB_PATH or ./routa.db
+  --dry-run                      Report planned changes without writing (default)
+  --apply                        Apply compaction
+  --session-cutoff-days <days>   Only compact sessions/messages older than this cutoff (default: 7)
+  --active-window-minutes <min>  Protect sessions updated within this window (default: 60)
+  --active-session <id>          Protect an explicit active session; repeatable
+  --checkpoint                   Run PRAGMA wal_checkpoint(TRUNCATE) in apply mode
+  --vacuum                       Run VACUUM in apply mode
+  --json                         Print machine-readable JSON
+`);
+}
+
+function parseJsonArray(value: string | null): SessionHistoryNotification[] {
+  if (!value) {
+    return [];
+  }
+  const parsed = JSON.parse(value) as unknown;
+  return Array.isArray(parsed) ? parsed as SessionHistoryNotification[] : [];
+}
+
+function parsePayload(value: string | Record<string, unknown>): Record<string, unknown> {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function isActiveSession(row: SessionRow, options: Options, now: number): boolean {
+  if (options.activeSessionIds.has(row.id)) {
+    return true;
+  }
+  if (typeof row.lease_expires_at === "number" && row.lease_expires_at > now) {
+    return true;
+  }
+  const activeCutoff = now - options.activeWindowMinutes * 60 * 1000;
+  return typeof row.updated_at === "number" && row.updated_at >= activeCutoff;
+}
+
+function groupConsecutiveChunks(rows: MessageRow[]): MessageRow[][] {
+  const groups: MessageRow[][] = [];
+  for (const row of rows) {
+    const last = groups[groups.length - 1];
+    const previous = last?.[last.length - 1];
+    if (!last || previous?.session_id !== row.session_id || previous.message_index !== row.message_index - 1) {
+      groups.push([row]);
+    } else {
+      last.push(row);
+    }
+  }
+  return groups.filter((group) => group.length > 1);
+}
+
+function buildMergedPayload(group: MessageRow[]): Record<string, unknown> {
+  const first = parsePayload(group[0].payload);
+  const text = group.map((row) => getSessionHistoryChunkText(parsePayload(row.payload))).join("");
+  return {
+    ...first,
+    update: {
+      ...(typeof first.update === "object" && first.update ? first.update : {}),
+      sessionUpdate: "agent_message",
+      content: { type: "text", text },
+      mergedFrom: group.length,
+    },
+  };
+}
+
+export function runSessionHistoryMaintenance(options: Options): MaintenanceSummary {
+  if (!fs.existsSync(options.dbPath)) {
+    throw new Error(`SQLite database not found: ${options.dbPath}`);
+  }
+
+  const sqlite = new BetterSqlite3(options.dbPath);
+  try {
+    sqlite.pragma("foreign_keys = ON");
+    const now = Date.now();
+    const cutoff = now - options.sessionCutoffDays * 24 * 60 * 60 * 1000;
+    const sessions = sqlite
+      .prepare("SELECT id, message_history, updated_at, lease_expires_at FROM acp_sessions")
+      .all() as SessionRow[];
+    const activeSessionIds = new Set(
+      sessions
+        .filter((session) => isActiveSession(session, options, now))
+        .map((session) => session.id),
+    );
+
+    const summary: MaintenanceSummary = {
+      mode: options.mode,
+      dbPath: options.dbPath,
+      protectedActiveSessions: [...activeSessionIds].sort(),
+      sessionMessages: {
+        candidateSessions: 0,
+        mergedGroups: 0,
+        mergedChunks: 0,
+        deletedRows: 0,
+      },
+      acpSessions: {
+        candidateSessions: 0,
+        compactedSessions: 0,
+        originalMessages: 0,
+        compactedMessages: 0,
+        mergedChunks: 0,
+      },
+      sqlite: {
+        checkpoint: options.checkpoint ? (options.mode === "apply" ? "applied" : "planned") : "skipped",
+        vacuum: options.vacuum ? (options.mode === "apply" ? "applied" : "planned") : "skipped",
+      },
+    };
+
+    const messageRows = sqlite
+      .prepare(`
+        SELECT id, session_id, message_index, payload
+        FROM session_messages
+        WHERE event_type = 'agent_message_chunk'
+          AND created_at < ?
+        ORDER BY session_id, message_index
+      `)
+      .all(cutoff) as MessageRow[];
+    const inactiveMessageRows = messageRows.filter((row) => !activeSessionIds.has(row.session_id));
+    const groups = groupConsecutiveChunks(inactiveMessageRows);
+    summary.sessionMessages.candidateSessions = new Set(groups.map((group) => group[0].session_id)).size;
+    summary.sessionMessages.mergedGroups = groups.length;
+    summary.sessionMessages.mergedChunks = groups.reduce((total, group) => total + group.length, 0);
+    summary.sessionMessages.deletedRows = groups.reduce((total, group) => total + group.length - 1, 0);
+
+    const applyMessageGroups = sqlite.transaction((chunkGroups: MessageRow[][]) => {
+      const update = sqlite.prepare("UPDATE session_messages SET event_type = ?, payload = ? WHERE id = ?");
+      const remove = sqlite.prepare("DELETE FROM session_messages WHERE id = ?");
+      for (const group of chunkGroups) {
+        update.run("agent_message", JSON.stringify(buildMergedPayload(group)), group[0].id);
+        for (const row of group.slice(1)) {
+          remove.run(row.id);
+        }
+      }
+    });
+
+    const applySessionJson = sqlite.transaction((updates: Array<{ id: string; history: SessionHistoryNotification[] }>) => {
+      const update = sqlite.prepare("UPDATE acp_sessions SET message_history = ? WHERE id = ?");
+      for (const item of updates) {
+        update.run(JSON.stringify(item.history), item.id);
+      }
+    });
+
+    const sessionJsonUpdates: Array<{ id: string; history: SessionHistoryNotification[] }> = [];
+    for (const session of sessions) {
+      if (activeSessionIds.has(session.id)) {
+        continue;
+      }
+      if (typeof session.updated_at === "number" && session.updated_at >= cutoff) {
+        continue;
+      }
+
+      const history = parseJsonArray(session.message_history);
+      if (history.length === 0) {
+        continue;
+      }
+
+      summary.acpSessions.candidateSessions++;
+      summary.acpSessions.originalMessages += history.length;
+      const compacted = compactSessionHistoryNotifications(history);
+      summary.acpSessions.compactedMessages += compacted.compactedCount;
+      summary.acpSessions.mergedChunks += compacted.mergedChunks;
+
+      if (compacted.compactedCount !== compacted.originalCount) {
+        summary.acpSessions.compactedSessions++;
+        sessionJsonUpdates.push({ id: session.id, history: compacted.history });
+      }
+    }
+
+    if (options.mode === "apply") {
+      applyMessageGroups(groups);
+      applySessionJson(sessionJsonUpdates);
+      if (options.checkpoint) {
+        sqlite.pragma("wal_checkpoint(TRUNCATE)");
+      }
+      if (options.vacuum) {
+        sqlite.exec("VACUUM");
+      }
+    }
+
+    return summary;
+  } finally {
+    sqlite.close();
+  }
+}
+
+function printSummary(summary: MaintenanceSummary): void {
+  console.log(`Session history maintenance (${summary.mode})`);
+  console.log(`Database: ${summary.dbPath}`);
+  console.log(`Protected active sessions: ${summary.protectedActiveSessions.length}`);
+  console.log(
+    `session_messages: ${summary.sessionMessages.mergedGroups} groups, ` +
+    `${summary.sessionMessages.mergedChunks} chunks, ${summary.sessionMessages.deletedRows} rows removable`,
+  );
+  console.log(
+    `acp_sessions.message_history: ${summary.acpSessions.compactedSessions}/` +
+    `${summary.acpSessions.candidateSessions} sessions compactable, ` +
+    `${summary.acpSessions.originalMessages} -> ${summary.acpSessions.compactedMessages} messages`,
+  );
+  console.log(`SQLite checkpoint: ${summary.sqlite.checkpoint}`);
+  console.log(`SQLite vacuum: ${summary.sqlite.vacuum}`);
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+  try {
+    const options = parseOptions(argv);
+    const summary = runSessionHistoryMaintenance(options);
+    if (options.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      printSummary(summary);
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main();
+}

--- a/scripts/maintenance/compact-session-history.ts
+++ b/scripts/maintenance/compact-session-history.ts
@@ -18,7 +18,6 @@ if (!runtimeHistoryCompactorModule?.compactSessionHistoryNotifications) {
 
 const {
   compactSessionHistoryNotifications,
-  getSessionHistoryChunkText,
 } = runtimeHistoryCompactorModule;
 
 type Mode = "dry-run" | "apply";
@@ -181,17 +180,15 @@ function groupConsecutiveChunks(rows: MessageRow[]): MessageRow[][] {
 }
 
 function buildMergedPayload(group: MessageRow[]): Record<string, unknown> {
-  const first = parsePayload(group[0].payload);
-  const text = group.map((row) => getSessionHistoryChunkText(parsePayload(row.payload))).join("");
-  return {
-    ...first,
-    update: {
-      ...(typeof first.update === "object" && first.update ? first.update : {}),
-      sessionUpdate: "agent_message",
-      content: { type: "text", text },
-      mergedFrom: group.length,
-    },
-  };
+  const compacted = compactSessionHistoryNotifications(group.map((row) => ({
+    ...(parsePayload(row.payload) as SessionHistoryNotification),
+    sessionId: row.session_id,
+  })));
+  const merged = compacted.history[0];
+  if (!merged || compacted.compactedCount !== 1) {
+    throw new Error(`Unexpected chunk compaction result for session ${group[0].session_id}`);
+  }
+  return merged as Record<string, unknown>;
 }
 
 export function runSessionHistoryMaintenance(options: Options): MaintenanceSummary {

--- a/scripts/maintenance/compact-session-history.ts
+++ b/scripts/maintenance/compact-session-history.ts
@@ -47,6 +47,11 @@ interface MessageRow {
   payload: string | Record<string, unknown>;
 }
 
+interface PlannedMessageGroup {
+  group: MessageRow[];
+  mergedPayload: Record<string, unknown>;
+}
+
 interface MaintenanceSummary {
   mode: Mode;
   dbPath: string;
@@ -179,14 +184,14 @@ function groupConsecutiveChunks(rows: MessageRow[]): MessageRow[][] {
   return groups.filter((group) => group.length > 1);
 }
 
-function buildMergedPayload(group: MessageRow[]): Record<string, unknown> {
+function buildMergedPayload(group: MessageRow[]): Record<string, unknown> | null {
   const compacted = compactSessionHistoryNotifications(group.map((row) => ({
     ...(parsePayload(row.payload) as SessionHistoryNotification),
     sessionId: row.session_id,
   })));
   const merged = compacted.history[0];
   if (!merged || compacted.compactedCount !== 1) {
-    throw new Error(`Unexpected chunk compaction result for session ${group[0].session_id}`);
+    return null;
   }
   return merged as Record<string, unknown>;
 }
@@ -244,17 +249,25 @@ export function runSessionHistoryMaintenance(options: Options): MaintenanceSumma
       .all(cutoff) as MessageRow[];
     const inactiveMessageRows = messageRows.filter((row) => !activeSessionIds.has(row.session_id));
     const groups = groupConsecutiveChunks(inactiveMessageRows);
-    summary.sessionMessages.candidateSessions = new Set(groups.map((group) => group[0].session_id)).size;
-    summary.sessionMessages.mergedGroups = groups.length;
-    summary.sessionMessages.mergedChunks = groups.reduce((total, group) => total + group.length, 0);
-    summary.sessionMessages.deletedRows = groups.reduce((total, group) => total + group.length - 1, 0);
+    const plannedMessageGroups: PlannedMessageGroup[] = [];
+    for (const group of groups) {
+      const mergedPayload = buildMergedPayload(group);
+      if (!mergedPayload) {
+        continue;
+      }
+      plannedMessageGroups.push({ group, mergedPayload });
+    }
+    summary.sessionMessages.candidateSessions = new Set(plannedMessageGroups.map((item) => item.group[0].session_id)).size;
+    summary.sessionMessages.mergedGroups = plannedMessageGroups.length;
+    summary.sessionMessages.mergedChunks = plannedMessageGroups.reduce((total, item) => total + item.group.length, 0);
+    summary.sessionMessages.deletedRows = plannedMessageGroups.reduce((total, item) => total + item.group.length - 1, 0);
 
-    const applyMessageGroups = sqlite.transaction((chunkGroups: MessageRow[][]) => {
+    const applyMessageGroups = sqlite.transaction((chunkGroups: PlannedMessageGroup[]) => {
       const update = sqlite.prepare("UPDATE session_messages SET event_type = ?, payload = ? WHERE id = ?");
       const remove = sqlite.prepare("DELETE FROM session_messages WHERE id = ?");
-      for (const group of chunkGroups) {
-        update.run("agent_message", JSON.stringify(buildMergedPayload(group)), group[0].id);
-        for (const row of group.slice(1)) {
+      for (const item of chunkGroups) {
+        update.run("agent_message", JSON.stringify(item.mergedPayload), item.group[0].id);
+        for (const row of item.group.slice(1)) {
           remove.run(row.id);
         }
       }
@@ -294,7 +307,7 @@ export function runSessionHistoryMaintenance(options: Options): MaintenanceSumma
     }
 
     if (options.mode === "apply") {
-      applyMessageGroups(groups);
+      applyMessageGroups(plannedMessageGroups);
       applySessionJson(sessionJsonUpdates);
       if (options.checkpoint) {
         sqlite.pragma("wal_checkpoint(TRUNCATE)");

--- a/src/core/storage/__tests__/history-compactor.test.ts
+++ b/src/core/storage/__tests__/history-compactor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { HistoryCompactor } from "../history-compactor";
+import {
+  compactSessionHistoryNotifications,
+  getSessionHistoryChunkText,
+  HistoryCompactor,
+} from "../history-compactor";
 
 describe("HistoryCompactor", () => {
   it("should be constructable with a database instance", () => {
@@ -12,5 +16,43 @@ describe("HistoryCompactor", () => {
     const mockDb = {} as any;
     const compactor = new HistoryCompactor(mockDb);
     expect(typeof compactor.compact).toBe("function");
+  });
+
+  it("extracts text from ACP chunk payloads", () => {
+    expect(getSessionHistoryChunkText({
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "hello" },
+      },
+    })).toBe("hello");
+  });
+
+  it("merges consecutive agent message chunks and preserves non-chunk events", () => {
+    const compacted = compactSessionHistoryNotifications([
+      { sessionId: "s1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } } },
+      { sessionId: "s1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "lo" } } },
+      { sessionId: "s1", update: { sessionUpdate: "tool_call", name: "read_file" } },
+      { sessionId: "s1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Done" } } },
+    ]);
+
+    expect(compacted.originalCount).toBe(4);
+    expect(compacted.compactedCount).toBe(3);
+    expect(compacted.mergedChunks).toBe(2);
+    expect(compacted.history[0].update?.sessionUpdate).toBe("agent_message");
+    expect(compacted.history[0].update?.content?.text).toBe("Hello");
+    expect(compacted.history[1].update?.sessionUpdate).toBe("tool_call");
+    expect(compacted.history[2].update?.sessionUpdate).toBe("agent_message_chunk");
+  });
+
+  it("normalizes legacy chunk markers when merging legacy payloads", () => {
+    const compacted = compactSessionHistoryNotifications([
+      { type: "agent_message_chunk", text: "Hel" },
+      { type: "agent_message_chunk", text: "lo" },
+    ]);
+
+    expect(compacted.compactedCount).toBe(1);
+    expect(compacted.history[0].type).toBe("agent_message");
+    expect(compacted.history[0].text).toBe("Hello");
+    expect(compactSessionHistoryNotifications(compacted.history).compactedCount).toBe(1);
   });
 });

--- a/src/core/storage/history-compactor.ts
+++ b/src/core/storage/history-compactor.ts
@@ -17,6 +17,148 @@ export interface CompactResult {
   deletedTraces: number;
 }
 
+export type SessionHistoryNotification = {
+  sessionId?: string;
+  update?: {
+    sessionUpdate?: string;
+    content?: {
+      type?: string;
+      text?: string;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export interface SessionHistoryCompactionResult {
+  history: SessionHistoryNotification[];
+  originalCount: number;
+  compactedCount: number;
+  mergedChunks: number;
+  mergedGroups: number;
+}
+
+export function getSessionHistoryChunkText(value: unknown): string {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+
+  const notification = value as SessionHistoryNotification & {
+    text?: unknown;
+    content?: unknown;
+  };
+  const directText = typeof notification.text === "string" ? notification.text : "";
+  if (directText) {
+    return directText;
+  }
+
+  if (typeof notification.content === "string") {
+    return notification.content;
+  }
+
+  const updateContent = notification.update?.content;
+  return typeof updateContent?.text === "string" ? updateContent.text : "";
+}
+
+export function isSessionHistoryChunk(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const notification = value as SessionHistoryNotification & {
+    type?: unknown;
+    eventType?: unknown;
+  };
+  return notification.update?.sessionUpdate === "agent_message_chunk"
+    || notification.type === "agent_message_chunk"
+    || notification.eventType === "agent_message_chunk";
+}
+
+export function compactSessionHistoryNotifications(
+  history: SessionHistoryNotification[],
+): SessionHistoryCompactionResult {
+  const compacted: SessionHistoryNotification[] = [];
+  let currentChunks: SessionHistoryNotification[] = [];
+  let currentSessionId: string | undefined;
+  let mergedChunks = 0;
+  let mergedGroups = 0;
+
+  const flushChunks = () => {
+    if (currentChunks.length === 0) {
+      return;
+    }
+
+    if (currentChunks.length === 1) {
+      compacted.push(currentChunks[0]);
+      currentChunks = [];
+      return;
+    }
+
+    const first = currentChunks[0];
+    const firstRecord = first as SessionHistoryNotification & {
+      content?: unknown;
+      eventType?: unknown;
+      text?: unknown;
+      type?: unknown;
+    };
+    const text = currentChunks.map(getSessionHistoryChunkText).join("");
+    const merged: SessionHistoryNotification = {
+      ...first,
+      sessionId: currentSessionId ?? first.sessionId,
+      update: {
+        ...(first.update ?? {}),
+        sessionUpdate: "agent_message",
+        content: {
+          type: "text",
+          text,
+        },
+        mergedFrom: currentChunks.length,
+      },
+    };
+    if (firstRecord.type === "agent_message_chunk") {
+      merged.type = "agent_message";
+    }
+    if (firstRecord.eventType === "agent_message_chunk") {
+      merged.eventType = "agent_message";
+    }
+    if (typeof firstRecord.text === "string") {
+      merged.text = text;
+    }
+    if (typeof firstRecord.content === "string") {
+      merged.content = text;
+    }
+    compacted.push(merged);
+    mergedChunks += currentChunks.length;
+    mergedGroups++;
+    currentChunks = [];
+  };
+
+  for (const notification of history) {
+    if (isSessionHistoryChunk(notification)) {
+      if (currentSessionId !== notification.sessionId) {
+        flushChunks();
+        currentSessionId = notification.sessionId;
+      }
+      currentChunks.push(notification);
+      continue;
+    }
+
+    flushChunks();
+    currentSessionId = notification.sessionId;
+    compacted.push(notification);
+  }
+
+  flushChunks();
+
+  return {
+    history: compacted,
+    originalCount: history.length,
+    compactedCount: compacted.length,
+    mergedChunks,
+    mergedGroups,
+  };
+}
+
 export class HistoryCompactor {
   constructor(private db: Database) {}
 
@@ -96,20 +238,19 @@ export class HistoryCompactor {
       for (const group of groups) {
         if (group.length < 2) continue;
 
-        // Merge payloads: concatenate text content from chunks
-        const mergedContent = group
-          .map((c) => {
-            const p = c.payload as Record<string, unknown>;
-            return (p.text as string) ?? (p.content as string) ?? "";
-          })
-          .join("");
+        const mergedContent = group.map((c) => getSessionHistoryChunkText(c.payload)).join("");
 
         const first = group[0];
-        const mergedPayload = {
+        const mergedPayload = compactSessionHistoryNotifications([
+          first.payload as SessionHistoryNotification,
+          ...group.slice(1).map((chunk) => chunk.payload as SessionHistoryNotification),
+        ]).history[0] ?? {
           ...(first.payload as Record<string, unknown>),
-          type: "agent_message",
-          text: mergedContent,
-          merged_from: group.length,
+          update: {
+            sessionUpdate: "agent_message",
+            content: { type: "text", text: mergedContent },
+            mergedFrom: group.length,
+          },
         };
 
         // Update first chunk to be the merged message

--- a/src/core/storage/history-compactor.ts
+++ b/src/core/storage/history-compactor.ts
@@ -238,20 +238,15 @@ export class HistoryCompactor {
       for (const group of groups) {
         if (group.length < 2) continue;
 
-        const mergedContent = group.map((c) => getSessionHistoryChunkText(c.payload)).join("");
-
         const first = group[0];
-        const mergedPayload = compactSessionHistoryNotifications([
-          first.payload as SessionHistoryNotification,
-          ...group.slice(1).map((chunk) => chunk.payload as SessionHistoryNotification),
-        ]).history[0] ?? {
-          ...(first.payload as Record<string, unknown>),
-          update: {
-            sessionUpdate: "agent_message",
-            content: { type: "text", text: mergedContent },
-            mergedFrom: group.length,
-          },
-        };
+        const compactedGroup = compactSessionHistoryNotifications(group.map((chunk) => ({
+          ...(chunk.payload as SessionHistoryNotification),
+          sessionId: chunk.sessionId,
+        })));
+        const mergedPayload = compactedGroup.history[0];
+        if (!mergedPayload || compactedGroup.compactedCount !== 1) {
+          continue;
+        }
 
         // Update first chunk to be the merged message
         await this.db


### PR DESCRIPTION
## Summary

- Add a SQLite maintenance command for compacting Routa ACP session history in local dev/runtime databases.
- Reuse and harden session history chunk compaction so ACP payloads using `update.content.text` compact correctly.
- Protect active sessions by lease, recent update window, or explicit `--active-session` during maintenance.
- Document safe dry-run/apply/checkpoint/vacuum usage for local SQLite operation.

## Scope

This PR is intentionally limited to local SQLite session-history maintenance. It does not implement metadata protection, retention policy scheduling, Postgres migration, workflow gates, or QuantDinger-specific behavior.

## Validation

Passed:

- `npm test -- --run src/core/storage/__tests__/history-compactor.test.ts scripts/__tests__/compact-session-history.test.ts`
- `node --import tsx -e import('./scripts/maintenance/compact-session-history.ts').then(m=>console.log(Object.keys(m)))`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/core/storage/history-compactor.ts src/core/storage/__tests__/history-compactor.test.ts scripts/maintenance/compact-session-history.ts scripts/__tests__/compact-session-history.test.ts`
- `git diff --check`
- `cargo fmt --check`
- `npm run test:run:fast`
- `cargo build -p entrix`
- `./target/debug/entrix.exe run --dry-run`

Local integration validation with PR1+PR2+PR3 stacked:

- `npm test -- --run src/core/kanban/__tests__/agent-trigger.test.ts src/core/kanban/__tests__/completion-fallback-artifact.test.ts src/core/mcp/__tests__/mcp-tool-executor.test.ts src/core/mcp/__tests__/mcp-tool-manager.test.ts src/core/storage/__tests__/history-compactor.test.ts scripts/__tests__/compact-session-history.test.ts`
- `npx tsc --noEmit --pretty false`
- `cargo test -p routa-server --test rust_api_mcp_routes api_mcp_kanban_profile_filters_tools_list -- --nocapture`
- `npm run db:sqlite:compact-sessions -- --db C:\Project\Routa\routa.db --dry-run --json`
- `GET http://127.0.0.1:3890/api/health` -> 200
- `GET http://127.0.0.1:3890/workspace/quantdinger/kanban` -> 200

Attempted but not clean in this Windows worktree:

- `./target/debug/entrix.exe run --tier fast`

Observed failures appear unrelated to this PR scope: Windows/path checker errors, npm mirror audit endpoint not implemented, existing desktop clippy dead-code in `apps/desktop/src-tauri/src/tray.rs`, and whole-repo lint issues outside the touched files. Targeted tests/lint/typecheck for this PR pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI maintenance tool to compact local SQLite session history with dry-run and apply modes, JSON or human output, optional checkpoint and VACUUM, and protections for recent/active sessions and unexpired leases.
  * Merges consecutive chunked agent messages into single messages and rewrites storage to reduce space.

* **Documentation**
  * Added Chinese operational guide describing maintenance steps, modes, protections, and recommendations.

* **Tests**
  * Added tests covering compaction, merging, protections, and dry-run vs apply behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->