### PR TITLE
feat: add hello world canvas

### DIFF
--- a/hello-world.canvas.tsx
+++ b/hello-world.canvas.tsx
@@ -1,0 +1,30 @@
+export default function Canvas() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 32,
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <section
+        style={{
+          border: "1px solid currentColor",
+          borderRadius: 12,
+          padding: "32px 40px",
+          textAlign: "center",
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: 24, lineHeight: 1.2 }}>
+          Hello World
+        </h1>
+        <p style={{ margin: "12px 0 0", fontSize: 14 }}>
+          This is a Routa Canvas.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- What changed: Added a minimal `hello-world.canvas.tsx` Routa Canvas source file.
- Why: Provides the requested Hello World canvas artifact.

## Validation

- [x] `entrix run --dry-run` attempted; blocked because `entrix` is not installed in PATH.
- [x] `cargo build -p entrix` attempted; blocked by local Cargo 1.83.0 not supporting a resolved dependency's `edition2024` manifest requirement.
- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] UI screenshots or recording attached when applicable

## Notes

- Related issue: N/A
- Risks or follow-up work: None expected for this standalone canvas file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6cfc5e-9cb7-4ab7-a47a-27e6612da118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6cfc5e-9cb7-4ab7-a47a-27e6612da118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

