### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,16 @@ ANTHROPIC_AUTH_TOKEN=your-token-here
 # ANTHROPIC_DEFAULT_OPUS_MODEL=GLM-4.7
 # ANTHROPIC_DEFAULT_HAIKU_MODEL=GLM-4.7
 
+# MiniMax Configuration (Anthropic-compatible API)
+# Required when using the minimax workspace agent provider
+# MINIMAX_API_KEY=your-minimax-api-key
+# Optional: Custom base URL (default: https://api.minimax.io/anthropic — overseas)
+# For mainland China use https://api.minimaxi.com/anthropic
+# MINIMAX_BASE_URL=https://api.minimax.io/anthropic
+# To select MiniMax as the workspace agent backend:
+# WORKSPACE_AGENT_PROVIDER=minimax
+# WORKSPACE_AGENT_MODEL=MiniMax-M2.7
+
 # Development Configuration
 # Optional: Additional allowed dev origins for Next.js (comma-separated)
 # Useful when accessing the dev server from other devices on your network

--- a/src/client/components/settings-panel-shared.ts
+++ b/src/client/components/settings-panel-shared.ts
@@ -178,6 +178,7 @@ export const settingsCardCls = "rounded-xl border border-gray-200 bg-white p-4 d
 
 export const BASE_URL_SUGGESTIONS = [
   "https://open.bigmodel.cn/api/anthropic",
+  "https://api.minimax.io/anthropic",
   "https://api.minimaxi.com/anthropic",
   "https://api.deepseek.com/anthropic",
   "https://api.moonshot.ai/anthropic",

--- a/src/core/acp/__tests__/workspace-agent.test.ts
+++ b/src/core/acp/__tests__/workspace-agent.test.ts
@@ -121,6 +121,32 @@ describe("resolveWorkspaceAgentConfig", () => {
       else process.env.WORKSPACE_AGENT_PROVIDER = originalProvider;
     }
   });
+
+  it("accepts minimax as a workspace agent provider", () => {
+    const config = resolveWorkspaceAgentConfig({
+      provider: "minimax",
+      modelId: "MiniMax-M2.7",
+    });
+    expect(config.provider).toBe("minimax");
+    expect(config.modelId).toBe("MiniMax-M2.7");
+  });
+
+  it("reads minimax provider from environment", () => {
+    const originalProvider = process.env.WORKSPACE_AGENT_PROVIDER;
+    const originalModel = process.env.WORKSPACE_AGENT_MODEL;
+    try {
+      process.env.WORKSPACE_AGENT_PROVIDER = "minimax";
+      process.env.WORKSPACE_AGENT_MODEL = "MiniMax-M2.7-highspeed";
+      const config = resolveWorkspaceAgentConfig();
+      expect(config.provider).toBe("minimax");
+      expect(config.modelId).toBe("MiniMax-M2.7-highspeed");
+    } finally {
+      if (originalProvider === undefined) delete process.env.WORKSPACE_AGENT_PROVIDER;
+      else process.env.WORKSPACE_AGENT_PROVIDER = originalProvider;
+      if (originalModel === undefined) delete process.env.WORKSPACE_AGENT_MODEL;
+      else process.env.WORKSPACE_AGENT_MODEL = originalModel;
+    }
+  });
 });
 
 // ─── Provider Adapter Integration ────────────────────────────────────────────

--- a/src/core/acp/api-based-providers.ts
+++ b/src/core/acp/api-based-providers.ts
@@ -84,6 +84,15 @@ export const API_BASED_PROVIDERS: ApiBasedProvider[] = [
     envKeyName: 'DEEPSEEK_API_KEY',
     status: 'requires_config',
   },
+  {
+    id: 'minimax-api',
+    name: 'MiniMax API',
+    description: 'MiniMax models via Anthropic-compatible API',
+    apiEndpoint: 'https://api.minimax.io/anthropic',
+    requiresApiKey: true,
+    envKeyName: 'MINIMAX_API_KEY',
+    status: 'requires_config',
+  },
 ];
 
 /**
@@ -141,6 +150,7 @@ To configure providers, add environment variables:
 - ANTHROPIC_API_KEY=sk-ant-...
 - GOOGLE_API_KEY=...
 - DEEPSEEK_API_KEY=sk-...
+- MINIMAX_API_KEY=... (for MiniMax)
 `.trim();
 }
 

--- a/src/core/acp/workspace-agent/workspace-agent-adapter.ts
+++ b/src/core/acp/workspace-agent/workspace-agent-adapter.ts
@@ -83,6 +83,10 @@ export class WorkspaceAgentAdapter {
       if (!process.env.OPENAI_API_KEY) {
         throw new Error("Workspace agent (openai) requires OPENAI_API_KEY");
       }
+    } else if (this.config.provider === "minimax") {
+      if (!process.env.MINIMAX_API_KEY) {
+        throw new Error("Workspace agent (minimax) requires MINIMAX_API_KEY");
+      }
     }
     this._alive = true;
     console.log(

--- a/src/core/acp/workspace-agent/workspace-agent-config.ts
+++ b/src/core/acp/workspace-agent/workspace-agent-config.ts
@@ -7,7 +7,7 @@
 
 import type { LanguageModel } from "ai";
 
-export type WorkspaceAgentProvider = "anthropic" | "openai" | "zhipu";
+export type WorkspaceAgentProvider = "anthropic" | "openai" | "zhipu" | "minimax";
 
 export interface WorkspaceAgentConfig {
   /** Model identifier, e.g. "claude-sonnet-4-20250514" or "gpt-4o" */
