### PR TITLE
fix(desktop): macOS system proxy support and missing native dependency

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ routa-server = { path = "../../../crates/routa-server" }
 
 # Async runtime (needed for Tauri integration)
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "socks"] }
 
 [dev-dependencies]
 axum = "0.8.8"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,9 @@ use tokio::sync::RwLock;
 mod pty;
 pub use pty::{pty_create, pty_kill, pty_list, pty_read, pty_resize, pty_write, PtyState};
 
+mod system_proxy;
+use system_proxy::build_http_client;
+
 // System tray module
 mod tray;
 pub use tray::GitHubRepo;
@@ -159,84 +162,6 @@ impl AcpState {
 
 const ACP_REGISTRY_URL: &str =
     "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
-
-/// Build a reqwest client that respects macOS system proxy settings.
-///
-/// reqwest's default proxy detection only reads `HTTP_PROXY`/`HTTPS_PROXY`
-/// environment variables. On macOS, proxy software like Surge, ClashX, or
-/// V2Ray configure the system proxy via `networksetup` (System Preferences),
-/// which reqwest ignores. This function reads the macOS system proxy via
-/// `scutil --proxy` and applies it to the client.
-fn build_http_client() -> Result<reqwest::Client, String> {
-    let mut builder = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(15));
-
-    #[cfg(target_os = "macos")]
-    {
-        if let Some(proxy_url) = read_macos_system_proxy() {
-            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-                builder = builder.proxy(proxy);
-            }
-        }
-    }
-
-    builder.build().map_err(|e| format!("Failed to build HTTP client: {e}"))
-}
-
-/// Read the macOS system HTTPS proxy via `scutil --proxy`.
-/// Returns `http://host:port` if an HTTPS proxy is enabled, `None` otherwise.
-#[cfg(target_os = "macos")]
-fn read_macos_system_proxy() -> Option<String> {
-    let output = std::process::Command::new("scutil")
-        .arg("--proxy")
-        .output()
-        .ok()?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut enabled = false;
-    let mut host: Option<String> = None;
-    let mut port: Option<String> = None;
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if let Some(v) = line.strip_prefix("HTTPSEnable : ") {
-            enabled = v.trim() == "1";
-        } else if let Some(v) = line.strip_prefix("HTTPSProxy : ") {
-            host = Some(v.trim().to_string());
-        } else if let Some(v) = line.strip_prefix("HTTPSPort : ") {
-            port = Some(v.trim().to_string());
-        }
-    }
-
-    if enabled {
-        if let (Some(h), Some(p)) = (host, port) {
-            return Some(format!("http://{h}:{p}"));
-        }
-    }
-
-    // Fall back to HTTP proxy if HTTPS proxy is not configured
-    let mut http_enabled = false;
-    let mut http_host: Option<String> = None;
-    let mut http_port: Option<String> = None;
-    for line in stdout.lines() {
-        let line = line.trim();
-        if let Some(v) = line.strip_prefix("HTTPEnable : ") {
-            http_enabled = v.trim() == "1";
-        } else if let Some(v) = line.strip_prefix("HTTPProxy : ") {
-            http_host = Some(v.trim().to_string());
-        } else if let Some(v) = line.strip_prefix("HTTPPort : ") {
-            http_port = Some(v.trim().to_string());
-        }
-    }
-
-    if http_enabled {
-        if let (Some(h), Some(p)) = (http_host, http_port) {
-            return Some(format!("http://{h}:{p}"));
-        }
-    }
-
-    None
-}
 
 /// Fetch the ACP registry from the CDN.
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -160,6 +160,84 @@ impl AcpState {
 const ACP_REGISTRY_URL: &str =
     "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
 
+/// Build a reqwest client that respects macOS system proxy settings.
+///
+/// reqwest's default proxy detection only reads `HTTP_PROXY`/`HTTPS_PROXY`
+/// environment variables. On macOS, proxy software like Surge, ClashX, or
+/// V2Ray configure the system proxy via `networksetup` (System Preferences),
+/// which reqwest ignores. This function reads the macOS system proxy via
+/// `scutil --proxy` and applies it to the client.
+fn build_http_client() -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15));
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(proxy_url) = read_macos_system_proxy() {
+            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+                builder = builder.proxy(proxy);
+            }
+        }
+    }
+
+    builder.build().map_err(|e| format!("Failed to build HTTP client: {e}"))
+}
+
+/// Read the macOS system HTTPS proxy via `scutil --proxy`.
+/// Returns `http://host:port` if an HTTPS proxy is enabled, `None` otherwise.
+#[cfg(target_os = "macos")]
+fn read_macos_system_proxy() -> Option<String> {
+    let output = std::process::Command::new("scutil")
+        .arg("--proxy")
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut enabled = false;
+    let mut host: Option<String> = None;
+    let mut port: Option<String> = None;
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(v) = line.strip_prefix("HTTPSEnable : ") {
+            enabled = v.trim() == "1";
+        } else if let Some(v) = line.strip_prefix("HTTPSProxy : ") {
+            host = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("HTTPSPort : ") {
+            port = Some(v.trim().to_string());
+        }
+    }
+
+    if enabled {
+        if let (Some(h), Some(p)) = (host, port) {
+            return Some(format!("http://{h}:{p}"));
+        }
+    }
+
+    // Fall back to HTTP proxy if HTTPS proxy is not configured
+    let mut http_enabled = false;
+    let mut http_host: Option<String> = None;
+    let mut http_port: Option<String> = None;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(v) = line.strip_prefix("HTTPEnable : ") {
+            http_enabled = v.trim() == "1";
+        } else if let Some(v) = line.strip_prefix("HTTPProxy : ") {
+            http_host = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("HTTPPort : ") {
+            http_port = Some(v.trim().to_string());
+        }
+    }
+
+    if http_enabled {
+        if let (Some(h), Some(p)) = (http_host, http_port) {
+            return Some(format!("http://{h}:{p}"));
+        }
+    }
+
+    None
+}
+
 /// Fetch the ACP registry from the CDN.
 #[tauri::command]
 async fn fetch_acp_registry(state: State<'_, AcpState>) -> Result<AcpRegistry, String> {
@@ -171,8 +249,11 @@ async fn fetch_acp_registry(state: State<'_, AcpState>) -> Result<AcpRegistry, S
         }
     }
 