@@ -37,7 +37,7 @@ const DEFAULTS: WorkspaceAgentConfig = {
  * Resolve configuration from environment variables, merged with explicit overrides.
  *
  * Environment variables:
- *   WORKSPACE_AGENT_PROVIDER  — "anthropic" | "openai"
+ *   WORKSPACE_AGENT_PROVIDER  — "anthropic" | "openai" | "zhipu" | "minimax"
  *   WORKSPACE_AGENT_MODEL     — model identifier
  *   WORKSPACE_AGENT_MAX_STEPS — max agentic loop steps
  */
@@ -91,6 +91,20 @@ export async function createLanguageModel(config: WorkspaceAgentConfig): Promise
       const provider = createZhipu({
         apiKey: process.env.ZHIPU_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN,
         ...(process.env.ZHIPU_BASE_URL && { baseURL: process.env.ZHIPU_BASE_URL }),
+      });
+      return provider(config.modelId);
+    }
+    case "minimax": {
+      const { createAnthropic } = await import("@ai-sdk/anthropic");
+      // MiniMax uses Anthropic-compatible API. Default base URL is the overseas endpoint.
+      // @ai-sdk/anthropic appends /messages to baseURL, so the configured URL must end with /v1.
+      let baseURL = process.env.MINIMAX_BASE_URL ?? "https://api.minimax.io/anthropic";
+      if (!baseURL.endsWith("/v1")) {
+        baseURL = `${baseURL.replace(/\/+$/, "")}/v1`;
+      }
+      const provider = createAnthropic({
+        apiKey: process.env.MINIMAX_API_KEY,
+        baseURL,
       });
       return provider(config.modelId);
     }


### PR DESCRIPTION
## Summary
Add MiniMax as a new workspace agent provider, reusing the existing
`@ai-sdk/anthropic` plumbing since MiniMax exposes an Anthropic-compatible API.

## Changes
- `workspace-agent-config.ts`: extend `WorkspaceAgentProvider` union with `"minimax"` and add a switch case that wires `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` into `createAnthropic`. Default base URL is `https://api.minimax.io/anthropic` (overseas), with the `/v1` suffix appended automatically so `@ai-sdk/anthropic` resolves to `/v1/messages` — matching how `ANTHROPIC_BASE_URL` is already handled for other Anthropic-compatible endpoints.
- `workspace-agent-adapter.ts`: validate `MINIMAX_API_KEY` in `connect()` mirroring the existing checks for `anthropic` / `openai`.
- `api-based-providers.ts`: register MiniMax in `API_BASED_PROVIDERS` so the providers UI/API surfaces it alongside Anthropic, OpenAI, DeepSeek, etc.
- `settings-panel-shared.ts`: add `https://api.minimax.io/anthropic` to `BASE_URL_SUGGESTIONS` (the China endpoint `api.minimaxi.com/anthropic` was already present).
- `.env.example`: document `MINIMAX_API_KEY`, `MINIMAX_BASE_URL` and `WORKSPACE_AGENT_PROVIDER=minimax` usage.
- `workspace-agent.test.ts`: add coverage for minimax resolution from explicit overrides and from environment variables.

## How To Use
```bash
export MINIMAX_API_KEY=...                              # required
export MINIMAX_BASE_URL=https://api.minimax.io/anthropic # optional, defaults to overseas endpoint
export WORKSPACE_AGENT_PROVIDER=minimax
export WORKSPACE_AGENT_MODEL=MiniMax-M2.7               # or MiniMax-M2.7-highspeed
```

## Testing
- `npx vitest run src/core/acp/__tests__/workspace-agent.test.ts` — 29 tests pass (including 2 new minimax cases).
- `npx tsc --noEmit -p tsconfig.json` — clean for the modified files.
- `npx eslint` on changed files — clean.
- End-to-end: invoked `createAnthropic({ apiKey, baseURL: "https://api.minimax.io/anthropic/v1" })` against `MiniMax-M2.7` and received a valid completion, confirming the wiring matches the existing `WorkspaceAgentAdapter` flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added MiniMax as a new supported workspace agent provider, enabling integration with MiniMax's Anthropic-compatible API endpoints
* Added environment configuration options for MiniMax API key and base URL setup to customize API connectivity
* Implemented automatic validation of MiniMax API credentials during workspace agent connection to ensure proper configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/routa/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->