-    // Fetch from CDN
-    let response = reqwest::get(ACP_REGISTRY_URL)
+    // Fetch from CDN (with macOS system proxy support)
+    let client = build_http_client()?;
+    let response = client
+        .get(ACP_REGISTRY_URL)
+        .send()
         .await
         .map_err(|e| format!("Failed to fetch registry: {e}"))?;
 
@@ -215,8 +296,11 @@ async fn install_acp_agent(
     let registry = match registry {
         Some(r) => r,
         None => {
-            // Fetch if not cached
-            let response = reqwest::get(ACP_REGISTRY_URL)
+            // Fetch if not cached (with macOS system proxy support)
+            let client = build_http_client()?;
+            let response = client
+                .get(ACP_REGISTRY_URL)
+                .send()
                 .await
                 .map_err(|e| format!("Failed to fetch registry: {e}"))?;
             response

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -277,9 +277,10 @@ async fn install_acp_agent(
                 .get_binary_info(&platform)
                 .ok_or_else(|| format!("No binary available for platform: {platform}"))?;
 
+            let http_client = build_http_client()?;
             let exe_path = state
                 .binary_manager
-                .install_binary(&agent_id, &version, binary_info)
+                .install_binary_with_client(&http_client, &agent_id, &version, binary_info)
                 .await?;
 
             state

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ mod pty;
 pub use pty::{pty_create, pty_kill, pty_list, pty_read, pty_resize, pty_write, PtyState};
 
 mod system_proxy;
-use system_proxy::build_http_client;
+use system_proxy::{build_download_http_client, build_registry_http_client};
 
 // System tray module
 mod tray;
@@ -175,7 +175,7 @@ async fn fetch_acp_registry(state: State<'_, AcpState>) -> Result<AcpRegistry, S
     }
 
     // Fetch from CDN (with macOS system proxy support)
-    let client = build_http_client()?;
+    let client = build_registry_http_client()?;
     let response = client
         .get(ACP_REGISTRY_URL)
         .send()
@@ -222,7 +222,7 @@ async fn install_acp_agent(
         Some(r) => r,
         None => {
             // Fetch if not cached (with macOS system proxy support)
-            let client = build_http_client()?;
+            let client = build_registry_http_client()?;
             let response = client
                 .get(ACP_REGISTRY_URL)
                 .send()
@@ -277,7 +277,7 @@ async fn install_acp_agent(
                 .get_binary_info(&platform)
                 .ok_or_else(|| format!("No binary available for platform: {platform}"))?;
 
-            let http_client = build_http_client()?;
+            let http_client = build_download_http_client()?;
             let exe_path = state
                 .binary_manager
                 .install_binary_with_client(&http_client, &agent_id, &version, binary_info)

--- a/apps/desktop/src-tauri/src/system_proxy.rs
+++ b/apps/desktop/src-tauri/src/system_proxy.rs
@@ -1,19 +1,62 @@
 use std::time::Duration;
 
-/// Build an HTTP client that respects the macOS system proxy when configured.
-pub(crate) fn build_http_client() -> Result<reqwest::Client, String> {
-    let builder = reqwest::Client::builder().timeout(Duration::from_secs(15));
+#[cfg(any(target_os = "macos", test))]
+const PROXY_ENV_VARS: [&str; 6] = [
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+];
 
+/// Build an HTTP client for the small ACP registry response.
+pub(crate) fn build_registry_http_client() -> Result<reqwest::Client, String> {
+    build_http_client(reqwest::Client::builder().timeout(Duration::from_secs(15)))
+}
+
+/// Build an HTTP client for agent archives without imposing a total transfer deadline.
+pub(crate) fn build_download_http_client() -> Result<reqwest::Client, String> {
+    build_http_client(
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(15))
+            .read_timeout(Duration::from_secs(60)),
+    )
+}
+
+/// Apply the macOS system proxy only when an environment proxy is not configured.
+fn build_http_client(builder: reqwest::ClientBuilder) -> Result<reqwest::Client, String> {
     #[cfg(target_os = "macos")]
-    let builder =
-        match read_macos_system_proxy().and_then(|proxy_url| reqwest::Proxy::all(proxy_url).ok()) {
+    let builder = if environment_proxy_is_configured() {
+        builder
+    } else {
+        match read_macos_system_proxy().and_then(|proxy_url| {
+            reqwest::Proxy::all(proxy_url)
+                .ok()
+                .map(|proxy| proxy.no_proxy(reqwest::NoProxy::from_env()))
+        }) {
             Some(proxy) => builder.proxy(proxy),
             None => builder,
-        };
+        }
+    };
 
     builder
         .build()
         .map_err(|error| format!("Failed to build HTTP client: {error}"))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn environment_proxy_is_configured() -> bool {
+    environment_proxy_is_configured_with(|name| std::env::var_os(name))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn environment_proxy_is_configured_with(
+    mut read_env: impl FnMut(&str) -> Option<std::ffi::OsString>,
+) -> bool {
+    PROXY_ENV_VARS
+        .iter()
+        .any(|name| read_env(name).is_some_and(|value| !value.is_empty()))
 }
 
 #[derive(Default)]
@@ -87,7 +130,8 @@ fn read_macos_system_proxy() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_macos_system_proxy;
+    use super::{environment_proxy_is_configured_with, parse_macos_system_proxy};
+    use std::ffi::OsString;
 
     #[test]
     fn prefers_enabled_https_proxy() {
@@ -173,5 +217,19 @@ mod tests {
         let proxy_url = parse_macos_system_proxy(output).expect("parse SOCKS proxy");
         assert_eq!(proxy_url, "socks5h://127.0.0.1:1080");
         reqwest::Proxy::all(proxy_url).expect("SOCKS proxy feature is enabled");
+    }
+
+    #[test]
+    fn recognizes_uppercase_and_lowercase_environment_proxies() {
+        for configured_name in ["ALL_PROXY", "https_proxy", "HTTP_PROXY"] {
+            assert!(environment_proxy_is_configured_with(|name| {
+                (name == configured_name).then(|| OsString::from("http://proxy.local:8080"))
+            }));
+        }
+
+        assert!(!environment_proxy_is_configured_with(|_| None));
+        assert!(!environment_proxy_is_configured_with(|_| {
+            Some(OsString::new())
+        }));
     }
 }

--- a/apps/desktop/src-tauri/src/system_proxy.rs
+++ b/apps/desktop/src-tauri/src/system_proxy.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+/// Build an HTTP client that respects the macOS system proxy when configured.
+pub(crate) fn build_http_client() -> Result<reqwest::Client, String> {
+    let builder = reqwest::Client::builder().timeout(Duration::from_secs(15));
+
+    #[cfg(target_os = "macos")]
+    let builder =
+        match read_macos_system_proxy().and_then(|proxy_url| reqwest::Proxy::all(proxy_url).ok()) {
+            Some(proxy) => builder.proxy(proxy),
+            None => builder,
+        };
+
+    builder
+        .build()
+        .map_err(|error| format!("Failed to build HTTP client: {error}"))
+}
+
+#[derive(Default)]
+struct ProxySettings {
+    enabled: bool,
+    host: Option<String>,
+    port: Option<u16>,
+}
+
+impl ProxySettings {
+    fn url(&self) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+
+        let host = self.host.as_deref()?;
+        let port = self.port?;
+        let authority = if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]")
+        } else {
+            host.to_string()
+        };
+        Some(format!("http://{authority}:{port}"))
+    }
+}
+
+/// Parse the output of `scutil --proxy`, preferring HTTPS over HTTP settings.
+fn parse_macos_system_proxy(output: &str) -> Option<String> {
+    let mut https = ProxySettings::default();
+    let mut http = ProxySettings::default();
+
+    for line in output.lines() {
+        let Some((key, value)) = line.trim().split_once(" : ") else {
+            continue;
+        };
+        let value = value.trim();
+
+        match key.trim() {
+            "HTTPSEnable" => https.enabled = value == "1",
+            "HTTPSProxy" => https.host = Some(value.to_string()),
+            "HTTPSPort" => https.port = value.parse().ok(),
+            "HTTPEnable" => http.enabled = value == "1",
+            "HTTPProxy" => http.host = Some(value.to_string()),
+            "HTTPPort" => http.port = value.parse().ok(),
+            _ => {}
+        }
+    }
+
+    https.url().or_else(|| http.url())
+}
+
+#[cfg(target_os = "macos")]
+fn read_macos_system_proxy() -> Option<String> {
+    let output = std::process::Command::new("scutil")
+        .arg("--proxy")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_macos_system_proxy(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_macos_system_proxy;
+
+    #[test]
+    fn prefers_enabled_https_proxy() {
+        let output = r#"
+<dictionary> {
+  HTTPEnable : 1
+  HTTPPort : 8080
+  HTTPProxy : http-proxy.local
+  HTTPSEnable : 1
+  HTTPSPort : 6152
+  HTTPSProxy : 127.0.0.1
+}
+"#;
+
+        assert_eq!(
+            parse_macos_system_proxy(output),
+            Some("http://127.0.0.1:6152".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_enabled_http_proxy() {
+        let output = r#"
+<dictionary> {
+  HTTPEnable : 1
+  HTTPPort : 8080
+  HTTPProxy : proxy.local
+  HTTPSEnable : 0
+  HTTPSPort : 6152
+  HTTPSProxy : 127.0.0.1
+}
+"#;
+
+        assert_eq!(
+            parse_macos_system_proxy(output),
+            Some("http://proxy.local:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_disabled_or_incomplete_proxy_settings() {
+        let output = r#"
+<dictionary> {
+  HTTPEnable : 0
+  HTTPPort : 8080
+  HTTPProxy : proxy.local
+  HTTPSEnable : 1
+  HTTPSPort : invalid
+}
+"#;
+
+        assert_eq!(parse_macos_system_proxy(output), None);
+    }
+
+    #[test]
+    fn formats_ipv6_proxy_hosts() {
+        let output = r#"
+<dictionary> {
+  HTTPSEnable : 1
+  HTTPSPort : 6152
+  HTTPSProxy : ::1
+}
+"#;
+
+        assert_eq!(
+            parse_macos_system_proxy(output),
+            Some("http://[::1]:6152".to_string())
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/system_proxy.rs
+++ b/apps/desktop/src-tauri/src/system_proxy.rs
@@ -30,13 +30,14 @@ fn build_http_client(builder: reqwest::ClientBuilder) -> Result<reqwest::Client,
     let builder = if environment_proxy_is_configured() {
         builder
     } else {
-        match read_macos_system_proxy().and_then(|proxy_url| {
-            reqwest::Proxy::all(proxy_url)
-                .ok()
-                .map(|proxy| proxy.no_proxy(reqwest::NoProxy::from_env()))
-        }) {
-            Some(proxy) => builder.proxy(proxy),
-            None => builder,
+        match read_macos_system_proxy() {
+            Some(settings) if settings.has_proxy() => {
+                let no_proxy = settings.no_proxy();
+                let proxy = reqwest::Proxy::custom(move |url| settings.proxy_for_url(url))
+                    .no_proxy(no_proxy);
+                builder.proxy(proxy)
+            }
+            _ => builder,
         }
     };
 
@@ -59,6 +60,7 @@ fn environment_proxy_is_configured_with(
         .any(|name| read_env(name).is_some_and(|value| !value.is_empty()))
 }
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Default)]
 struct ProxySettings {
     enabled: bool,
@@ -66,6 +68,7 @@ struct ProxySettings {
     port: Option<u16>,
 }
 
+#[cfg(any(target_os = "macos", test))]
 impl ProxySettings {
     fn url(&self, scheme: &str) -> Option<String> {
         if !self.enabled {
@@ -83,19 +86,118 @@ impl ProxySettings {
     }
 }
 
-/// Parse `scutil --proxy`, preferring HTTPS, then HTTP, then SOCKS settings.
-fn parse_macos_system_proxy(output: &str) -> Option<String> {
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct MacosProxySettings {
+    http: Option<String>,
+    https: Option<String>,
+    socks: Option<String>,
+    exceptions: Vec<String>,
+    exclude_simple_hostnames: bool,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl MacosProxySettings {
+    fn has_proxy(&self) -> bool {
+        self.http.is_some() || self.https.is_some() || self.socks.is_some()
+    }
+
+    fn proxy_for_url(&self, url: &reqwest::Url) -> Option<String> {
+        if self.exclude_simple_hostnames
+            && url
+                .host_str()
+                .is_some_and(|host| !host.contains('.') && !host.contains(':'))
+        {
+            return None;
+        }
+
+        match url.scheme() {
+            "http" => self.http.clone().or_else(|| self.socks.clone()),
+            "https" => self.https.clone().or_else(|| self.socks.clone()),
+            _ => self.socks.clone(),
+        }
+    }
+
+    fn no_proxy(&self) -> Option<reqwest::NoProxy> {
+        let environment = std::env::var("NO_PROXY")
+            .or_else(|_| std::env::var("no_proxy"))
+            .ok();
+        let entries = self.no_proxy_entries(environment.as_deref());
+        if entries.is_empty() {
+            None
+        } else {
+            reqwest::NoProxy::from_string(&entries.join(","))
+        }
+    }
+
+    fn no_proxy_entries(&self, environment: Option<&str>) -> Vec<String> {
+        let mut entries: Vec<String> = self
+            .exceptions
+            .iter()
+            .filter_map(|entry| normalize_exception(entry))
+            .collect();
+        if let Some(environment) = environment {
+            entries.push(environment.to_string());
+        }
+        entries
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn normalize_exception(entry: &str) -> Option<String> {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return None;
+    }
+
+    Some(match entry.strip_prefix("*.") {
+        Some(suffix) => format!(".{suffix}"),
+        None => entry.to_string(),
+    })
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_exception_entry(line: &str) -> Option<String> {
+    let (index, value) = line.split_once(" : ")?;
+    index.trim().parse::<usize>().ok()?;
+    Some(value.trim().to_string())
+}
+
+/// Parse the protocol-specific proxies and bypass rules from `scutil --proxy`.
+#[cfg(any(target_os = "macos", test))]
+fn parse_macos_system_proxy(output: &str) -> MacosProxySettings {
     let mut https = ProxySettings::default();
     let mut http = ProxySettings::default();
     let mut socks = ProxySettings::default();
+    let mut exceptions = Vec::new();
+    let mut exclude_simple_hostnames = false;
+    let mut in_exceptions = false;
 
     for line in output.lines() {
-        let Some((key, value)) = line.trim().split_once(" : ") else {
+        let line = line.trim();
+
+        if in_exceptions {
+            match (line, parse_exception_entry(line)) {
+                ("}", _) => {
+                    in_exceptions = false;
+                    continue;
+                }
+                (_, Some(exception)) => {
+                    exceptions.push(exception);
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        let Some((key, value)) = line.split_once(" : ") else {
             continue;
         };
         let value = value.trim();
 
         match key.trim() {
+            "ExceptionsList" => in_exceptions = value.starts_with("<array>"),
+            "ExcludeSimpleHostnames" => exclude_simple_hostnames = value == "1",
             "HTTPSEnable" => https.enabled = value == "1",
             "HTTPSProxy" => https.host = Some(value.to_string()),
             "HTTPSPort" => https.port = value.parse().ok(),
@@ -109,14 +211,17 @@ fn parse_macos_system_proxy(output: &str) -> Option<String> {
         }
     }
 
-    https
-        .url("http")
-        .or_else(|| http.url("http"))
-        .or_else(|| socks.url("socks5h"))
+    MacosProxySettings {
+        http: http.url("http"),
+        https: https.url("http"),
+        socks: socks.url("socks5h"),
+        exceptions,
+        exclude_simple_hostnames,
+    }
 }
 
 #[cfg(target_os = "macos")]
-fn read_macos_system_proxy() -> Option<String> {
+fn read_macos_system_proxy() -> Option<MacosProxySettings> {
     let output = std::process::Command::new("scutil")
         .arg("--proxy")
         .output()
@@ -125,7 +230,9 @@ fn read_macos_system_proxy() -> Option<String> {
         return None;
     }
 
-    parse_macos_system_proxy(&String::from_utf8_lossy(&output.stdout))
+    Some(parse_macos_system_proxy(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
 #[cfg(test)]
@@ -134,7 +241,7 @@ mod tests {
     use std::ffi::OsString;
 
     #[test]
-    fn prefers_enabled_https_proxy() {
+    fn preserves_protocol_specific_proxies() {
         let output = r#"
 <dictionary> {
   HTTPEnable : 1
@@ -145,15 +252,20 @@ mod tests {
   HTTPSProxy : 127.0.0.1
 }
 "#;
+        let settings = parse_macos_system_proxy(output);
 
         assert_eq!(
-            parse_macos_system_proxy(output),
+            settings.proxy_for_url(&reqwest::Url::parse("https://registry.example").unwrap()),
             Some("http://127.0.0.1:6152".to_string())
+        );
+        assert_eq!(
+            settings.proxy_for_url(&reqwest::Url::parse("http://archive.example").unwrap()),
+            Some("http://http-proxy.local:8080".to_string())
         );
     }
 
     #[test]
-    fn falls_back_to_enabled_http_proxy() {
+    fn does_not_use_http_proxy_for_https_requests() {
         let output = r#"
 <dictionary> {
   HTTPEnable : 1
@@ -164,10 +276,15 @@ mod tests {
   HTTPSProxy : 127.0.0.1
 }
 "#;
+        let settings = parse_macos_system_proxy(output);
 
         assert_eq!(
-            parse_macos_system_proxy(output),
+            settings.proxy_for_url(&reqwest::Url::parse("http://archive.example").unwrap()),
             Some("http://proxy.local:8080".to_string())
+        );
+        assert_eq!(
+            settings.proxy_for_url(&reqwest::Url::parse("https://registry.example").unwrap()),
+            None
         );
     }
 
@@ -183,7 +300,7 @@ mod tests {
 }
 "#;
 
-        assert_eq!(parse_macos_system_proxy(output), None);
+        assert!(!parse_macos_system_proxy(output).has_proxy());
     }
 
     #[test]
@@ -197,7 +314,8 @@ mod tests {
 "#;
 
         assert_eq!(
-            parse_macos_system_proxy(output),
+            parse_macos_system_proxy(output)
+                .proxy_for_url(&reqwest::Url::parse("https://registry.example").unwrap()),
             Some("http://[::1]:6152".to_string())
         );
     }
@@ -214,9 +332,44 @@ mod tests {
 }
 "#;
 
-        let proxy_url = parse_macos_system_proxy(output).expect("parse SOCKS proxy");
-        assert_eq!(proxy_url, "socks5h://127.0.0.1:1080");
-        reqwest::Proxy::all(proxy_url).expect("SOCKS proxy feature is enabled");
+        let settings = parse_macos_system_proxy(output);
+        for url in ["http://archive.example", "https://registry.example"] {
+            assert_eq!(
+                settings.proxy_for_url(&reqwest::Url::parse(url).unwrap()),
+                Some("socks5h://127.0.0.1:1080".to_string())
+            );
+        }
+        reqwest::Proxy::all(settings.socks.unwrap()).expect("SOCKS proxy feature is enabled");
+    }
+
+    #[test]
+    fn parses_macos_bypass_rules() {
+        let output = r#"
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : *.local
+    1 : 169.254.0.0/16
+  }
+  ExcludeSimpleHostnames : 1
+  HTTPSEnable : 1
+  HTTPSPort : 6152
+  HTTPSProxy : proxy.local
+}
+"#;
+        let settings = parse_macos_system_proxy(output);
+
+        assert_eq!(
+            settings.no_proxy_entries(Some("internal.example")),
+            [".local", "169.254.0.0/16", "internal.example"]
+        );
+        assert_eq!(
+            settings.proxy_for_url(&reqwest::Url::parse("https://intranet/path").unwrap()),
+            None
+        );
+        assert_eq!(
+            settings.proxy_for_url(&reqwest::Url::parse("https://public.example/path").unwrap()),
+            Some("http://proxy.local:6152".to_string())
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/system_proxy.rs
+++ b/apps/desktop/src-tauri/src/system_proxy.rs
@@ -24,7 +24,7 @@ struct ProxySettings {
 }
 
 impl ProxySettings {
-    fn url(&self) -> Option<String> {
+    fn url(&self, scheme: &str) -> Option<String> {
         if !self.enabled {
             return None;
         }
@@ -36,14 +36,15 @@ impl ProxySettings {
         } else {
             host.to_string()
         };
-        Some(format!("http://{authority}:{port}"))
+        Some(format!("{scheme}://{authority}:{port}"))
     }
 }
 
-/// Parse the output of `scutil --proxy`, preferring HTTPS over HTTP settings.
+/// Parse `scutil --proxy`, preferring HTTPS, then HTTP, then SOCKS settings.
 fn parse_macos_system_proxy(output: &str) -> Option<String> {
     let mut https = ProxySettings::default();
     let mut http = ProxySettings::default();
+    let mut socks = ProxySettings::default();
 
     for line in output.lines() {
         let Some((key, value)) = line.trim().split_once(" : ") else {
@@ -58,11 +59,17 @@ fn parse_macos_system_proxy(output: &str) -> Option<String> {
             "HTTPEnable" => http.enabled = value == "1",
             "HTTPProxy" => http.host = Some(value.to_string()),
             "HTTPPort" => http.port = value.parse().ok(),
+            "SOCKSEnable" => socks.enabled = value == "1",
+            "SOCKSProxy" => socks.host = Some(value.to_string()),
+            "SOCKSPort" => socks.port = value.parse().ok(),
             _ => {}
         }
     }
 
-    https.url().or_else(|| http.url())
+    https
+        .url("http")
+        .or_else(|| http.url("http"))
+        .or_else(|| socks.url("socks5h"))
 }
 
 #[cfg(target_os = "macos")]
@@ -149,5 +156,22 @@ mod tests {
             parse_macos_system_proxy(output),
             Some("http://[::1]:6152".to_string())
         );
+    }
+
+    #[test]
+    fn falls_back_to_enabled_socks_proxy() {
+        let output = r#"
+<dictionary> {
+  HTTPEnable : 0
+  HTTPSEnable : 0
+  SOCKSEnable : 1
+  SOCKSPort : 1080
+  SOCKSProxy : 127.0.0.1
+}
+"#;
+
+        let proxy_url = parse_macos_system_proxy(output).expect("parse SOCKS proxy");
+        assert_eq!(proxy_url, "socks5h://127.0.0.1:1080");
+        reqwest::Proxy::all(proxy_url).expect("SOCKS proxy feature is enabled");
     }
 }

--- a/crates/routa-core/src/acp/binary_manager.rs
+++ b/crates/routa-core/src/acp/binary_manager.rs
@@ -38,6 +38,22 @@ impl AcpBinaryManager {
         version: &str,
         binary_info: &BinaryInfo,
     ) -> Result<PathBuf, String> {
+        let http_client = reqwest::Client::new();
+        self.install_binary_with_client(&http_client, agent_id, version, binary_info)
+            .await
+    }
+
+    /// Download and install a binary agent with a caller-provided HTTP client.
+    ///
+    /// Runtime adapters can use this to preserve transport concerns such as
+    /// system proxy configuration without coupling them into the core domain.
+    pub async fn install_binary_with_client(
+        &self,
+        http_client: &reqwest::Client,
+        agent_id: &str,
+        version: &str,
+        binary_info: &BinaryInfo,
+    ) -> Result<PathBuf, String> {
         // Get or create a lock for this agent
         let lock = {
             let mut locks = self.download_locks.lock().await;
@@ -75,7 +91,7 @@ impl AcpBinaryManager {
 
         // Download the archive
         let archive_path = self
-            .download_archive(&binary_info.archive, &download_dir)
+            .download_archive_with_client(http_client, &binary_info.archive, &download_dir)
             .await?;
 
         // Extract the archive
@@ -103,10 +119,17 @@ impl AcpBinaryManager {
     }
 
     /// Download an archive from a URL.
-    async fn download_archive(&self, url: &str, download_dir: &Path) -> Result<PathBuf, String> {
+    async fn download_archive_with_client(
+        &self,
+        http_client: &reqwest::Client,
+        url: &str,
+        download_dir: &Path,
+    ) -> Result<PathBuf, String> {
         tracing::info!("[AcpBinaryManager] Downloading from {}", url);
 
-        let response = reqwest::get(url)
+        let response = http_client
+            .get(url)
+            .send()
             .await
             .map_err(|e| format!("Failed to download: {e}"))?;
 
@@ -329,5 +352,78 @@ impl AcpBinaryManager {
                 .map_err(|e| format!("Failed to remove agent directory: {e}"))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::AcpBinaryManager;
+    use crate::acp::AcpPaths;
+
+    #[tokio::test]
+    async fn download_archive_uses_caller_provided_http_client() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("read test server address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request = Vec::new();
+            let mut chunk = [0; 1024];
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let read = socket.read(&mut chunk).await.expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let request = String::from_utf8_lossy(&request);
+            let (status, body) = if request
+                .to_ascii_lowercase()
+                .contains("x-routa-test-client: configured")
+            {
+                ("200 OK", "binary")
+            } else {
+                ("403 Forbidden", "missing client header")
+            };
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-routa-test-client",
+            HeaderValue::from_static("configured"),
+        );
+        let http_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("build configured client");
+        let temp_dir = tempfile::tempdir().expect("create download directory");
+        let manager = AcpBinaryManager::new(AcpPaths::new());
+
+        let archive = manager
+            .download_archive_with_client(
+                &http_client,
+                &format!("http://{address}/agent.bin"),
+                temp_dir.path(),
+            )
+            .await
+            .expect("download archive");
+
+        assert_eq!(
+            tokio::fs::read(archive).await.expect("read archive"),
+            b"binary"
+        );
+        server.await.expect("join test server");
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@xyflow/react": "^12.10.2",
         "adm-zip": "^0.5.17",
         "ai": "^6.0.104",
+        "better-sqlite3": "^12.11.1",
         "bufferutil": "^4.1.0",
         "dagre": "^0.8.5",
         "drizzle-orm": "^0.45.2",
@@ -147,7 +148,7 @@
         "vitest": "^4.1.2"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.11.1",
         "node-pty": "^1.1.0",
         "opencode-ai": "latest"
       }
@@ -16128,9 +16129,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16139,7 +16140,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bidi-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "@xyflow/react": "^12.10.2",
         "adm-zip": "^0.5.17",
         "ai": "^6.0.104",
-        "better-sqlite3": "^12.11.1",
         "bufferutil": "^4.1.0",
         "dagre": "^0.8.5",
         "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "node-pty": "^1.1.0",
     "opencode-ai": "latest"
   },

--- a/src/client/components/__tests__/agent-install-panel.test.tsx
+++ b/src/client/components/__tests__/agent-install-panel.test.tsx
@@ -91,6 +91,24 @@ function registryResponse() {
   };
 }
 
+function tauriRegistryResponse() {
+  return {
+    agents: [
+      {
+        id: "crafter",
+        name: "Crafter",
+        version: "1.0.0",
+        description: "Writes code",
+        authors: ["Routa"],
+        license: "MIT",
+        distribution: {
+          npx: { package: "@acme/crafter" },
+        },
+      },
+    ],
+  };
+}
+
 function responseLike(data: unknown, init?: { ok?: boolean; status?: number }) {
   return {
     ok: init?.ok ?? true,
@@ -190,5 +208,57 @@ describe("AgentInstallPanel", () => {
     render(<AgentInstallPanel />);
 
     expect(await screen.findByText("Failed to fetch registry: proxy unavailable")).not.toBeNull();
+  });
+
+  it.each([
+    {
+      command: "install_acp_agent",
+      button: "Install",
+      installedAgents: [],
+      error: "Binary download failed behind proxy",
+    },
+    {
+      command: "uninstall_acp_agent",
+      button: "Uninstall",
+      installedAgents: [
+        {
+          agentId: "crafter",
+          version: "1.0.0",
+          distType: "npx",
+          installedAt: "2026-07-28T00:00:00Z",
+          package: "@acme/crafter",
+        },
+      ],
+      error: "Failed to remove installed agent",
+    },
+  ])("preserves Tauri string errors from $command", async ({
+    command,
+    button,
+    installedAgents,
+    error,
+  }) => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    (window as typeof window & {
+      __TAURI_INTERNALS__?: { invoke: ReturnType<typeof vi.fn> };
+    }).__TAURI_INTERNALS__ = {
+      invoke: vi.fn((invokedCommand: string) => {
+        if (invokedCommand === "fetch_acp_registry") {
+          return Promise.resolve(tauriRegistryResponse());
+        }
+        if (invokedCommand === "get_installed_agents") {
+          return Promise.resolve(installedAgents);
+        }
+        if (invokedCommand === command) {
+          return Promise.reject(error);
+        }
+        return Promise.reject(new Error(`unexpected command: ${invokedCommand}`));
+      }),
+    };
+
+    render(<AgentInstallPanel />);
+
+    fireEvent.click(await screen.findByRole("button", { name: button }));
+
+    expect(await screen.findByText(error)).not.toBeNull();
   });
 });

--- a/src/client/components/__tests__/agent-install-panel.test.tsx
+++ b/src/client/components/__tests__/agent-install-panel.test.tsx
@@ -103,7 +103,8 @@ describe("AgentInstallPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isTauriRuntimeMock.mockReturnValue(false);
-    vi.stubGlobal("fetch", vi.fn(async () => responseLike(registryResponse())));
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    desktopAwareFetchMock.mockImplementation(async () => responseLike(registryResponse()));
   });
 
   it("loads registry agents, filters by search, and refreshes", async () => {
@@ -122,23 +123,21 @@ describe("AgentInstallPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith("/api/acp/registry?refresh=true");
+      expect(desktopAwareFetchMock).toHaveBeenCalledWith("/api/acp/registry?refresh=true");
     });
   });
 
   it("installs and uninstalls agents through the web API", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    desktopAwareFetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith("/api/acp/registry")) {
         return responseLike(registryResponse());
       }
+      if (url === "/api/acp/install") {
+        return responseLike({ success: true });
+      }
       throw new Error(`unexpected url: ${url}`);
     });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    desktopAwareFetchMock
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
 
     render(<AgentInstallPanel />);
 
@@ -160,17 +159,17 @@ describe("AgentInstallPanel", () => {
   });
 
   it("shows registry and install errors", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => responseLike({}, { ok: false, status: 500 })) as unknown as typeof fetch);
+    desktopAwareFetchMock.mockResolvedValueOnce(responseLike({}, { ok: false, status: 500 }));
 
     render(<AgentInstallPanel embedded />);
 
     expect(await screen.findByText("Failed to fetch registry: 500")).not.toBeNull();
 
-    vi.stubGlobal("fetch", vi.fn(async () => responseLike(registryResponse())) as unknown as typeof fetch);
-
-    desktopAwareFetchMock.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Install exploded" }),
+    desktopAwareFetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).startsWith("/api/acp/registry")) {
+        return responseLike(registryResponse());
+      }
+      return responseLike({ error: "Install exploded" }, { ok: false, status: 500 });
     });
 
     render(<AgentInstallPanel embedded />);
@@ -178,5 +177,18 @@ describe("AgentInstallPanel", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Install" }));
 
     expect(await screen.findByText("Install exploded")).not.toBeNull();
+  });
+
+  it("preserves string errors returned by Tauri invoke", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    (window as typeof window & {
+      __TAURI_INTERNALS__?: { invoke: ReturnType<typeof vi.fn> };
+    }).__TAURI_INTERNALS__ = {
+      invoke: vi.fn().mockRejectedValue("Failed to fetch registry: proxy unavailable"),
+    };
+
+    render(<AgentInstallPanel />);
+
+    expect(await screen.findByText("Failed to fetch registry: proxy unavailable")).not.toBeNull();
   });
 });

--- a/src/client/components/agent-install-panel.tsx
+++ b/src/client/components/agent-install-panel.tsx
@@ -128,6 +128,11 @@ async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): 
   throw new Error("Tauri invoke not available - not running in Tauri environment");
 }
 
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === "string" ? error : fallback;
+}
+
 // ─── Component ─────────────────────────────────────────────────────────────
 
 interface AgentInstallPanelProps {
@@ -208,8 +213,7 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
           setRuntimeAvailability(data.runtimeAvailability);
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : typeof err === "string" ? err : t.agents.failedToLoad;
-        setError(msg);
+        setError(getErrorMessage(err, t.agents.failedToLoad));
       } finally {
         setLoading(false);
       }
@@ -255,7 +259,7 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
         }
         await fetchAgents();
       } catch (err) {
-        setError(err instanceof Error ? err.message : t.agents.installFailed);
+        setError(getErrorMessage(err, t.agents.installFailed));
       } finally {
         setInstallingAgents((prev) => {
           const next = new Set(prev);
@@ -289,7 +293,7 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
         }
         await fetchAgents();
       } catch (err) {
-        setError(err instanceof Error ? err.message : t.agents.uninstallFailed);
+        setError(getErrorMessage(err, t.agents.uninstallFailed));
       } finally {
         setInstallingAgents((prev) => {
           const next = new Set(prev);

--- a/src/client/components/agent-install-panel.tsx
+++ b/src/client/components/agent-install-panel.tsx
@@ -16,6 +16,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import Image from "next/image";
 import { isTauriRuntime, desktopAwareFetch } from "@/client/utils/diagnostics";
+import { resolveApiPath } from "@/client/config/backend";
 import { useTranslation } from "@/i18n";
 import { Search, Bot } from "lucide-react";
 
@@ -198,7 +199,7 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
           setRuntimeAvailability({ npx: true, uvx: true });
         } else {
           // Web: Use API routes
-          const url = refresh ? "/api/acp/registry?refresh=true" : "/api/acp/registry";
+          const url = resolveApiPath(refresh ? "/api/acp/registry?refresh=true" : "/api/acp/registry");
           const res = await fetch(url);
           if (!res.ok) throw new Error(`Failed to fetch registry: ${res.status}`);
           const data: RegistryResponse = await res.json();
@@ -207,7 +208,8 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
           setRuntimeAvailability(data.runtimeAvailability);
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : t.agents.failedToLoad);
+        const msg = err instanceof Error ? err.message : typeof err === "string" ? err : t.agents.failedToLoad;
+        setError(msg);
       } finally {
         setLoading(false);
       }

--- a/src/client/components/agent-install-panel.tsx
+++ b/src/client/components/agent-install-panel.tsx
@@ -200,7 +200,7 @@ export function AgentInstallPanel({ embedded = false }: AgentInstallPanelProps) 
         } else {
           // Web: Use API routes
           const url = resolveApiPath(refresh ? "/api/acp/registry?refresh=true" : "/api/acp/registry");
-          const res = await fetch(url);
+          const res = await desktopAwareFetch(url);
           if (!res.ok) throw new Error(`Failed to fetch registry: ${res.status}`);
           const data: RegistryResponse = await res.json();
           setAgents(data.agents);


### PR DESCRIPTION
## Summary

Fixes three desktop runtime issues discovered on macOS:

- **ACP agent registry fails to load behind system proxy** — `reqwest` only reads `HTTP_PROXY`/`HTTPS_PROXY` env vars and ignores macOS system proxy settings. Proxy software like Surge, ClashX, and V2Ray configure the proxy via `networksetup` (System Preferences), which reqwest never sees. Added `build_http_client()` that reads the system proxy via `scutil --proxy` and applies it to the reqwest client.

- **Agent install errors silently replaced with generic message** — Tauri invoke returns errors as strings, but `err instanceof Error` was `false`, so real errors like "Failed to fetch registry: ..." were silently replaced with a generic message. Now preserves the actual error. Also switched the web-mode fallback from raw `fetch` to `resolveApiPath` per project conventions.

- **"Module not found: Can't resolve 'better-sqlite3'"** — The native module was listed as `optionalDependencies` but not installed on some machines. Bumped version range to `^12.11.1` to pick up latest prebuilt binaries.

## Commits

1. `fix(desktop): respect macOS system proxy for ACP registry fetch`
2. `fix(deps): bump better-sqlite3 to ^12.11.1`

## Test plan

- [x] `cargo check` passes in `apps/desktop/src-tauri`
- [x] Vitest passes for `agent-install-panel.test.tsx`
- [x] Verified ACP registry loads behind Surge proxy (port 6152)
- [x] Verified `better-sqlite3` loads after install


💘 Generated with Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS agent registry lookup and binary downloads by honoring system proxy settings (including protocol-specific HTTP/HTTPS/SOCKS handling and NO_PROXY rules).
  * Refined installation/uninstallation error messaging with consistent, user-friendly formatting across web and Tauri modes.
* **Improvements**
  * Improved web-mode registry URL resolution during agent installation.
  * Updated binary downloading and ACP installs to use caller-provided/proxy-aware HTTP clients, preserving networking configuration.
* **Tests**
  * Updated/expanded agent install panel tests to mock HTTP interactions reliably and validate Tauri/web error rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->